### PR TITLE
Add MCP server with rmcp SDK, OAuth 2.1, and karta-core tools

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+.karta/
+graphify-out/
+*.db
+.env
+.env.*

--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,10 @@
 # GitHub OAuth (for user authentication)
 # GITHUB_CLIENT_ID=...
 # GITHUB_CLIENT_SECRET=...
+
+# CORS allowed origins (comma-separated, defaults to KARTA_BASE_URL)
+# KARTA_ALLOWED_ORIGINS=https://karta.example.com,https://claude.ai
+# Auth DB file path (default: karta-auth.db)
+# KARTA_AUTH_DB_PATH=karta-auth.db
+# Registration token (if set, /oauth/register requires Bearer auth)
+# KARTA_REGISTRATION_TOKEN=your-secret-registration-token

--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,17 @@
 
 # ─── Reranker (optional, improves retrieval + abstention) ───
 # JINA_API_KEY=jina_...
+
+# ─── karta-server (OAuth 2.1 HTTP server) ──────────────────
+# KARTA_HOST=0.0.0.0
+# KARTA_PORT=3000
+# KARTA_BASE_URL=https://karta.example.com
+# KARTA_COOKIE_SECRET=<base64-encoded-32+-byte-key>
+
+# Google OIDC (for user authentication)
+# GOOGLE_CLIENT_ID=...
+# GOOGLE_CLIENT_SECRET=...
+
+# GitHub OAuth (for user authentication)
+# GITHUB_CLIENT_ID=...
+# GITHUB_CLIENT_SECRET=...

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/karta-core",
     "crates/karta-cli",
+    "crates/karta-server",
 ]
 
 [workspace.package]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:latest AS builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release -p karta-server
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/karta-server /usr/local/bin/
+ENV KARTA_HOST=0.0.0.0
+ENV KARTA_PORT=8080
+EXPOSE 8080
+CMD ["karta-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ COPY --from=builder /app/target/release/karta-server /usr/local/bin/
 ENV KARTA_HOST=0.0.0.0
 ENV KARTA_PORT=8080
 EXPOSE 8080
+RUN useradd -r -s /bin/false karta
+USER karta
 CMD ["karta-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY --from=builder /app/target/release/karta-server /usr/local/bin/
 ENV KARTA_HOST=0.0.0.0
 ENV KARTA_PORT=8080
 EXPOSE 8080
-RUN useradd -r -s /bin/false karta
+RUN useradd -r -s /bin/false karta && mkdir -p /data && chown karta:karta /data
 USER karta
+WORKDIR /data
 CMD ["karta-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM rust:latest AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY . .
 RUN cargo build --release -p karta-server

--- a/crates/karta-core/Cargo.toml
+++ b/crates/karta-core/Cargo.toml
@@ -40,7 +40,7 @@ tracing = "0.1"
 dotenvy = "0.15"
 
 # Vector store: LanceDB
-lancedb = { version = "0.27", optional = true }
+lancedb = { version = "0.27", optional = true, features = ["gcs"] }
 arrow-array = { version = "57", optional = true }
 arrow-schema = { version = "57", optional = true }
 

--- a/crates/karta-core/src/config.rs
+++ b/crates/karta-core/src/config.rs
@@ -47,14 +47,18 @@ impl Default for EpisodeConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageConfig {
-    /// Directory for embedded storage (LanceDB + SQLite).
+    /// Directory for embedded storage (SQLite graph store).
     pub data_dir: String,
+    /// Optional URI for LanceDB vector store (e.g. "gs://bucket/path").
+    /// If not set, defaults to "{data_dir}/lance".
+    pub lance_uri: Option<String>,
 }
 
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
             data_dir: ".karta".into(),
+            lance_uri: None,
         }
     }
 }

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -98,8 +98,10 @@ impl Karta {
         // Load .env if present (silently ignore if missing)
         let _ = dotenvy::dotenv();
 
+        let lance_uri = config.storage.lance_uri.clone()
+            .unwrap_or_else(|| format!("{}/lance", config.storage.data_dir));
         let vector_store = Arc::new(
-            LanceVectorStore::new(&config.storage.data_dir).await?,
+            LanceVectorStore::new(&lance_uri).await?,
         ) as Arc<dyn VectorStore>;
 
         let graph_store = Arc::new(

--- a/crates/karta-core/src/store/lance.rs
+++ b/crates/karta-core/src/store/lance.rs
@@ -29,11 +29,13 @@ pub struct LanceVectorStore {
 }
 
 impl LanceVectorStore {
-    pub async fn new(data_dir: &str) -> Result<Self> {
-        let uri = format!("{}/lance", data_dir);
-        std::fs::create_dir_all(&uri)
-            .map_err(|e| KartaError::VectorStore(e.to_string()))?;
-        let conn = connect(&uri)
+    pub async fn new(uri: &str) -> Result<Self> {
+        // Only create local directories for local paths
+        if !uri.starts_with("gs://") && !uri.starts_with("s3://") && !uri.starts_with("az://") {
+            std::fs::create_dir_all(uri)
+                .map_err(|e| KartaError::VectorStore(e.to_string()))?;
+        }
+        let conn = connect(uri)
             .execute()
             .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -20,8 +20,9 @@ impl SqliteGraphStore {
         let conn = Connection::open(&path)
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        // Enable WAL mode for concurrent reads during dream writes
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+        // Use DELETE journal mode for compatibility with network filesystems (e.g. GCS FUSE).
+        // WAL requires shared memory / file locking that FUSE mounts don't support.
+        conn.execute_batch("PRAGMA journal_mode=DELETE; PRAGMA foreign_keys=ON;")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         let store = Self {

--- a/crates/karta-server/Cargo.toml
+++ b/crates/karta-server/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "karta-server"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "MCP server with OAuth 2.1 for karta agentic memory"
+
+[dependencies]
+karta-core = { path = "../karta-core" }
+
+# MCP SDK
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features = [
+    "server",
+    "macros",
+    "transport-streamable-http-server",
+] }
+
+# Web framework
+axum = { version = "0.8", features = ["macros"] }
+axum-extra = { version = "0.10", features = ["cookie-private"] }
+tokio = { version = "1", features = ["full"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+
+# OAuth
+oauth2 = "5"
+openidconnect = "4"
+
+# HTTP
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+schemars = "1.0"
+
+# Storage
+rusqlite = { version = "0.35", features = ["bundled"] }
+
+# Utilities
+uuid = { version = "1", features = ["v4"] }
+chrono = { version = "0.4", features = ["serde"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+rand = "0.9"
+sha2 = "0.10"
+base64 = "0.22"
+thiserror = "2"
+anyhow = "1"
+dotenvy = "0.15"
+url = "2"
+urlencoding = "2"
+subtle = "2"

--- a/crates/karta-server/Cargo.toml
+++ b/crates/karta-server/Cargo.toml
@@ -9,7 +9,7 @@ description = "MCP server with OAuth 2.1 for karta agentic memory"
 karta-core = { path = "../karta-core" }
 
 # MCP SDK
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features = [
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", rev = "a64be231527f923e9f84d4dd7bf3c3bd695ee53e", features = [
     "server",
     "macros",
     "transport-streamable-http-server",

--- a/crates/karta-server/src/config.rs
+++ b/crates/karta-server/src/config.rs
@@ -1,0 +1,92 @@
+use crate::error::{Result, ServerError};
+
+#[derive(Clone)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub base_url: String,
+    pub cookie_secret: Vec<u8>,
+    pub google_client_id: String,
+    pub google_client_secret: String,
+    pub github_client_id: String,
+    pub github_client_secret: String,
+    pub db_path: String,
+    pub registration_token: Option<String>,
+    pub allowed_origins: Vec<String>,
+}
+
+impl std::fmt::Debug for ServerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServerConfig")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("base_url", &self.base_url)
+            .field("cookie_secret", &"[REDACTED]")
+            .field("google_client_id", &self.google_client_id)
+            .field("google_client_secret", &"[REDACTED]")
+            .field("github_client_id", &self.github_client_id)
+            .field("github_client_secret", &"[REDACTED]")
+            .field("db_path", &self.db_path)
+            .field("registration_token", &self.registration_token.as_ref().map(|_| "[REDACTED]"))
+            .field("allowed_origins", &self.allowed_origins)
+            .finish()
+    }
+}
+
+impl ServerConfig {
+    pub fn from_env() -> Result<Self> {
+        let host = std::env::var("KARTA_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+        let port = std::env::var("KARTA_PORT")
+            .unwrap_or_else(|_| "3000".to_string())
+            .parse::<u16>()
+            .map_err(|e| ServerError::Config(format!("Invalid KARTA_PORT: {e}")))?;
+        let base_url = required_env("KARTA_BASE_URL")?;
+        let cookie_secret_b64 = required_env("KARTA_COOKIE_SECRET")?;
+        let cookie_secret = base64::Engine::decode(
+            &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+            &cookie_secret_b64,
+        )
+        .or_else(|_| base64::Engine::decode(
+            &base64::engine::general_purpose::STANDARD,
+            &cookie_secret_b64,
+        ))
+        .map_err(|e| ServerError::Config(format!("Invalid KARTA_COOKIE_SECRET base64: {e}")))?;
+        if cookie_secret.len() < 64 {
+            return Err(ServerError::Config(
+                "KARTA_COOKIE_SECRET must decode to at least 64 bytes (88 base64 chars)".to_string(),
+            ));
+        }
+
+        let google_client_id = required_env("GOOGLE_CLIENT_ID")?;
+        let google_client_secret = required_env("GOOGLE_CLIENT_SECRET")?;
+        let github_client_id = required_env("GITHUB_CLIENT_ID")?;
+        let github_client_secret = required_env("GITHUB_CLIENT_SECRET")?;
+
+        let db_path = std::env::var("KARTA_AUTH_DB_PATH")
+            .unwrap_or_else(|_| "karta-auth.db".to_string());
+
+        let registration_token = std::env::var("KARTA_REGISTRATION_TOKEN").ok();
+
+        let allowed_origins = std::env::var("KARTA_ALLOWED_ORIGINS")
+            .map(|v| v.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect())
+            .unwrap_or_else(|_| vec![base_url.clone()]);
+
+        Ok(Self {
+            host,
+            port,
+            base_url,
+            cookie_secret,
+            google_client_id,
+            google_client_secret,
+            github_client_id,
+            github_client_secret,
+            db_path,
+            registration_token,
+            allowed_origins,
+        })
+    }
+}
+
+fn required_env(name: &str) -> Result<String> {
+    std::env::var(name).map_err(|_| ServerError::Config(format!("{name} is required")))
+}

--- a/crates/karta-server/src/db.rs
+++ b/crates/karta-server/src/db.rs
@@ -1,0 +1,538 @@
+use rusqlite::{Connection, params};
+use std::sync::Mutex;
+
+use crate::error::{Result, ServerError};
+
+/// OAuth client registered via dynamic client registration.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct OAuthClient {
+    pub client_id: String,
+    pub client_secret_hash: Option<String>,
+    pub redirect_uris: Vec<String>,
+    pub client_name: Option<String>,
+}
+
+/// User created on first login via an upstream IdP.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct User {
+    pub id: String,
+    pub provider: String,
+    pub provider_sub: String,
+    pub email: Option<String>,
+    pub display_name: Option<String>,
+}
+
+/// Short-lived authorization code.
+#[derive(Debug, Clone)]
+pub struct AuthCode {
+    pub code: String,
+    pub client_id: String,
+    pub user_id: String,
+    pub redirect_uri: String,
+    pub code_challenge: String,
+    pub code_challenge_method: String,
+    pub scope: Option<String>,
+    pub expires_at: String,
+}
+
+/// Pending authorization request stored while user logs in via IdP.
+#[derive(Debug, Clone)]
+pub struct PendingAuth {
+    pub state_token: String,
+    pub client_id: String,
+    pub redirect_uri: String,
+    pub code_challenge: String,
+    pub code_challenge_method: String,
+    pub scope: Option<String>,
+    pub original_state: String,
+    pub idp_csrf: String,
+    pub idp_nonce: Option<String>,
+    pub idp_pkce_verifier: String,
+    pub provider: String,
+    pub expires_at: String,
+}
+
+/// SQLite-backed auth database (matches karta-core's Mutex<Connection> pattern).
+#[derive(Clone)]
+pub struct AuthDb {
+    conn: std::sync::Arc<Mutex<Connection>>,
+}
+
+impl AuthDb {
+    pub fn new(path: &str) -> Result<Self> {
+        let conn = Connection::open(path)
+            .map_err(|e| ServerError::Internal(format!("Failed to open auth db: {e}")))?;
+
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .map_err(|e| ServerError::Internal(format!("Failed to set pragmas: {e}")))?;
+
+        let db = Self {
+            conn: std::sync::Arc::new(Mutex::new(conn)),
+        };
+        db.init()?;
+        Ok(db)
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {
+        self.conn
+            .lock()
+            .map_err(|e| ServerError::Internal(format!("DB mutex poisoned: {e}")))
+    }
+
+    fn init(&self) -> Result<()> {
+        let conn = self.lock()?;
+        conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS oauth_clients (
+                client_id TEXT PRIMARY KEY,
+                client_secret_hash TEXT,
+                redirect_uris TEXT NOT NULL,
+                client_name TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS users (
+                id TEXT PRIMARY KEY,
+                provider TEXT NOT NULL,
+                provider_sub TEXT NOT NULL,
+                email TEXT,
+                display_name TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                UNIQUE(provider, provider_sub)
+            );
+
+            CREATE TABLE IF NOT EXISTS auth_codes (
+                code TEXT PRIMARY KEY,
+                client_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                redirect_uri TEXT NOT NULL,
+                code_challenge TEXT NOT NULL,
+                code_challenge_method TEXT NOT NULL DEFAULT 'S256',
+                scope TEXT,
+                expires_at TEXT NOT NULL,
+                used INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS access_tokens (
+                token_hash TEXT PRIMARY KEY,
+                client_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                scope TEXT,
+                expires_at TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS refresh_tokens (
+                token_hash TEXT PRIMARY KEY,
+                client_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                scope TEXT,
+                expires_at TEXT NOT NULL,
+                revoked INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS pending_auth_requests (
+                state_token TEXT PRIMARY KEY,
+                client_id TEXT NOT NULL,
+                redirect_uri TEXT NOT NULL,
+                code_challenge TEXT NOT NULL,
+                code_challenge_method TEXT NOT NULL,
+                scope TEXT,
+                original_state TEXT NOT NULL,
+                idp_csrf TEXT NOT NULL UNIQUE,
+                idp_nonce TEXT,
+                idp_pkce_verifier TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                expires_at TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            ",
+        )?;
+        Ok(())
+    }
+
+    // ── Clients ──────────────────────────────────────────────
+
+    pub fn insert_client(&self, client: &OAuthClient) -> Result<()> {
+        let conn = self.lock()?;
+        let uris_json = serde_json::to_string(&client.redirect_uris)
+            .map_err(|e| ServerError::Internal(e.to_string()))?;
+        conn.execute(
+            "INSERT INTO oauth_clients (client_id, client_secret_hash, redirect_uris, client_name)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                client.client_id,
+                client.client_secret_hash,
+                uris_json,
+                client.client_name,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_client(&self, client_id: &str) -> Result<Option<OAuthClient>> {
+        let conn = self.lock()?;
+        let mut stmt = conn.prepare(
+            "SELECT client_id, client_secret_hash, redirect_uris, client_name
+             FROM oauth_clients WHERE client_id = ?1",
+        )?;
+        let mut rows = stmt.query(params![client_id])?;
+        match rows.next()? {
+            Some(row) => {
+                let uris_json: String = row.get(2)?;
+                let redirect_uris: Vec<String> = serde_json::from_str(&uris_json)
+                    .map_err(|e| ServerError::Internal(e.to_string()))?;
+                Ok(Some(OAuthClient {
+                    client_id: row.get(0)?,
+                    client_secret_hash: row.get(1)?,
+                    redirect_uris,
+                    client_name: row.get(3)?,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    // ── Users ────────────────────────────────────────────────
+
+    pub fn upsert_user(
+        &self,
+        provider: &str,
+        provider_sub: &str,
+        email: Option<&str>,
+        display_name: Option<&str>,
+    ) -> Result<User> {
+        let conn = self.lock()?;
+        // Try to find existing user
+        let mut stmt = conn.prepare(
+            "SELECT id, provider, provider_sub, email, display_name
+             FROM users WHERE provider = ?1 AND provider_sub = ?2",
+        )?;
+        let existing: Option<User> = stmt
+            .query(params![provider, provider_sub])?
+            .next()?
+            .map(|row| -> rusqlite::Result<User> {
+                Ok(User {
+                    id: row.get(0)?,
+                    provider: row.get(1)?,
+                    provider_sub: row.get(2)?,
+                    email: row.get(3)?,
+                    display_name: row.get(4)?,
+                })
+            })
+            .transpose()?;
+
+        if let Some(mut user) = existing {
+            // Update email/name if they changed
+            conn.execute(
+                "UPDATE users SET email = COALESCE(?1, email), display_name = COALESCE(?2, display_name)
+                 WHERE id = ?3",
+                params![email, display_name, user.id],
+            )?;
+            user.email = email.map(String::from).or(user.email);
+            user.display_name = display_name.map(String::from).or(user.display_name);
+            Ok(user)
+        } else {
+            let id = uuid::Uuid::new_v4().to_string();
+            conn.execute(
+                "INSERT INTO users (id, provider, provider_sub, email, display_name)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![id, provider, provider_sub, email, display_name],
+            )?;
+            Ok(User {
+                id,
+                provider: provider.to_string(),
+                provider_sub: provider_sub.to_string(),
+                email: email.map(String::from),
+                display_name: display_name.map(String::from),
+            })
+        }
+    }
+
+    // ── Auth codes ───────────────────────────────────────────
+
+    pub fn insert_auth_code(&self, code: &AuthCode) -> Result<()> {
+        let conn = self.lock()?;
+        conn.execute(
+            "INSERT INTO auth_codes (code, client_id, user_id, redirect_uri, code_challenge, code_challenge_method, scope, expires_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                code.code,
+                code.client_id,
+                code.user_id,
+                code.redirect_uri,
+                code.code_challenge,
+                code.code_challenge_method,
+                code.scope,
+                code.expires_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Consume an auth code atomically (one-time use). Returns None if not found, already used, or expired.
+    pub fn consume_auth_code(&self, code: &str) -> Result<Option<AuthCode>> {
+        let conn = self.lock()?;
+        let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+        // Atomically mark the code as used, checking used=0 and expiry in the WHERE clause
+        conn.execute(
+            "UPDATE auth_codes SET used = 1 WHERE code = ?1 AND used = 0 AND expires_at >= ?2",
+            params![code, now],
+        )?;
+
+        if conn.changes() == 0 {
+            return Ok(None);
+        }
+
+        // Read back the consumed row
+        let mut stmt = conn.prepare(
+            "SELECT code, client_id, user_id, redirect_uri, code_challenge, code_challenge_method, scope, expires_at
+             FROM auth_codes WHERE code = ?1",
+        )?;
+        let result: Option<AuthCode> = stmt
+            .query(params![code])?
+            .next()?
+            .map(|row| -> rusqlite::Result<AuthCode> {
+                Ok(AuthCode {
+                    code: row.get(0)?,
+                    client_id: row.get(1)?,
+                    user_id: row.get(2)?,
+                    redirect_uri: row.get(3)?,
+                    code_challenge: row.get(4)?,
+                    code_challenge_method: row.get(5)?,
+                    scope: row.get(6)?,
+                    expires_at: row.get(7)?,
+                })
+            })
+            .transpose()?;
+
+        Ok(result)
+    }
+
+    // ── Access tokens ────────────────────────────────────────
+
+    pub fn insert_access_token(
+        &self,
+        token_hash: &str,
+        client_id: &str,
+        user_id: &str,
+        scope: Option<&str>,
+        expires_at: &str,
+    ) -> Result<()> {
+        let conn = self.lock()?;
+        conn.execute(
+            "INSERT INTO access_tokens (token_hash, client_id, user_id, scope, expires_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![token_hash, client_id, user_id, scope, expires_at],
+        )?;
+        Ok(())
+    }
+
+    /// Validate an access token by its hash. Returns (user_id, scope) if valid.
+    pub fn validate_access_token(&self, token_hash: &str) -> Result<Option<(String, Option<String>)>> {
+        let conn = self.lock()?;
+        let mut stmt = conn.prepare(
+            "SELECT user_id, scope, expires_at FROM access_tokens WHERE token_hash = ?1",
+        )?;
+        let result = stmt
+            .query(params![token_hash])?
+            .next()?
+            .map(|row| -> rusqlite::Result<(String, Option<String>, String)> {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .transpose()?;
+
+        match result {
+            Some((user_id, scope, expires_at)) => {
+                let expires = chrono::NaiveDateTime::parse_from_str(&expires_at, "%Y-%m-%dT%H:%M:%SZ")
+                    .map_err(|e| ServerError::Internal(format!("Bad expiry timestamp: {e}")))?;
+                let expires_utc = expires.and_utc();
+                if expires_utc < chrono::Utc::now() {
+                    Ok(None)
+                } else {
+                    Ok(Some((user_id, scope)))
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    // ── Refresh tokens ───────────────────────────────────────
+
+    pub fn insert_refresh_token(
+        &self,
+        token_hash: &str,
+        client_id: &str,
+        user_id: &str,
+        scope: Option<&str>,
+        expires_at: &str,
+    ) -> Result<()> {
+        let conn = self.lock()?;
+        conn.execute(
+            "INSERT INTO refresh_tokens (token_hash, client_id, user_id, scope, expires_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![token_hash, client_id, user_id, scope, expires_at],
+        )?;
+        Ok(())
+    }
+
+    /// Consume a refresh token (rotation). Atomically revokes the old one, returns (client_id, user_id, scope).
+    /// Implements breach detection: if a revoked token is reused, all tokens for that client/user are revoked.
+    pub fn consume_refresh_token(
+        &self,
+        token_hash: &str,
+    ) -> Result<Option<(String, String, Option<String>)>> {
+        let conn = self.lock()?;
+        let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+        // Atomically revoke the token, checking revoked=0 and expiry in the WHERE clause
+        conn.execute(
+            "UPDATE refresh_tokens SET revoked = 1 WHERE token_hash = ?1 AND revoked = 0 AND expires_at >= ?2",
+            params![token_hash, now],
+        )?;
+
+        if conn.changes() == 0 {
+            // Check if token exists but was already revoked (breach detection)
+            let already_revoked: bool = conn.prepare(
+                "SELECT 1 FROM refresh_tokens WHERE token_hash = ?1 AND revoked = 1",
+            )?.exists(params![token_hash])?;
+
+            if already_revoked {
+                // Revoke all tokens for this client+user (token theft detected)
+                let (client_id, user_id): (String, String) = {
+                    let mut s = conn.prepare(
+                        "SELECT client_id, user_id FROM refresh_tokens WHERE token_hash = ?1",
+                    )?;
+                    s.query_row(params![token_hash], |r| Ok((r.get(0)?, r.get(1)?)))?
+                };
+                conn.execute(
+                    "UPDATE refresh_tokens SET revoked = 1 WHERE client_id = ?1 AND user_id = ?2",
+                    params![client_id, user_id],
+                )?;
+                conn.execute(
+                    "DELETE FROM access_tokens WHERE client_id = ?1 AND user_id = ?2",
+                    params![client_id, user_id],
+                )?;
+                tracing::warn!(
+                    client_id = %client_id,
+                    user_id = %user_id,
+                    "Refresh token reuse detected - revoked all tokens for client/user"
+                );
+            }
+            return Ok(None);
+        }
+
+        // Read back the consumed row
+        let mut stmt = conn.prepare(
+            "SELECT client_id, user_id, scope FROM refresh_tokens WHERE token_hash = ?1",
+        )?;
+        let result = stmt
+            .query(params![token_hash])?
+            .next()?
+            .map(|row| -> rusqlite::Result<(String, String, Option<String>)> {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .transpose()?;
+
+        Ok(result)
+    }
+
+    // ── Pending auth requests ────────────────────────────────
+
+    pub fn insert_pending_auth(&self, pending: &PendingAuth) -> Result<()> {
+        let conn = self.lock()?;
+        conn.execute(
+            "INSERT INTO pending_auth_requests
+             (state_token, client_id, redirect_uri, code_challenge, code_challenge_method,
+              scope, original_state, idp_csrf, idp_nonce, idp_pkce_verifier, provider, expires_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                pending.state_token,
+                pending.client_id,
+                pending.redirect_uri,
+                pending.code_challenge,
+                pending.code_challenge_method,
+                pending.scope,
+                pending.original_state,
+                pending.idp_csrf,
+                pending.idp_nonce,
+                pending.idp_pkce_verifier,
+                pending.provider,
+                pending.expires_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Consume a pending auth request by the IdP CSRF token.
+    /// Safety: the Mutex serializes all access within this process, preventing TOCTOU races.
+    pub fn consume_pending_auth(&self, idp_csrf: &str) -> Result<Option<PendingAuth>> {
+        let conn = self.lock()?;
+        let mut stmt = conn.prepare(
+            "SELECT state_token, client_id, redirect_uri, code_challenge, code_challenge_method,
+                    scope, original_state, idp_csrf, idp_nonce, idp_pkce_verifier, provider, expires_at
+             FROM pending_auth_requests WHERE idp_csrf = ?1",
+        )?;
+        let result: Option<PendingAuth> = stmt
+            .query(params![idp_csrf])?
+            .next()?
+            .map(|row| -> rusqlite::Result<PendingAuth> {
+                Ok(PendingAuth {
+                    state_token: row.get(0)?,
+                    client_id: row.get(1)?,
+                    redirect_uri: row.get(2)?,
+                    code_challenge: row.get(3)?,
+                    code_challenge_method: row.get(4)?,
+                    scope: row.get(5)?,
+                    original_state: row.get(6)?,
+                    idp_csrf: row.get(7)?,
+                    idp_nonce: row.get(8)?,
+                    idp_pkce_verifier: row.get(9)?,
+                    provider: row.get(10)?,
+                    expires_at: row.get(11)?,
+                })
+            })
+            .transpose()?;
+
+        if result.is_some() {
+            conn.execute(
+                "DELETE FROM pending_auth_requests WHERE idp_csrf = ?1",
+                params![idp_csrf],
+            )?;
+            if conn.changes() == 0 {
+                // Someone else consumed it between SELECT and DELETE
+                return Ok(None);
+            }
+        }
+        Ok(result)
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────
+
+    pub fn cleanup_expired(&self) -> Result<u64> {
+        let conn = self.lock()?;
+        let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        let mut total = 0u64;
+        total += conn.execute(
+            "DELETE FROM auth_codes WHERE expires_at < ?1 OR used = 1",
+            params![now],
+        )? as u64;
+        total += conn.execute(
+            "DELETE FROM access_tokens WHERE expires_at < ?1",
+            params![now],
+        )? as u64;
+        total += conn.execute(
+            "DELETE FROM refresh_tokens WHERE expires_at < ?1 OR revoked = 1",
+            params![now],
+        )? as u64;
+        total += conn.execute(
+            "DELETE FROM pending_auth_requests WHERE expires_at < ?1",
+            params![now],
+        )? as u64;
+        Ok(total)
+    }
+}

--- a/crates/karta-server/src/db.rs
+++ b/crates/karta-server/src/db.rs
@@ -256,11 +256,12 @@ impl AuthDb {
 
     pub fn insert_auth_code(&self, code: &AuthCode) -> Result<()> {
         let conn = self.lock()?;
+        let code_hash = crate::middleware::hash_token(&code.code);
         conn.execute(
             "INSERT INTO auth_codes (code, client_id, user_id, redirect_uri, code_challenge, code_challenge_method, scope, expires_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![
-                code.code,
+                code_hash,
                 code.client_id,
                 code.user_id,
                 code.redirect_uri,
@@ -277,11 +278,12 @@ impl AuthDb {
     pub fn consume_auth_code(&self, code: &str) -> Result<Option<AuthCode>> {
         let conn = self.lock()?;
         let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        let code_hash = crate::middleware::hash_token(code);
 
         // Atomically mark the code as used, checking used=0 and expiry in the WHERE clause
         conn.execute(
             "UPDATE auth_codes SET used = 1 WHERE code = ?1 AND used = 0 AND expires_at >= ?2",
-            params![code, now],
+            params![code_hash, now],
         )?;
 
         if conn.changes() == 0 {
@@ -294,7 +296,7 @@ impl AuthDb {
              FROM auth_codes WHERE code = ?1",
         )?;
         let result: Option<AuthCode> = stmt
-            .query(params![code])?
+            .query(params![code_hash])?
             .next()?
             .map(|row| -> rusqlite::Result<AuthCode> {
                 Ok(AuthCode {

--- a/crates/karta-server/src/error.rs
+++ b/crates/karta-server/src/error.rs
@@ -1,0 +1,113 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+
+pub type Result<T> = std::result::Result<T, ServerError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ServerError {
+    #[error("Database error: {0}")]
+    Db(#[from] rusqlite::Error),
+
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    #[error("Invalid request: {0}")]
+    BadRequest(String),
+
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
+
+    #[error("Not found: {0}")]
+    #[allow(dead_code)]
+    NotFound(String),
+
+    #[error("OAuth error: {error}")]
+    OAuth {
+        error: String,
+        error_description: String,
+        status: StatusCode,
+    },
+
+    #[error("Upstream IdP error: {0}")]
+    IdpError(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+impl ServerError {
+    pub fn oauth(error: &str, description: &str, status: StatusCode) -> Self {
+        Self::OAuth {
+            error: error.to_string(),
+            error_description: description.to_string(),
+            status,
+        }
+    }
+}
+
+impl IntoResponse for ServerError {
+    fn into_response(self) -> Response {
+        let (status, body) = match &self {
+            ServerError::Db(e) => {
+                tracing::error!("Database error: {e}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    json!({"error": "server_error", "error_description": "Internal server error"}),
+                )
+            }
+            ServerError::Config(msg) => {
+                tracing::error!("Config error: {msg}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    json!({"error": "server_error", "error_description": "Server misconfiguration"}),
+                )
+            }
+            ServerError::BadRequest(msg) => {
+                tracing::warn!("Bad request: {msg}");
+                (
+                    StatusCode::BAD_REQUEST,
+                    json!({"error": "invalid_request", "error_description": msg}),
+                )
+            }
+            ServerError::Unauthorized(msg) => {
+                tracing::warn!("Unauthorized: {msg}");
+                (
+                    StatusCode::UNAUTHORIZED,
+                    json!({"error": "invalid_token", "error_description": msg}),
+                )
+            }
+            ServerError::NotFound(msg) => (
+                StatusCode::NOT_FOUND,
+                json!({"error": "not_found", "error_description": msg}),
+            ),
+            ServerError::OAuth {
+                error,
+                error_description,
+                status,
+            } => {
+                tracing::warn!(error = %error, description = %error_description, "OAuth error");
+                (
+                    *status,
+                    json!({"error": error, "error_description": error_description}),
+                )
+            }
+            ServerError::IdpError(msg) => {
+                tracing::error!("IdP error: {msg}");
+                (
+                    StatusCode::BAD_GATEWAY,
+                    json!({"error": "server_error", "error_description": "Upstream identity provider error"}),
+                )
+            }
+            ServerError::Internal(msg) => {
+                tracing::error!("Internal error: {msg}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    json!({"error": "server_error", "error_description": "Internal server error"}),
+                )
+            }
+        };
+
+        (status, axum::Json(body)).into_response()
+    }
+}

--- a/crates/karta-server/src/logo.svg
+++ b/crates/karta-server/src/logo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <defs>
+    <style>
+      .node{fill:currentColor}
+      .edge{stroke:currentColor;stroke-width:1.2;fill:none;opacity:0.5}
+      .ring{stroke:currentColor;stroke-width:1.5;fill:none;opacity:0.25}
+      .compass{stroke:currentColor;stroke-width:1.8;fill:none;opacity:0.15}
+    </style>
+  </defs>
+  <circle cx="24" cy="24" r="22" class="compass"/>
+  <line x1="24" y1="2" x2="24" y2="5" class="compass" style="opacity:0.3"/>
+  <line x1="24" y1="43" x2="24" y2="46" class="compass" style="opacity:0.3"/>
+  <line x1="2" y1="24" x2="5" y2="24" class="compass" style="opacity:0.3"/>
+  <line x1="43" y1="24" x2="46" y2="24" class="compass" style="opacity:0.3"/>
+  <circle cx="24" cy="24" r="15" class="ring"/>
+  <line x1="24" y1="24" x2="14" y2="14" class="edge"/>
+  <line x1="24" y1="24" x2="35" y2="16" class="edge"/>
+  <line x1="24" y1="24" x2="16" y2="34" class="edge"/>
+  <line x1="24" y1="24" x2="36" y2="32" class="edge"/>
+  <line x1="14" y1="14" x2="35" y2="16" class="edge"/>
+  <line x1="16" y1="34" x2="36" y2="32" class="edge"/>
+  <line x1="14" y1="14" x2="16" y2="34" class="edge"/>
+  <line x1="35" y1="16" x2="36" y2="32" class="edge"/>
+  <circle cx="24" cy="24" r="4" class="node"/>
+  <circle cx="14" cy="14" r="2.5" class="node"/>
+  <circle cx="35" cy="16" r="2.5" class="node"/>
+  <circle cx="16" cy="34" r="2.5" class="node"/>
+  <circle cx="36" cy="32" r="2.5" class="node"/>
+  <circle cx="24" cy="24" r="7" stroke="currentColor" stroke-width="0.8" fill="none" opacity="0.35" stroke-dasharray="2 2"/>
+</svg>

--- a/crates/karta-server/src/main.rs
+++ b/crates/karta-server/src/main.rs
@@ -150,13 +150,15 @@ async fn main() -> anyhow::Result<()> {
             );
 
         // Protected MCP routes (require Bearer token)
+        // In axum, last .layer() is outermost (runs first on request).
+        // CORS must be outermost so OPTIONS preflight isn't blocked by auth.
         let protected_mcp = Router::new()
             .nest_service("/mcp", mcp_service)
-            .layer(mcp_cors)
             .layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 middleware::validate_token_middleware,
-            ));
+            ))
+            .layer(mcp_cors);
 
         app = app.merge(protected_mcp);
         tracing::info!("MCP endpoint enabled at /mcp");

--- a/crates/karta-server/src/main.rs
+++ b/crates/karta-server/src/main.rs
@@ -1,0 +1,160 @@
+mod config;
+mod db;
+mod error;
+mod mcp;
+mod middleware;
+mod oauth;
+mod routes;
+mod state;
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::http::{Method, HeaderValue, header};
+use axum::routing::{get, post};
+use tower_http::cors::{CorsLayer, AllowOrigin, Any as CorsAny};
+use tower_http::trace::TraceLayer;
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpService, StreamableHttpServerConfig,
+    session::local::LocalSessionManager,
+};
+
+use config::ServerConfig;
+use db::AuthDb;
+use karta_core::Karta;
+use state::AppState;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenvy::dotenv().ok();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "karta_server=info,tower_http=info".into()),
+        )
+        .init();
+
+    let config = ServerConfig::from_env()?;
+    tracing::info!(host = %config.host, port = %config.port, "Starting karta-server");
+
+    // Initialize auth database
+    let db = AuthDb::new(&config.db_path)?;
+
+    // Background cleanup task
+    let cleanup_db = db.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(600));
+        loop {
+            interval.tick().await;
+            match cleanup_db.cleanup_expired() {
+                Ok(n) => {
+                    if n > 0 {
+                        tracing::info!(cleaned = n, "Expired token cleanup");
+                    }
+                }
+                Err(e) => tracing::error!("Token cleanup failed: {e}"),
+            }
+        }
+    });
+
+    // Build OAuth application state
+    let app_state = AppState::new(config.clone(), db).await?;
+
+    // Initialize karta-core
+    let karta = {
+        let karta_config = karta_core::config::KartaConfig::default();
+        match Karta::with_defaults(karta_config).await {
+            Ok(k) => {
+                tracing::info!("karta-core initialized");
+                Some(Arc::new(k))
+            }
+            Err(e) => {
+                tracing::warn!("karta-core not available (MCP tools disabled): {e}");
+                None
+            }
+        }
+    };
+
+    // Build CORS for OAuth endpoints
+    let origins: Vec<HeaderValue> = config
+        .allowed_origins
+        .iter()
+        .filter_map(|o| o.parse::<HeaderValue>().ok())
+        .collect();
+    let oauth_cors = CorsLayer::new()
+        .allow_origin(AllowOrigin::list(origins))
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE, header::ACCEPT]);
+
+    // MCP CORS needs to be more permissive (Claude.ai sends various headers)
+    let mcp_cors = CorsLayer::new()
+        .allow_origin(CorsAny)
+        .allow_methods(CorsAny)
+        .allow_headers(CorsAny);
+
+    // OAuth routes (unprotected)
+    let oauth_routes = Router::new()
+        .route(
+            "/.well-known/oauth-authorization-server",
+            get(oauth::discovery::oauth_metadata),
+        )
+        .route("/oauth/register", post(oauth::register::register_client))
+        .route("/oauth/authorize", get(oauth::authorize::authorize))
+        .route("/oauth/token", post(oauth::token::token))
+        .route(
+            "/auth/google/callback",
+            get(oauth::callback::google_callback),
+        )
+        .route(
+            "/auth/github/callback",
+            get(oauth::callback::github_callback),
+        )
+        .layer(oauth_cors)
+        .with_state(app_state.clone());
+
+    // Static icon endpoint
+    let icon_route = Router::new().route("/icon.svg", get(routes::icon_svg));
+
+    // Health check (protected)
+    let health_route = Router::new()
+        .route("/api/health", get(routes::health))
+        .with_state(app_state.clone());
+
+    // Build final router
+    let mut app = Router::new()
+        .merge(oauth_routes)
+        .merge(icon_route)
+        .merge(health_route);
+
+    // Add MCP service if karta-core is available
+    if let Some(karta_ref) = karta {
+        let mcp_service: StreamableHttpService<mcp::KartaService, LocalSessionManager> =
+            StreamableHttpService::new(
+                move || Ok(mcp::KartaService::new(karta_ref.clone())),
+                LocalSessionManager::default().into(),
+                StreamableHttpServerConfig::default(),
+            );
+
+        // Protected MCP routes (require Bearer token)
+        let protected_mcp = Router::new()
+            .nest_service("/mcp", mcp_service)
+            .layer(mcp_cors)
+            .layer(axum::middleware::from_fn_with_state(
+                app_state.clone(),
+                middleware::validate_token_middleware,
+            ));
+
+        app = app.merge(protected_mcp);
+        tracing::info!("MCP endpoint enabled at /mcp");
+    }
+
+    app = app.layer(TraceLayer::new_for_http());
+
+    let addr = format!("{}:{}", config.host, config.port);
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!(addr = %addr, "Listening");
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}

--- a/crates/karta-server/src/main.rs
+++ b/crates/karta-server/src/main.rs
@@ -129,11 +129,24 @@ async fn main() -> anyhow::Result<()> {
 
     // Add MCP service if karta-core is available
     if let Some(karta_ref) = karta {
+        // Extract hostname from base URL for DNS rebinding protection
+        let allowed_host = url::Url::parse(&config.base_url)
+            .ok()
+            .and_then(|u| u.host_str().map(String::from))
+            .unwrap_or_else(|| "localhost".to_string());
+
+        let mcp_config = StreamableHttpServerConfig::default()
+            .with_allowed_hosts([
+                "localhost".to_string(),
+                "127.0.0.1".to_string(),
+                allowed_host,
+            ]);
+
         let mcp_service: StreamableHttpService<mcp::KartaService, LocalSessionManager> =
             StreamableHttpService::new(
                 move || Ok(mcp::KartaService::new(karta_ref.clone())),
                 LocalSessionManager::default().into(),
-                StreamableHttpServerConfig::default(),
+                mcp_config,
             );
 
         // Protected MCP routes (require Bearer token)

--- a/crates/karta-server/src/main.rs
+++ b/crates/karta-server/src/main.rs
@@ -63,7 +63,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Initialize karta-core
     let karta = {
-        let karta_config = karta_core::config::KartaConfig::default();
+        let mut karta_config = karta_core::config::KartaConfig::default();
+        if let Ok(lance_uri) = std::env::var("KARTA_LANCE_URI") {
+            karta_config.storage.lance_uri = Some(lance_uri);
+        }
         match Karta::with_defaults(karta_config).await {
             Ok(k) => {
                 tracing::info!("karta-core initialized");
@@ -142,9 +145,10 @@ async fn main() -> anyhow::Result<()> {
                 allowed_host,
             ]);
 
+        let base_url = config.base_url.clone();
         let mcp_service: StreamableHttpService<mcp::KartaService, LocalSessionManager> =
             StreamableHttpService::new(
-                move || Ok(mcp::KartaService::new(karta_ref.clone())),
+                move || Ok(mcp::KartaService::new(karta_ref.clone(), base_url.clone())),
                 LocalSessionManager::default().into(),
                 mcp_config,
             );

--- a/crates/karta-server/src/mcp.rs
+++ b/crates/karta-server/src/mcp.rs
@@ -1,0 +1,243 @@
+use std::sync::Arc;
+
+use rmcp::{
+    ErrorData as McpError, ServerHandler,
+    handler::server::router::tool::ToolRouter,
+    handler::server::wrapper::Parameters,
+    model::*,
+    schemars, tool, tool_handler, tool_router,
+};
+use serde::Deserialize;
+
+use karta_core::Karta;
+
+// -- Tool parameter types --
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct AddNoteParams {
+    /// The content of the memory note to store
+    pub content: String,
+    /// Optional session ID for grouping related notes
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SearchParams {
+    /// The search query
+    pub query: String,
+    /// Number of results to return (default: 5)
+    #[serde(default = "default_top_k")]
+    pub top_k: usize,
+}
+
+fn default_top_k() -> usize {
+    5
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct AskParams {
+    /// The question to ask against stored memories
+    pub query: String,
+    /// Number of context notes to consider (default: 5)
+    #[serde(default = "default_top_k")]
+    pub top_k: usize,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetNoteParams {
+    /// The ID of the note to retrieve
+    pub id: String,
+}
+
+// -- SVG logo as embedded data URI --
+const LOGO_SVG: &str = include_str!("logo.svg");
+
+// -- MCP Service --
+
+#[derive(Clone)]
+pub struct KartaService {
+    karta: Arc<Karta>,
+    #[allow(dead_code)]
+    tool_router: ToolRouter<KartaService>,
+}
+
+#[tool_router]
+impl KartaService {
+    pub fn new(karta: Arc<Karta>) -> Self {
+        Self {
+            karta,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Store a new memory note in the knowledge graph.
+    #[tool(description = "Store a new memory note in the knowledge graph. The note will be automatically enriched with LLM-extracted attributes, linked to related notes, and indexed for retrieval.")]
+    async fn add_note(
+        &self,
+        Parameters(params): Parameters<AddNoteParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let result = if let Some(session_id) = &params.session_id {
+            self.karta
+                .add_note_with_session(&params.content, session_id)
+                .await
+        } else {
+            self.karta.add_note(&params.content).await
+        };
+
+        match result {
+            Ok(note) => {
+                let response = serde_json::json!({
+                    "id": note.id,
+                    "content": note.content,
+                    "context": note.context,
+                    "keywords": note.keywords,
+                    "tags": note.tags,
+                    "links": note.links,
+                    "created_at": note.created_at.to_rfc3339(),
+                });
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&response).unwrap_or_default(),
+                )]))
+            }
+            Err(e) => Err(McpError::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to add note: {e}"),
+                None,
+            )),
+        }
+    }
+
+    /// Search stored memories by semantic similarity.
+    #[tool(description = "Search stored memories by semantic similarity. Returns the most relevant notes ranked by a combination of vector similarity, recency, and graph connectivity.")]
+    async fn search(
+        &self,
+        Parameters(params): Parameters<SearchParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.karta.search(&params.query, params.top_k).await {
+            Ok(results) => {
+                let response: Vec<serde_json::Value> = results
+                    .iter()
+                    .map(|r| {
+                        serde_json::json!({
+                            "id": r.note.id,
+                            "content": r.note.content,
+                            "score": r.score,
+                            "tags": r.note.tags,
+                            "created_at": r.note.created_at.to_rfc3339(),
+                        })
+                    })
+                    .collect();
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&response).unwrap_or_default(),
+                )]))
+            }
+            Err(e) => Err(McpError::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Search failed: {e}"),
+                None,
+            )),
+        }
+    }
+
+    /// Ask a question and get a synthesized answer from stored memories.
+    #[tool(description = "Ask a question against stored memories and get a synthesized answer. Uses retrieval-augmented generation: searches for relevant notes, then synthesizes a coherent answer using an LLM.")]
+    async fn ask(
+        &self,
+        Parameters(params): Parameters<AskParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.karta.ask(&params.query, params.top_k).await {
+            Ok(result) => {
+                let response = serde_json::json!({
+                    "answer": result.answer,
+                    "query_mode": result.query_mode,
+                    "notes_used": result.notes_used,
+                    "note_ids": result.note_ids,
+                    "has_contradiction": result.has_contradiction,
+                });
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&response).unwrap_or_default(),
+                )]))
+            }
+            Err(e) => Err(McpError::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Ask failed: {e}"),
+                None,
+            )),
+        }
+    }
+
+    /// Retrieve a specific note by its ID.
+    #[tool(description = "Retrieve a specific memory note by its ID. Returns the full note content and metadata.")]
+    async fn get_note(
+        &self,
+        Parameters(params): Parameters<GetNoteParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.karta.get_note(&params.id).await {
+            Ok(Some(note)) => {
+                let response = serde_json::json!({
+                    "id": note.id,
+                    "content": note.content,
+                    "context": note.context,
+                    "keywords": note.keywords,
+                    "tags": note.tags,
+                    "links": note.links,
+                    "created_at": note.created_at.to_rfc3339(),
+                });
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&response).unwrap_or_default(),
+                )]))
+            }
+            Ok(None) => Err(McpError::resource_not_found(
+                format!("Note not found: {}", params.id),
+                None,
+            )),
+            Err(e) => Err(McpError::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Get note failed: {e}"),
+                None,
+            )),
+        }
+    }
+
+    /// Get the total count of stored memory notes.
+    #[tool(description = "Get the total count of stored memory notes.")]
+    async fn note_count(&self) -> Result<CallToolResult, McpError> {
+        match self.karta.note_count().await {
+            Ok(count) => Ok(CallToolResult::success(vec![Content::text(
+                count.to_string(),
+            )])),
+            Err(e) => Err(McpError::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Count failed: {e}"),
+                None,
+            )),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for KartaService {
+    fn get_info(&self) -> ServerInfo {
+        // Build data URI for the SVG icon
+        let icon_data_uri = format!(
+            "data:image/svg+xml;base64,{}",
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, LOGO_SVG)
+        );
+
+        ServerInfo::new(
+            ServerCapabilities::builder().enable_tools().build(),
+        )
+        .with_server_info(
+            Implementation::new("karta", env!("CARGO_PKG_VERSION"))
+                .with_title("Karta Memory Server")
+                .with_description("Agentic memory system that thinks, not just stores. Store, search, and reason over knowledge using LLM-enriched notes and graph-based retrieval.")
+                .with_icons(vec![
+                    Icon::new(icon_data_uri)
+                        .with_mime_type("image/svg+xml")
+                        .with_sizes(vec!["any".into()]),
+                ]),
+        )
+        .with_instructions("Available tools: add_note (store a memory), search (semantic search), ask (RAG-powered Q&A), get_note (retrieve by ID), note_count (total notes)".to_string())
+    }
+}

--- a/crates/karta-server/src/mcp.rs
+++ b/crates/karta-server/src/mcp.rs
@@ -50,23 +50,22 @@ pub struct GetNoteParams {
     pub id: String,
 }
 
-// -- SVG logo as embedded data URI --
-const LOGO_SVG: &str = include_str!("logo.svg");
-
 // -- MCP Service --
 
 #[derive(Clone)]
 pub struct KartaService {
     karta: Arc<Karta>,
+    base_url: String,
     #[allow(dead_code)]
     tool_router: ToolRouter<KartaService>,
 }
 
 #[tool_router]
 impl KartaService {
-    pub fn new(karta: Arc<Karta>) -> Self {
+    pub fn new(karta: Arc<Karta>, base_url: String) -> Self {
         Self {
             karta,
+            base_url,
             tool_router: Self::tool_router(),
         }
     }
@@ -221,11 +220,7 @@ impl KartaService {
 #[tool_handler]
 impl ServerHandler for KartaService {
     fn get_info(&self) -> ServerInfo {
-        // Build data URI for the SVG icon
-        let icon_data_uri = format!(
-            "data:image/svg+xml;base64,{}",
-            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, LOGO_SVG)
-        );
+        let icon_url = format!("{}/icon.svg", self.base_url);
 
         ServerInfo::new(
             ServerCapabilities::builder().enable_tools().build(),
@@ -235,7 +230,7 @@ impl ServerHandler for KartaService {
                 .with_title("Karta Memory Server")
                 .with_description("Agentic memory system that thinks, not just stores. Store, search, and reason over knowledge using LLM-enriched notes and graph-based retrieval.")
                 .with_icons(vec![
-                    Icon::new(icon_data_uri)
+                    Icon::new(icon_url)
                         .with_mime_type("image/svg+xml")
                         .with_sizes(vec!["any".into()]),
                 ]),

--- a/crates/karta-server/src/mcp.rs
+++ b/crates/karta-server/src/mcp.rs
@@ -114,7 +114,8 @@ impl KartaService {
         &self,
         Parameters(params): Parameters<SearchParams>,
     ) -> Result<CallToolResult, McpError> {
-        match self.karta.search(&params.query, params.top_k).await {
+        let top_k = params.top_k.min(100).max(1);
+        match self.karta.search(&params.query, top_k).await {
             Ok(results) => {
                 let response: Vec<serde_json::Value> = results
                     .iter()
@@ -146,7 +147,8 @@ impl KartaService {
         &self,
         Parameters(params): Parameters<AskParams>,
     ) -> Result<CallToolResult, McpError> {
-        match self.karta.ask(&params.query, params.top_k).await {
+        let top_k = params.top_k.min(100).max(1);
+        match self.karta.ask(&params.query, top_k).await {
             Ok(result) => {
                 let response = serde_json::json!({
                     "answer": result.answer,

--- a/crates/karta-server/src/mcp.rs
+++ b/crates/karta-server/src/mcp.rs
@@ -50,6 +50,30 @@ pub struct GetNoteParams {
     pub id: String,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DreamParams {
+    /// Dream scope type (default: "workspace")
+    #[serde(default = "default_scope_type")]
+    pub scope_type: String,
+    /// Scope identifier (default: "default")
+    #[serde(default = "default_scope_id")]
+    pub scope_id: String,
+}
+
+fn default_scope_type() -> String {
+    "workspace".into()
+}
+
+fn default_scope_id() -> String {
+    "default".into()
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetLinksParams {
+    /// The note ID to get links for
+    pub note_id: String,
+}
+
 // -- MCP Service --
 
 #[derive(Clone)]
@@ -93,6 +117,7 @@ impl KartaService {
                     "keywords": note.keywords,
                     "tags": note.tags,
                     "links": note.links,
+                    "confidence": note.confidence,
                     "created_at": note.created_at.to_rfc3339(),
                 });
                 Ok(CallToolResult::success(vec![Content::text(
@@ -122,6 +147,9 @@ impl KartaService {
                         serde_json::json!({
                             "id": r.note.id,
                             "content": r.note.content,
+                            "context": r.note.context,
+                            "keywords": r.note.keywords,
+                            "confidence": r.note.confidence,
                             "score": r.score,
                             "tags": r.note.tags,
                             "created_at": r.note.created_at.to_rfc3339(),
@@ -155,6 +183,7 @@ impl KartaService {
                     "notes_used": result.notes_used,
                     "note_ids": result.note_ids,
                     "has_contradiction": result.has_contradiction,
+                    "contradiction_injected": result.contradiction_injected,
                 });
                 Ok(CallToolResult::success(vec![Content::text(
                     serde_json::to_string_pretty(&response).unwrap_or_default(),
@@ -183,7 +212,10 @@ impl KartaService {
                     "keywords": note.keywords,
                     "tags": note.tags,
                     "links": note.links,
+                    "confidence": note.confidence,
+                    "status": note.status,
                     "created_at": note.created_at.to_rfc3339(),
+                    "updated_at": note.updated_at.to_rfc3339(),
                 });
                 Ok(CallToolResult::success(vec![Content::text(
                     serde_json::to_string_pretty(&response).unwrap_or_default(),
@@ -215,6 +247,60 @@ impl KartaService {
             )),
         }
     }
+
+    /// Run background reasoning over the knowledge graph.
+    #[tool(description = "Run background reasoning over the knowledge graph. Produces new inferred notes via deduction, induction, abduction, consolidation, contradiction detection, and episode digests.")]
+    async fn dream(
+        &self,
+        Parameters(params): Parameters<DreamParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.karta.run_dreaming(&params.scope_type, &params.scope_id).await {
+            Ok(run) => {
+                let types: Vec<String> = run.dreams.iter()
+                    .filter(|d| d.would_write)
+                    .map(|d| d.dream_type.as_str().to_string())
+                    .collect();
+                let response = serde_json::json!({
+                    "dreams_attempted": run.dreams_attempted,
+                    "dreams_written": run.dreams_written,
+                    "notes_inspected": run.notes_inspected,
+                    "types_produced": types,
+                    "total_tokens_used": run.total_tokens_used,
+                });
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&response).unwrap_or_default(),
+                )]))
+            }
+            Err(e) => Err(McpError::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Dream failed: {e}"),
+                None,
+            )),
+        }
+    }
+
+    /// Get all note IDs linked to a given note.
+    #[tool(description = "Get all note IDs linked to a given note in the knowledge graph.")]
+    async fn get_links(
+        &self,
+        Parameters(params): Parameters<GetLinksParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match self.karta.get_links(&params.note_id).await {
+            Ok(links) => {
+                let response = serde_json::json!({
+                    "linked_note_ids": links,
+                });
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&response).unwrap_or_default(),
+                )]))
+            }
+            Err(e) => Err(McpError::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Get links failed: {e}"),
+                None,
+            )),
+        }
+    }
 }
 
 #[tool_handler]
@@ -235,6 +321,6 @@ impl ServerHandler for KartaService {
                         .with_sizes(vec!["any".into()]),
                 ]),
         )
-        .with_instructions("Available tools: add_note (store a memory), search (semantic search), ask (RAG-powered Q&A), get_note (retrieve by ID), note_count (total notes)".to_string())
+        .with_instructions("Available tools: add_note (store a memory), search (semantic search), ask (RAG-powered Q&A), get_note (retrieve by ID), note_count (total notes), dream (background reasoning), get_links (linked note IDs)".to_string())
     }
 }

--- a/crates/karta-server/src/middleware.rs
+++ b/crates/karta-server/src/middleware.rs
@@ -1,0 +1,84 @@
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use sha2::{Digest, Sha256};
+
+use crate::error::ServerError;
+use crate::state::AppState;
+
+/// Authenticated user extracted from Bearer token.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct AuthenticatedUser {
+    pub user_id: String,
+    pub scope: Option<String>,
+}
+
+impl FromRequestParts<AppState> for AuthenticatedUser {
+    type Rejection = ServerError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let auth_header_value = parts
+            .headers
+            .get("authorization")
+            .ok_or_else(|| ServerError::Unauthorized("Missing Authorization header".to_string()))?;
+
+        let auth_header = auth_header_value
+            .to_str()
+            .map_err(|_| ServerError::Unauthorized("Authorization header contains invalid characters".to_string()))?;
+
+        let token = auth_header
+            .strip_prefix("Bearer ")
+            .ok_or_else(|| ServerError::Unauthorized("Invalid Authorization scheme".to_string()))?;
+
+        let token_hash = hash_token(token);
+
+        let (user_id, scope) = state
+            .db
+            .validate_access_token(&token_hash)?
+            .ok_or_else(|| ServerError::Unauthorized("Invalid or expired token".to_string()))?;
+
+        Ok(AuthenticatedUser { user_id, scope })
+    }
+}
+
+/// Tower middleware for MCP route protection.
+pub async fn validate_token_middleware(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    request: axum::http::Request<axum::body::Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    let auth_header = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok());
+
+    let token = match auth_header {
+        Some(h) => match h.strip_prefix("Bearer ") {
+            Some(t) => t,
+            None => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
+        },
+        None => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
+    };
+
+    let token_hash = hash_token(token);
+    match state.db.validate_access_token(&token_hash) {
+        Ok(Some(_)) => next.run(request).await,
+        _ => axum::http::StatusCode::UNAUTHORIZED.into_response(),
+    }
+}
+
+/// Hash a token with SHA-256 and return hex string.
+pub fn hash_token(token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write;
+        write!(hex, "{byte:02x}").unwrap();
+    }
+    hex
+}

--- a/crates/karta-server/src/oauth/authorize.rs
+++ b/crates/karta-server/src/oauth/authorize.rs
@@ -1,0 +1,301 @@
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Redirect, Response};
+use oauth2::PkceCodeChallenge;
+use serde::Deserialize;
+
+use crate::db::PendingAuth;
+use crate::error::{Result, ServerError};
+use crate::state::AppState;
+
+const VALID_SCOPES: &[&str] = &["read", "write", "admin"];
+
+#[derive(Debug, Deserialize)]
+pub struct AuthorizeParams {
+    pub response_type: Option<String>,
+    pub client_id: Option<String>,
+    pub redirect_uri: Option<String>,
+    pub code_challenge: Option<String>,
+    pub code_challenge_method: Option<String>,
+    pub state: Option<String>,
+    pub scope: Option<String>,
+    pub provider: Option<String>,
+}
+
+/// `GET /oauth/authorize` — Authorization endpoint.
+pub async fn authorize(
+    State(state): State<AppState>,
+    Query(params): Query<AuthorizeParams>,
+) -> Result<Response> {
+    // Validate required parameters
+    let response_type = params
+        .response_type
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("response_type is required".to_string()))?;
+    if response_type != "code" {
+        return Err(ServerError::oauth(
+            "unsupported_response_type",
+            "Only response_type=code is supported",
+            StatusCode::BAD_REQUEST,
+        ));
+    }
+
+    let client_id = params
+        .client_id
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("client_id is required".to_string()))?;
+    let redirect_uri = params
+        .redirect_uri
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("redirect_uri is required".to_string()))?;
+    let code_challenge = params
+        .code_challenge
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("code_challenge is required (PKCE)".to_string()))?;
+    let code_challenge_method = params
+        .code_challenge_method
+        .as_deref()
+        .unwrap_or("S256");
+    let client_state = params
+        .state
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("state is required".to_string()))?;
+
+    if code_challenge_method != "S256" {
+        return Err(ServerError::oauth(
+            "invalid_request",
+            "Only code_challenge_method=S256 is supported",
+            StatusCode::BAD_REQUEST,
+        ));
+    }
+
+    // Validate scope if provided
+    if let Some(scope) = &params.scope {
+        for s in scope.split_whitespace() {
+            if !VALID_SCOPES.contains(&s) {
+                return Err(ServerError::oauth(
+                    "invalid_scope",
+                    &format!("Unknown scope: {s}"),
+                    StatusCode::BAD_REQUEST,
+                ));
+            }
+        }
+    }
+
+    // Validate client exists and redirect_uri matches
+    let client = state
+        .db
+        .get_client(client_id)?
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_client",
+            "Unknown client_id",
+            StatusCode::BAD_REQUEST,
+        ))?;
+
+    if !client.redirect_uris.iter().any(|u| u == redirect_uri) {
+        return Err(ServerError::oauth(
+            "invalid_request",
+            "redirect_uri does not match any registered URI",
+            StatusCode::BAD_REQUEST,
+        ));
+    }
+
+    // If no provider selected, show the login page
+    let provider = match &params.provider {
+        Some(p) => p.as_str(),
+        None => {
+            return Ok(render_login_page(&state.config.base_url, &params).into_response());
+        }
+    };
+
+    if provider != "google" && provider != "github" {
+        return Err(ServerError::BadRequest(format!(
+            "Unknown provider: {provider}"
+        )));
+    }
+
+    let idp_csrf = generate_random_string();
+    let expires_at = (chrono::Utc::now() + chrono::Duration::minutes(10))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+
+    // Build upstream IdP authorization URL
+    let idp_redirect_url = match provider {
+        "google" => {
+            let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+            let nonce = openidconnect::Nonce::new_random();
+            let nonce_secret = nonce.secret().clone();
+
+            let pending = PendingAuth {
+                state_token: uuid::Uuid::new_v4().to_string(),
+                client_id: client_id.to_string(),
+                redirect_uri: redirect_uri.to_string(),
+                code_challenge: code_challenge.to_string(),
+                code_challenge_method: code_challenge_method.to_string(),
+                scope: params.scope.clone(),
+                original_state: client_state.to_string(),
+                idp_csrf: idp_csrf.clone(),
+                idp_nonce: Some(nonce_secret),
+                idp_pkce_verifier: pkce_verifier.secret().to_string(),
+                provider: "google".to_string(),
+                expires_at,
+            };
+            state.db.insert_pending_auth(&pending)?;
+
+            let (auth_url, _csrf_token, _nonce) = state
+                .google_client
+                .authorize_url(
+                    openidconnect::core::CoreAuthenticationFlow::AuthorizationCode,
+                    move || openidconnect::CsrfToken::new(idp_csrf.clone()),
+                    move || nonce,
+                )
+                .add_scope(openidconnect::Scope::new("email".to_string()))
+                .add_scope(openidconnect::Scope::new("profile".to_string()))
+                .set_pkce_challenge(pkce_challenge)
+                .url();
+
+            auth_url.to_string()
+        }
+        "github" => {
+            let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+            let pending = PendingAuth {
+                state_token: uuid::Uuid::new_v4().to_string(),
+                client_id: client_id.to_string(),
+                redirect_uri: redirect_uri.to_string(),
+                code_challenge: code_challenge.to_string(),
+                code_challenge_method: code_challenge_method.to_string(),
+                scope: params.scope.clone(),
+                original_state: client_state.to_string(),
+                idp_csrf: idp_csrf.clone(),
+                idp_nonce: None,
+                idp_pkce_verifier: pkce_verifier.secret().to_string(),
+                provider: "github".to_string(),
+                expires_at,
+            };
+            state.db.insert_pending_auth(&pending)?;
+
+            let (auth_url, _csrf_token) = state
+                .github_client
+                .authorize_url(|| oauth2::CsrfToken::new(idp_csrf.clone()))
+                .add_scope(oauth2::Scope::new("read:user".to_string()))
+                .add_scope(oauth2::Scope::new("user:email".to_string()))
+                .set_pkce_challenge(pkce_challenge)
+                .url();
+
+            auth_url.to_string()
+        }
+        _ => unreachable!(),
+    };
+
+    Ok(Redirect::temporary(&idp_redirect_url).into_response())
+}
+
+fn render_login_page(base_url: &str, params: &AuthorizeParams) -> Html<String> {
+    let mut qs = Vec::new();
+    if let Some(v) = &params.response_type {
+        qs.push(format!("response_type={}", urlencoding::encode(v)));
+    }
+    if let Some(v) = &params.client_id {
+        qs.push(format!("client_id={}", urlencoding::encode(v)));
+    }
+    if let Some(v) = &params.redirect_uri {
+        qs.push(format!("redirect_uri={}", urlencoding::encode(v)));
+    }
+    if let Some(v) = &params.code_challenge {
+        qs.push(format!("code_challenge={}", urlencoding::encode(v)));
+    }
+    if let Some(v) = &params.code_challenge_method {
+        qs.push(format!(
+            "code_challenge_method={}",
+            urlencoding::encode(v)
+        ));
+    }
+    if let Some(v) = &params.state {
+        qs.push(format!("state={}", urlencoding::encode(v)));
+    }
+    if let Some(v) = &params.scope {
+        qs.push(format!("scope={}", urlencoding::encode(v)));
+    }
+
+    let query_string = qs.join("&");
+    let google_url = format!(
+        "{base_url}/oauth/authorize?{query_string}&provider=google"
+    );
+    let github_url = format!(
+        "{base_url}/oauth/authorize?{query_string}&provider=github"
+    );
+
+    Html(format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Karta - Sign In</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            background: #f5f5f5;
+        }}
+        .card {{
+            background: white;
+            border-radius: 12px;
+            padding: 2rem;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            text-align: center;
+            max-width: 360px;
+            width: 100%;
+        }}
+        h1 {{
+            margin: 0 0 0.5rem;
+            font-size: 1.5rem;
+        }}
+        p {{
+            color: #666;
+            margin: 0 0 1.5rem;
+        }}
+        a.btn {{
+            display: block;
+            padding: 0.75rem 1rem;
+            margin: 0.5rem 0;
+            border-radius: 8px;
+            text-decoration: none;
+            font-weight: 500;
+            font-size: 1rem;
+        }}
+        .btn-google {{
+            background: #4285f4;
+            color: white;
+        }}
+        .btn-github {{
+            background: #24292e;
+            color: white;
+        }}
+        .btn:hover {{
+            opacity: 0.9;
+        }}
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Sign in to Karta</h1>
+        <p>Choose your identity provider</p>
+        <a class="btn btn-google" href="{google_url}">Sign in with Google</a>
+        <a class="btn btn-github" href="{github_url}">Sign in with GitHub</a>
+    </div>
+</body>
+</html>"#
+    ))
+}
+
+fn generate_random_string() -> String {
+    use base64::Engine;
+    let bytes: [u8; 32] = rand::random();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}

--- a/crates/karta-server/src/oauth/callback.rs
+++ b/crates/karta-server/src/oauth/callback.rs
@@ -1,0 +1,243 @@
+use axum::extract::{Query, State};
+use axum::response::{IntoResponse, Redirect, Response};
+use oauth2::{AuthorizationCode, PkceCodeVerifier};
+use oauth2::TokenResponse as _;  // for access_token() on GitHub response
+use openidconnect::TokenResponse as _; // for id_token() on Google response
+use serde::Deserialize;
+
+use crate::db::AuthCode;
+use crate::error::{Result, ServerError};
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct CallbackParams {
+    pub code: Option<String>,
+    pub state: Option<String>,
+    pub error: Option<String>,
+    pub error_description: Option<String>,
+}
+
+/// `GET /auth/google/callback` — Google OIDC callback.
+pub async fn google_callback(
+    State(state): State<AppState>,
+    Query(params): Query<CallbackParams>,
+) -> Result<Response> {
+    if let Some(err) = &params.error {
+        let desc = params.error_description.as_deref().unwrap_or("Unknown error");
+        return Err(ServerError::IdpError(format!("Google OAuth error: {err}: {desc}")));
+    }
+
+    let idp_code = params
+        .code
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("Missing code parameter".to_string()))?;
+    let idp_state = params
+        .state
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("Missing state parameter".to_string()))?;
+
+    // Look up pending auth request by IdP CSRF token
+    let pending = state
+        .db
+        .consume_pending_auth(idp_state)?
+        .ok_or_else(|| ServerError::BadRequest("Unknown or expired state".to_string()))?;
+
+    if pending.provider != "google" {
+        return Err(ServerError::BadRequest("State does not match Google provider".to_string()));
+    }
+
+    // Check expiry
+    let expires = chrono::NaiveDateTime::parse_from_str(&pending.expires_at, "%Y-%m-%dT%H:%M:%SZ")
+        .map_err(|e| ServerError::Internal(format!("Bad expiry: {e}")))?;
+    if expires.and_utc() < chrono::Utc::now() {
+        return Err(ServerError::BadRequest("Authorization request expired".to_string()));
+    }
+
+    // Exchange code for tokens at Google
+    let pkce_verifier = PkceCodeVerifier::new(pending.idp_pkce_verifier.clone());
+
+    let token_response = state
+        .google_client
+        .exchange_code(openidconnect::AuthorizationCode::new(idp_code.to_string()))
+        .map_err(|e| ServerError::IdpError(format!("Google token exchange config error: {e}")))?
+        .set_pkce_verifier(pkce_verifier)
+        .request_async(&state.http_client)
+        .await
+        .map_err(|e| ServerError::IdpError(format!("Google token exchange failed: {e}")))?;
+
+    // Validate ID token
+    let id_token = token_response
+        .id_token()
+        .ok_or_else(|| ServerError::IdpError("Google did not return an ID token".to_string()))?;
+
+    let nonce = pending
+        .idp_nonce
+        .as_ref()
+        .map(|n| openidconnect::Nonce::new(n.clone()))
+        .ok_or_else(|| ServerError::Internal("Missing nonce for Google OIDC".to_string()))?;
+
+    let verifier = state.google_client.id_token_verifier();
+    let claims = id_token
+        .claims(&verifier, &nonce)
+        .map_err(|e| ServerError::IdpError(format!("Google ID token validation failed: {e}")))?;
+
+    let sub = claims.subject().to_string();
+    let email: Option<String> = claims.email().map(|e| e.to_string());
+    let name: Option<String> = claims
+        .given_name()
+        .and_then(|names| names.get(None))
+        .map(|n| n.to_string())
+        .or_else(|| {
+            claims
+                .name()
+                .and_then(|names| names.get(None))
+                .map(|n| n.to_string())
+        });
+
+    // Upsert user
+    let user = state.db.upsert_user("google", &sub, email.as_deref(), name.as_deref())?;
+
+    // Generate authorization code for the downstream client
+    let auth_code = generate_auth_code(&state, &pending, &user.id)?;
+
+    // Redirect to client's redirect_uri
+    let redirect_url = build_client_redirect(&pending.redirect_uri, &auth_code, &pending.original_state);
+    tracing::info!(user_id = %user.id, provider = "google", "User authenticated");
+
+    Ok(Redirect::temporary(&redirect_url).into_response())
+}
+
+/// `GET /auth/github/callback` — GitHub OAuth callback.
+pub async fn github_callback(
+    State(state): State<AppState>,
+    Query(params): Query<CallbackParams>,
+) -> Result<Response> {
+    if let Some(err) = &params.error {
+        let desc = params.error_description.as_deref().unwrap_or("Unknown error");
+        return Err(ServerError::IdpError(format!("GitHub OAuth error: {err}: {desc}")));
+    }
+
+    let idp_code = params
+        .code
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("Missing code parameter".to_string()))?;
+    let idp_state = params
+        .state
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("Missing state parameter".to_string()))?;
+
+    // Look up pending auth request
+    let pending = state
+        .db
+        .consume_pending_auth(idp_state)?
+        .ok_or_else(|| ServerError::BadRequest("Unknown or expired state".to_string()))?;
+
+    if pending.provider != "github" {
+        return Err(ServerError::BadRequest("State does not match GitHub provider".to_string()));
+    }
+
+    // Check expiry
+    let expires = chrono::NaiveDateTime::parse_from_str(&pending.expires_at, "%Y-%m-%dT%H:%M:%SZ")
+        .map_err(|e| ServerError::Internal(format!("Bad expiry: {e}")))?;
+    if expires.and_utc() < chrono::Utc::now() {
+        return Err(ServerError::BadRequest("Authorization request expired".to_string()));
+    }
+
+    // Exchange code for tokens at GitHub
+    let pkce_verifier = PkceCodeVerifier::new(pending.idp_pkce_verifier.clone());
+
+    let token_response = state
+        .github_client
+        .exchange_code(AuthorizationCode::new(idp_code.to_string()))
+        .set_pkce_verifier(pkce_verifier)
+        .request_async(&state.http_client)
+        .await
+        .map_err(|e| ServerError::IdpError(format!("GitHub token exchange failed: {e}")))?;
+
+    let access_token = token_response.access_token().secret().clone();
+
+    // Fetch user info from GitHub API with timeout
+    let resp = state
+        .http_client
+        .get("https://api.github.com/user")
+        .header("Authorization", format!("Bearer {access_token}"))
+        .header("User-Agent", "karta-server")
+        .header("Accept", "application/json")
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| ServerError::IdpError(format!("GitHub user API failed: {e}")))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(ServerError::IdpError(format!(
+            "GitHub user API returned {status}: {body}"
+        )));
+    }
+
+    let github_user: GitHubUser = resp
+        .json()
+        .await
+        .map_err(|e| ServerError::IdpError(format!("GitHub user API parse failed: {e}")))?;
+
+    let sub = github_user.id.to_string();
+    let email = github_user.email;
+    let name = github_user.name.or(github_user.login);
+
+    // Upsert user
+    let user = state.db.upsert_user("github", &sub, email.as_deref(), name.as_deref())?;
+
+    // Generate authorization code
+    let auth_code = generate_auth_code(&state, &pending, &user.id)?;
+
+    // Redirect to client's redirect_uri
+    let redirect_url = build_client_redirect(&pending.redirect_uri, &auth_code, &pending.original_state);
+    tracing::info!(user_id = %user.id, provider = "github", "User authenticated");
+
+    Ok(Redirect::temporary(&redirect_url).into_response())
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubUser {
+    id: u64,
+    login: Option<String>,
+    name: Option<String>,
+    email: Option<String>,
+}
+
+fn generate_auth_code(
+    state: &AppState,
+    pending: &crate::db::PendingAuth,
+    user_id: &str,
+) -> Result<String> {
+    use base64::Engine;
+    let code_bytes: [u8; 32] = rand::random();
+    let code = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(code_bytes);
+
+    let expires_at = (chrono::Utc::now() + chrono::Duration::minutes(10))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+
+    let auth_code = AuthCode {
+        code: code.clone(),
+        client_id: pending.client_id.clone(),
+        user_id: user_id.to_string(),
+        redirect_uri: pending.redirect_uri.clone(),
+        code_challenge: pending.code_challenge.clone(),
+        code_challenge_method: pending.code_challenge_method.clone(),
+        scope: pending.scope.clone(),
+        expires_at,
+    };
+    state.db.insert_auth_code(&auth_code)?;
+
+    Ok(code)
+}
+
+fn build_client_redirect(redirect_uri: &str, code: &str, state: &str) -> String {
+    format!(
+        "{redirect_uri}?code={}&state={}",
+        urlencoding::encode(code),
+        urlencoding::encode(state),
+    )
+}

--- a/crates/karta-server/src/oauth/discovery.rs
+++ b/crates/karta-server/src/oauth/discovery.rs
@@ -7,7 +7,7 @@ use crate::state::AppState;
 /// `GET /.well-known/oauth-authorization-server`
 /// Returns OAuth 2.0 Authorization Server Metadata per RFC 8414.
 pub async fn oauth_metadata(State(state): State<AppState>) -> Json<Value> {
-    let base = &state.config.base_url;
+    let base = state.config.base_url.trim_end_matches('/');
     Json(json!({
         "issuer": base,
         "authorization_endpoint": format!("{base}/oauth/authorize"),

--- a/crates/karta-server/src/oauth/discovery.rs
+++ b/crates/karta-server/src/oauth/discovery.rs
@@ -1,0 +1,22 @@
+use axum::extract::State;
+use axum::Json;
+use serde_json::{Value, json};
+
+use crate::state::AppState;
+
+/// `GET /.well-known/oauth-authorization-server`
+/// Returns OAuth 2.0 Authorization Server Metadata per RFC 8414.
+pub async fn oauth_metadata(State(state): State<AppState>) -> Json<Value> {
+    let base = &state.config.base_url;
+    Json(json!({
+        "issuer": base,
+        "authorization_endpoint": format!("{base}/oauth/authorize"),
+        "token_endpoint": format!("{base}/oauth/token"),
+        "registration_endpoint": format!("{base}/oauth/register"),
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
+        "scopes_supported": ["read", "write", "admin"]
+    }))
+}

--- a/crates/karta-server/src/oauth/mod.rs
+++ b/crates/karta-server/src/oauth/mod.rs
@@ -1,0 +1,5 @@
+pub mod authorize;
+pub mod callback;
+pub mod discovery;
+pub mod register;
+pub mod token;

--- a/crates/karta-server/src/oauth/register.rs
+++ b/crates/karta-server/src/oauth/register.rs
@@ -71,6 +71,12 @@ pub async fn register_client(
         .as_deref()
         .unwrap_or("none");
 
+    if auth_method != "none" && auth_method != "client_secret_post" {
+        return Err(ServerError::BadRequest(
+            format!("Unsupported token_endpoint_auth_method: {auth_method}. Supported: none, client_secret_post")
+        ));
+    }
+
     let client_id = uuid::Uuid::new_v4().to_string();
 
     let (client_secret, client_secret_hash) = if auth_method == "client_secret_post" {

--- a/crates/karta-server/src/oauth/register.rs
+++ b/crates/karta-server/src/oauth/register.rs
@@ -1,0 +1,121 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::db::OAuthClient;
+use crate::error::{Result, ServerError};
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
+    pub redirect_uris: Vec<String>,
+    pub client_name: Option<String>,
+    pub token_endpoint_auth_method: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RegisterResponse {
+    pub client_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+    pub redirect_uris: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_name: Option<String>,
+    pub token_endpoint_auth_method: String,
+}
+
+/// `POST /oauth/register` — Dynamic Client Registration (RFC 7591).
+pub async fn register_client(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<RegisterRequest>,
+) -> Result<(StatusCode, Json<RegisterResponse>)> {
+    // Check registration token if configured
+    if let Some(expected_token) = &state.config.registration_token {
+        let provided = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .ok_or_else(|| ServerError::Unauthorized(
+                "Registration requires Authorization: Bearer <token>".to_string(),
+            ))?;
+        if provided != expected_token {
+            return Err(ServerError::Unauthorized("Invalid registration token".to_string()));
+        }
+    }
+
+    if req.redirect_uris.is_empty() {
+        return Err(ServerError::BadRequest(
+            "redirect_uris must not be empty".to_string(),
+        ));
+    }
+
+    // Validate all redirect URIs are valid URLs with appropriate schemes
+    for uri in &req.redirect_uris {
+        let parsed = url::Url::parse(uri)
+            .map_err(|_| ServerError::BadRequest(format!("Invalid redirect_uri: {uri}")))?;
+        let is_loopback = parsed
+            .host_str()
+            .is_some_and(|h| h == "localhost" || h == "127.0.0.1");
+        if parsed.scheme() != "https" && !(parsed.scheme() == "http" && is_loopback) {
+            return Err(ServerError::BadRequest(
+                "redirect_uri must use HTTPS (HTTP allowed only for localhost)".to_string(),
+            ));
+        }
+    }
+
+    let auth_method = req
+        .token_endpoint_auth_method
+        .as_deref()
+        .unwrap_or("none");
+
+    let client_id = uuid::Uuid::new_v4().to_string();
+
+    let (client_secret, client_secret_hash) = if auth_method == "client_secret_post" {
+        let secret = generate_random_string();
+        let hash = sha256_hex(&secret);
+        (Some(secret), Some(hash))
+    } else {
+        (None, None)
+    };
+
+    let client = OAuthClient {
+        client_id: client_id.clone(),
+        client_secret_hash,
+        redirect_uris: req.redirect_uris.clone(),
+        client_name: req.client_name.clone(),
+    };
+
+    state.db.insert_client(&client)?;
+
+    tracing::info!(client_id = %client_id, "Registered new OAuth client");
+
+    Ok((
+        StatusCode::CREATED,
+        Json(RegisterResponse {
+            client_id,
+            client_secret,
+            redirect_uris: req.redirect_uris,
+            client_name: req.client_name,
+            token_endpoint_auth_method: auth_method.to_string(),
+        }),
+    ))
+}
+
+fn generate_random_string() -> String {
+    use base64::Engine;
+    let bytes: [u8; 32] = rand::random();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn sha256_hex(input: &str) -> String {
+    let digest = Sha256::digest(input.as_bytes());
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write;
+        write!(hex, "{byte:02x}").unwrap();
+    }
+    hex
+}

--- a/crates/karta-server/src/oauth/token.rs
+++ b/crates/karta-server/src/oauth/token.rs
@@ -1,0 +1,266 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+
+use crate::error::{Result, ServerError};
+use crate::middleware::hash_token;
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct TokenRequest {
+    pub grant_type: Option<String>,
+    pub code: Option<String>,
+    pub redirect_uri: Option<String>,
+    pub code_verifier: Option<String>,
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
+    pub refresh_token: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub token_type: String,
+    pub expires_in: u64,
+    pub refresh_token: String,
+}
+
+/// `POST /oauth/token` — Token endpoint.
+pub async fn token(
+    State(state): State<AppState>,
+    axum::Form(req): axum::Form<TokenRequest>,
+) -> Result<Json<TokenResponse>> {
+    let grant_type = req
+        .grant_type
+        .as_deref()
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_request",
+            "grant_type is required",
+            StatusCode::BAD_REQUEST,
+        ))?;
+
+    match grant_type {
+        "authorization_code" => handle_auth_code_grant(&state, &req).await,
+        "refresh_token" => handle_refresh_token_grant(&state, &req).await,
+        _ => Err(ServerError::oauth(
+            "unsupported_grant_type",
+            "Only authorization_code and refresh_token are supported",
+            StatusCode::BAD_REQUEST,
+        )),
+    }
+}
+
+async fn handle_auth_code_grant(
+    state: &AppState,
+    req: &TokenRequest,
+) -> Result<Json<TokenResponse>> {
+    let code = req
+        .code
+        .as_deref()
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_request",
+            "code is required",
+            StatusCode::BAD_REQUEST,
+        ))?;
+    let redirect_uri = req
+        .redirect_uri
+        .as_deref()
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_request",
+            "redirect_uri is required",
+            StatusCode::BAD_REQUEST,
+        ))?;
+    let code_verifier = req
+        .code_verifier
+        .as_deref()
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_request",
+            "code_verifier is required",
+            StatusCode::BAD_REQUEST,
+        ))?;
+    let client_id = req
+        .client_id
+        .as_deref()
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_request",
+            "client_id is required",
+            StatusCode::BAD_REQUEST,
+        ))?;
+
+    // Look up the client and verify client_secret if the client has one
+    let client = state
+        .db
+        .get_client(client_id)?
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_client",
+            "Unknown client_id",
+            StatusCode::UNAUTHORIZED,
+        ))?;
+
+    if let Some(expected_hash) = &client.client_secret_hash {
+        let provided_secret = req
+            .client_secret
+            .as_deref()
+            .ok_or_else(|| ServerError::oauth(
+                "invalid_client",
+                "client_secret is required for this client",
+                StatusCode::UNAUTHORIZED,
+            ))?;
+        let provided_hash = hash_token(provided_secret);
+        if provided_hash != *expected_hash {
+            return Err(ServerError::oauth(
+                "invalid_client",
+                "Invalid client_secret",
+                StatusCode::UNAUTHORIZED,
+            ));
+        }
+    }
+
+    // Consume the auth code atomically (one-time use, expiry checked in SQL)
+    let auth_code = state
+        .db
+        .consume_auth_code(code)?
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_grant",
+            "Invalid, expired, or already used authorization code",
+            StatusCode::BAD_REQUEST,
+        ))?;
+
+    // Verify client_id matches the auth code
+    if auth_code.client_id != client_id {
+        return Err(ServerError::oauth(
+            "invalid_grant",
+            "client_id does not match authorization code",
+            StatusCode::BAD_REQUEST,
+        ));
+    }
+
+    // Verify redirect_uri matches
+    if auth_code.redirect_uri != redirect_uri {
+        return Err(ServerError::oauth(
+            "invalid_grant",
+            "redirect_uri does not match",
+            StatusCode::BAD_REQUEST,
+        ));
+    }
+
+    // Verify PKCE with constant-time comparison: BASE64URL(SHA256(code_verifier)) == code_challenge
+    let computed_challenge = {
+        let digest = Sha256::digest(code_verifier.as_bytes());
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
+    };
+
+    let computed_bytes = computed_challenge.as_bytes();
+    let stored_bytes = auth_code.code_challenge.as_bytes();
+    if computed_bytes.len() != stored_bytes.len()
+        || computed_bytes.ct_eq(stored_bytes).unwrap_u8() != 1
+    {
+        return Err(ServerError::oauth(
+            "invalid_grant",
+            "PKCE code_verifier does not match code_challenge",
+            StatusCode::BAD_REQUEST,
+        ));
+    }
+
+    // Issue tokens
+    issue_tokens(state, &auth_code.client_id, &auth_code.user_id, auth_code.scope.as_deref())
+}
+
+async fn handle_refresh_token_grant(
+    state: &AppState,
+    req: &TokenRequest,
+) -> Result<Json<TokenResponse>> {
+    let refresh_token = req
+        .refresh_token
+        .as_deref()
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_request",
+            "refresh_token is required",
+            StatusCode::BAD_REQUEST,
+        ))?;
+    let client_id = req
+        .client_id
+        .as_deref()
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_request",
+            "client_id is required",
+            StatusCode::BAD_REQUEST,
+        ))?;
+
+    let token_hash = hash_token(refresh_token);
+
+    let (stored_client_id, user_id, scope) = state
+        .db
+        .consume_refresh_token(&token_hash)?
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_grant",
+            "Invalid, expired, or revoked refresh token",
+            StatusCode::BAD_REQUEST,
+        ))?;
+
+    // Verify client_id matches the stored refresh token
+    if stored_client_id != client_id {
+        return Err(ServerError::oauth(
+            "invalid_grant",
+            "client_id does not match refresh token",
+            StatusCode::BAD_REQUEST,
+        ));
+    }
+
+    // Issue new tokens (rotation)
+    issue_tokens(state, &stored_client_id, &user_id, scope.as_deref())
+}
+
+fn issue_tokens(
+    state: &AppState,
+    client_id: &str,
+    user_id: &str,
+    scope: Option<&str>,
+) -> Result<Json<TokenResponse>> {
+    // Generate access token (32 random bytes, base64url)
+    let access_token_bytes: [u8; 32] = rand::random();
+    let access_token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(access_token_bytes);
+    let access_token_hash = hash_token(&access_token);
+
+    // Generate refresh token (32 random bytes, base64url)
+    let refresh_token_bytes: [u8; 32] = rand::random();
+    let refresh_token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(refresh_token_bytes);
+    let refresh_token_hash = hash_token(&refresh_token);
+
+    let now = chrono::Utc::now();
+    let access_expires = (now + chrono::Duration::hours(1))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+    let refresh_expires = (now + chrono::Duration::days(30))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+
+    // Store hashed tokens
+    state.db.insert_access_token(
+        &access_token_hash,
+        client_id,
+        user_id,
+        scope,
+        &access_expires,
+    )?;
+    state.db.insert_refresh_token(
+        &refresh_token_hash,
+        client_id,
+        user_id,
+        scope,
+        &refresh_expires,
+    )?;
+
+    tracing::info!(user_id = %user_id, client_id = %client_id, "Issued new token pair");
+
+    Ok(Json(TokenResponse {
+        access_token,
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        refresh_token,
+    }))
+}

--- a/crates/karta-server/src/oauth/token.rs
+++ b/crates/karta-server/src/oauth/token.rs
@@ -191,6 +191,35 @@ async fn handle_refresh_token_grant(
             StatusCode::BAD_REQUEST,
         ))?;
 
+    // Look up the client and verify client_secret if the client has one
+    let client = state
+        .db
+        .get_client(client_id)?
+        .ok_or_else(|| ServerError::oauth(
+            "invalid_client",
+            "Unknown client_id",
+            StatusCode::UNAUTHORIZED,
+        ))?;
+
+    if let Some(expected_hash) = &client.client_secret_hash {
+        let provided_secret = req
+            .client_secret
+            .as_deref()
+            .ok_or_else(|| ServerError::oauth(
+                "invalid_client",
+                "client_secret is required for this client",
+                StatusCode::UNAUTHORIZED,
+            ))?;
+        let provided_hash = hash_token(provided_secret);
+        if provided_hash != *expected_hash {
+            return Err(ServerError::oauth(
+                "invalid_client",
+                "Invalid client_secret",
+                StatusCode::UNAUTHORIZED,
+            ));
+        }
+    }
+
     let token_hash = hash_token(refresh_token);
 
     let (stored_client_id, user_id, scope) = state

--- a/crates/karta-server/src/routes.rs
+++ b/crates/karta-server/src/routes.rs
@@ -1,0 +1,26 @@
+use axum::Json;
+use axum::http::{StatusCode, header};
+use axum::response::IntoResponse;
+use serde_json::{Value, json};
+
+use crate::error::Result;
+use crate::middleware::AuthenticatedUser;
+
+const LOGO_SVG: &str = include_str!("logo.svg");
+
+/// `GET /api/health` — Protected health check.
+pub async fn health(user: AuthenticatedUser) -> Result<Json<Value>> {
+    Ok(Json(json!({
+        "status": "ok",
+        "user_id": user.user_id,
+    })))
+}
+
+/// `GET /icon.svg` — Serve the SVG logo.
+pub async fn icon_svg() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "image/svg+xml")],
+        LOGO_SVG,
+    )
+}

--- a/crates/karta-server/src/state.rs
+++ b/crates/karta-server/src/state.rs
@@ -42,6 +42,7 @@ impl AppState {
     pub async fn new(config: ServerConfig, db: AuthDb) -> Result<Self> {
         let http_client = reqwest::ClientBuilder::new()
             .redirect(reqwest::redirect::Policy::none())
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|e| ServerError::Internal(format!("Failed to build HTTP client: {e}")))?;
 

--- a/crates/karta-server/src/state.rs
+++ b/crates/karta-server/src/state.rs
@@ -1,0 +1,111 @@
+use axum_extra::extract::cookie::Key;
+use oauth2::basic::BasicClient;
+use oauth2::{AuthUrl, ClientId, ClientSecret, EndpointMaybeSet, EndpointNotSet, EndpointSet, RedirectUrl, TokenUrl};
+use openidconnect::core::CoreClient;
+use openidconnect::{IssuerUrl, ClientId as OidcClientId, ClientSecret as OidcClientSecret};
+
+use crate::config::ServerConfig;
+use crate::db::AuthDb;
+use crate::error::{Result, ServerError};
+
+/// The Google OIDC client type after discovery (auth URL set, token URL maybe set).
+pub type GoogleClient = CoreClient<
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointMaybeSet,
+    EndpointMaybeSet,
+>;
+
+/// The GitHub OAuth2 client type with auth + token URLs set.
+pub type GithubClient = BasicClient<
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointSet,
+>;
+
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct AppState {
+    pub db: AuthDb,
+    pub google_client: GoogleClient,
+    pub github_client: GithubClient,
+    pub config: ServerConfig,
+    pub http_client: reqwest::Client,
+    pub cookie_key: Key,
+}
+
+impl AppState {
+    pub async fn new(config: ServerConfig, db: AuthDb) -> Result<Self> {
+        let http_client = reqwest::ClientBuilder::new()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| ServerError::Internal(format!("Failed to build HTTP client: {e}")))?;
+
+        let google_client = build_google_client(&config, &http_client).await?;
+        let github_client = build_github_client(&config)?;
+        let cookie_key = Key::from(&config.cookie_secret);
+
+        Ok(Self {
+            db,
+            google_client,
+            github_client,
+            config,
+            http_client,
+            cookie_key,
+        })
+    }
+}
+
+async fn build_google_client(
+    config: &ServerConfig,
+    http_client: &reqwest::Client,
+) -> Result<GoogleClient> {
+    let issuer = IssuerUrl::new("https://accounts.google.com".to_string())
+        .map_err(|e| ServerError::Config(format!("Invalid Google issuer URL: {e}")))?;
+
+    let provider_metadata = openidconnect::core::CoreProviderMetadata::discover_async(
+        issuer,
+        http_client,
+    )
+    .await
+    .map_err(|e| ServerError::Config(format!("Failed to discover Google OIDC: {e}")))?;
+
+    let redirect_url = format!("{}/auth/google/callback", config.base_url);
+
+    let client = CoreClient::from_provider_metadata(
+        provider_metadata,
+        OidcClientId::new(config.google_client_id.clone()),
+        Some(OidcClientSecret::new(config.google_client_secret.clone())),
+    )
+    .set_redirect_uri(
+        openidconnect::RedirectUrl::new(redirect_url)
+            .map_err(|e| ServerError::Config(format!("Invalid Google redirect URL: {e}")))?,
+    );
+
+    Ok(client)
+}
+
+fn build_github_client(config: &ServerConfig) -> Result<GithubClient> {
+    let redirect_url = format!("{}/auth/github/callback", config.base_url);
+
+    let client = BasicClient::new(ClientId::new(config.github_client_id.clone()))
+        .set_client_secret(ClientSecret::new(config.github_client_secret.clone()))
+        .set_auth_uri(
+            AuthUrl::new("https://github.com/login/oauth/authorize".to_string())
+                .map_err(|e| ServerError::Config(format!("Invalid GitHub auth URL: {e}")))?,
+        )
+        .set_token_uri(
+            TokenUrl::new("https://github.com/login/oauth/access_token".to_string())
+                .map_err(|e| ServerError::Config(format!("Invalid GitHub token URL: {e}")))?,
+        )
+        .set_redirect_uri(
+            RedirectUrl::new(redirect_url)
+                .map_err(|e| ServerError::Config(format!("Invalid GitHub redirect URL: {e}")))?,
+        );
+
+    Ok(client)
+}


### PR DESCRIPTION
## Summary

- Adds `karta-server` crate: a full MCP server using the official `rmcp` Rust SDK, exposing karta-core as MCP tools with OAuth 2.1 + PKCE authentication
- **5 MCP tools**: `add_note`, `search`, `ask`, `get_note`, `note_count` — wrapping karta-core operations
- **OAuth 2.1 Authorization Server** with Google OIDC + GitHub OAuth as upstream IdPs
- **SVG icon** embedded via MCP `ServerInfo` and served at `/icon.svg`

## Architecture

```
Claude.ai ──OAuth 2.1──► karta-server ──MCP/JSON-RPC──► karta-core
                              │                              │
                         axum + rmcp                    LanceDB + SQLite
                         StreamableHTTP                  + LLM enrichment
                              │
                    Google/GitHub IdP federation
```

### MCP Tools

| Tool | Description |
|---|---|
| `add_note` | Store a memory note with LLM-enriched attributes and graph linking |
| `search` | Semantic similarity search with recency + graph scoring |
| `ask` | RAG-powered Q&A: retrieves notes then synthesizes an answer |
| `get_note` | Retrieve a specific note by ID |
| `note_count` | Get total stored note count |

### Key Components

| Component | Implementation |
|---|---|
| MCP Protocol | `rmcp::StreamableHttpService` at `/mcp` |
| OAuth 2.1 AS | Custom axum handlers with PKCE S256, token hashing, refresh rotation |
| IdP Federation | Google (OIDC + discovery) and GitHub (OAuth2 + user API) |
| Auth Middleware | Bearer token validation on MCP endpoints |
| Icon | SVG knowledge graph logo, data URI in `ServerInfo` + static `/icon.svg` |
| Session Mgmt | `LocalSessionManager` (in-memory MCP sessions) |

### Security

- PKCE S256 mandatory, constant-time verification (`subtle` crate)
- Tokens stored as SHA-256 hashes
- Auth codes: one-time use, atomic SQL consumption (TOCTOU-safe)
- Refresh token rotation with breach detection (family revocation)
- CORS: explicit allowlist on OAuth endpoints
- Registration gated by `KARTA_REGISTRATION_TOKEN` when set

## Test plan

- [ ] `cargo check -p karta-server` compiles cleanly
- [ ] Deploy to Cloud Run with OAuth credentials
- [ ] Register client via `POST /oauth/register`
- [ ] Complete OAuth flow with Google/GitHub
- [ ] Connect from Claude.ai as remote MCP server
- [ ] Verify icon appears in Claude.ai
- [ ] Test all 5 MCP tools via Claude.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth 2.1 authorization server: Google & GitHub sign-in, dynamic client registration, discovery, PKCE-backed auth code and refresh-token flows
  * Bearer-token API auth with protected health check
  * MCP tools: add note, search, ask, get note, note count
  * Server startup with periodic token cleanup and embedded icon/static asset

* **Chores**
  * Example environment variables added for server and OAuth configuration
  * Dockerfile and .dockerignore to support container builds

* **Infrastructure**
  * New server crate added to the workspace
<!-- end of auto-generated comment: release notes by coderabbit.ai -->