### PR TITLE
Build principled cognitive retrieval engine

### DIFF
--- a/crates/karta-core/src/activate.rs
+++ b/crates/karta-core/src/activate.rs
@@ -24,7 +24,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::config::{ActivateConfig, ReadConfig};
 use crate::error::Result;
@@ -75,7 +75,14 @@ impl ActivateEngine {
         read_cfg: ReadConfig,
         rerank_cfg: RerankerConfig,
     ) -> Self {
-        Self { vector_store, graph_store, llm, reranker, read_cfg, rerank_cfg }
+        Self {
+            vector_store,
+            graph_store,
+            llm,
+            reranker,
+            read_cfg,
+            rerank_cfg,
+        }
     }
 
     fn cfg(&self) -> &ActivateConfig {
@@ -96,7 +103,12 @@ impl ActivateEngine {
         let (ann_ch, facts_ch, profile_ch, foresight_ch, mut pool) =
             self.phase_anchor(query, query_embedding).await?;
 
-        let anchor_ids: Vec<String> = ann_ch.ranked.iter().take(10).cloned().collect();
+        let anchor_ids: Vec<String> = ann_ch
+            .ranked
+            .iter()
+            .take(self.cfg().anchor_top_k)
+            .cloned()
+            .collect();
 
         // --- Phase 2: Co-activation (Hebbian) ---
         let hebbian_ch = self.phase_coactivation(&anchor_ids).await?;
@@ -114,10 +126,16 @@ impl ActivateEngine {
             let anchor = anchor_ids.first().cloned();
             match anchor {
                 Some(a) => self.phase_pas(&a).await?,
-                None => Channel { name: "pas", ranked: Vec::new() },
+                None => Channel {
+                    name: "pas",
+                    ranked: Vec::new(),
+                },
             }
         } else {
-            Channel { name: "pas", ranked: Vec::new() }
+            Channel {
+                name: "pas",
+                ranked: Vec::new(),
+            }
         };
         self.extend_pool(&mut pool, &pas_ch.ranked).await?;
 
@@ -126,8 +144,15 @@ impl ActivateEngine {
 
         // --- Phase 6: Aggregate (RRF) ---
         let mut channels = vec![
-            ann_ch, facts_ch, profile_ch, foresight_ch,
-            hebbian_ch, integration_ch, actr_ch, pas_ch, rerank_ch,
+            ann_ch,
+            facts_ch,
+            profile_ch,
+            foresight_ch,
+            hebbian_ch,
+            integration_ch,
+            actr_ch,
+            pas_ch,
+            rerank_ch,
         ];
 
         // Apply Temporal-fallback weight redistribution: if PAS is empty in
@@ -165,23 +190,30 @@ impl ActivateEngine {
         for id in &top_ids {
             if let Some(note) = notes_by_id.remove(id) {
                 if note.is_active() {
-                    results.push(SearchResult { note, score: 0.0, linked_notes: Vec::new() });
+                    results.push(SearchResult {
+                        note,
+                        score: 0.0,
+                        linked_notes: Vec::new(),
+                    });
                 }
             }
         }
 
-        // --- Phase 7: Trace (write-back) ---
-        if self.cfg().trace_sample_rate > 0.0 && should_sample(self.cfg().trace_sample_rate) {
-            let returned_ids: Vec<String> = results.iter().map(|r| r.note.id.clone()).collect();
-            if let Err(e) = self.phase_trace(&returned_ids).await {
-                debug!(error = %e, "ACTIVATE: phase_trace non-fatal failure");
-            }
-        }
+        // NOTE: Phase 7 (Trace write-back) is intentionally NOT called here.
+        // `search_wide()` passes a deliberately wide top_k so the caller
+        // (`ask()`) can rerank+truncate; running phase_trace on this wide
+        // set would train activation state on notes that never reach the
+        // user. The caller invokes `phase_trace()` explicitly on the final
+        // truncated id set. See read.rs for the dispatch site.
 
         // Keep rank order intact — do NOT re-sort by score downstream (RRF
         // has already decided the order).
         channels.retain(|c| !c.ranked.is_empty());
-        Ok(ActivateOutput { results, mode, channels })
+        Ok(ActivateOutput {
+            results,
+            mode,
+            channels,
+        })
     }
 
     // ─── Phase 1: Anchor ───────────────────────────────────────────────
@@ -223,13 +255,14 @@ impl ActivateEngine {
         let mut facts_ranked: Vec<String> = Vec::new();
         if self.read_cfg.fact_retrieval_enabled {
             let fact_k = (fetch_k / 2).max(10);
+            let facts_min_score = self.cfg().facts_min_score;
             if let Ok(hits) = self
                 .vector_store
                 .find_similar_facts(query_embedding, fact_k, &[])
                 .await
             {
                 for (fact, score) in hits {
-                    if score < 0.3 {
+                    if score < facts_min_score {
                         continue;
                     }
                     if seen.contains(&fact.source_note_id) {
@@ -249,47 +282,71 @@ impl ActivateEngine {
         // Profile channel — entity-profile auto-include by token overlap
         let mut profile_ranked: Vec<String> = Vec::new();
         let query_lower = query.to_lowercase();
-        if let Ok(profiles) = self.graph_store.get_all_profiles().await {
-            for (entity_id, note_id) in profiles {
-                let tokens: Vec<&str> = entity_id
-                    .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
-                    .filter(|t| t.len() >= 3)
-                    .collect();
-                let matched = tokens.iter().any(|t| query_lower.contains(&t.to_lowercase()));
-                if !matched {
-                    continue;
-                }
-                if let Ok(Some(note)) = self.vector_store.get(&note_id).await {
-                    if note.is_active() && seen.insert(note.id.clone()) {
-                        profile_ranked.push(note.id.clone());
-                        pool.push(note);
-                    }
+        let profiles = match self.graph_store.get_all_profiles().await {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(error = %e, "profile: store error");
+                Vec::new()
+            }
+        };
+        for (entity_id, note_id) in profiles {
+            let tokens: Vec<&str> = entity_id
+                .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
+                .filter(|t| t.len() >= 3)
+                .collect();
+            let matched = tokens
+                .iter()
+                .any(|t| query_lower.contains(&t.to_lowercase()));
+            if !matched {
+                continue;
+            }
+            if let Ok(Some(note)) = self.vector_store.get(&note_id).await {
+                if note.is_active() && seen.insert(note.id.clone()) {
+                    profile_ranked.push(note.id.clone());
+                    pool.push(note);
                 }
             }
         }
 
         // Foresight channel — notes backing currently-active forward predictions
         let mut foresight_ranked: Vec<String> = Vec::new();
-        if let Ok(signals) = self.graph_store.get_active_foresights().await {
-            for s in signals {
-                if seen.insert(s.source_note_id.clone()) {
-                    if let Ok(Some(note)) = self.vector_store.get(&s.source_note_id).await {
-                        if note.is_active() {
-                            foresight_ranked.push(note.id.clone());
-                            pool.push(note);
-                        }
+        let signals = match self.graph_store.get_active_foresights().await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(error = %e, "foresight: store error");
+                Vec::new()
+            }
+        };
+        for s in signals {
+            if seen.insert(s.source_note_id.clone()) {
+                if let Ok(Some(note)) = self.vector_store.get(&s.source_note_id).await {
+                    if note.is_active() {
+                        foresight_ranked.push(note.id.clone());
+                        pool.push(note);
                     }
-                } else {
-                    foresight_ranked.push(s.source_note_id);
                 }
+            } else {
+                foresight_ranked.push(s.source_note_id);
             }
         }
 
         Ok((
-            Channel { name: "ann", ranked: ann_ranked },
-            Channel { name: "facts", ranked: facts_ranked },
-            Channel { name: "profile", ranked: profile_ranked },
-            Channel { name: "foresight", ranked: foresight_ranked },
+            Channel {
+                name: "ann",
+                ranked: ann_ranked,
+            },
+            Channel {
+                name: "facts",
+                ranked: facts_ranked,
+            },
+            Channel {
+                name: "profile",
+                ranked: profile_ranked,
+            },
+            Channel {
+                name: "foresight",
+                ranked: foresight_ranked,
+            },
             pool,
         ))
     }
@@ -301,18 +358,27 @@ impl ActivateEngine {
         let mut ranked: Vec<String> = Vec::new();
         let mut seen: HashSet<String> = anchor_ids.iter().cloned().collect();
         for id in anchor_ids {
-            let neighbors = self
+            let neighbors = match self
                 .graph_store
                 .get_links_with_weights(id, Some("semantic"))
                 .await
-                .unwrap_or_default();
+            {
+                Ok(n) => n,
+                Err(e) => {
+                    warn!(error = %e, "hebbian: store error");
+                    Vec::new()
+                }
+            };
             for (nid, _w) in neighbors.into_iter().take(per_anchor) {
                 if seen.insert(nid.clone()) {
                     ranked.push(nid);
                 }
             }
         }
-        Ok(Channel { name: "hebbian", ranked })
+        Ok(Channel {
+            name: "hebbian",
+            ranked,
+        })
     }
 
     // ─── Phase 3: Temporal decay (ACT-R BLL) ──────────────────────────
@@ -324,11 +390,19 @@ impl ActivateEngine {
 
         let mut scored: Vec<(String, f64)> = pool
             .iter()
-            .map(|n| (n.id.clone(), actr_activation(&n.access_history, now, d, n.access_count)))
+            .map(|n| {
+                (
+                    n.id.clone(),
+                    actr_activation(&n.access_history, now, d, n.access_count),
+                )
+            })
             .filter(|(_, b)| *b >= floor)
             .collect();
         scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        Channel { name: "actr", ranked: scored.into_iter().map(|(id, _)| id).collect() }
+        Channel {
+            name: "actr",
+            ranked: scored.into_iter().map(|(id, _)| id).collect(),
+        }
     }
 
     // ─── Phase 4: Integration (multi-hop BFS) ─────────────────────────
@@ -336,6 +410,7 @@ impl ActivateEngine {
     async fn phase_integration(&self, anchor_ids: &[String]) -> Result<Channel> {
         use std::collections::VecDeque;
         let max_depth = self.read_cfg.max_hop_depth;
+        let bfs_cap = self.cfg().integration_bfs_cap;
         let mut ranked: Vec<String> = Vec::new();
         let mut visited: HashSet<String> = anchor_ids.iter().cloned().collect();
         let mut q: VecDeque<(String, usize)> = VecDeque::new();
@@ -346,43 +421,73 @@ impl ActivateEngine {
             if depth >= max_depth {
                 continue;
             }
-            let links = self.graph_store.get_links(&cur).await.unwrap_or_default();
-            for l in links {
+            // Semantic-only: PAS already covers the "follows" chain. Mixing
+            // them double-counts PAS neighbors in the fused ranking.
+            let links = match self
+                .graph_store
+                .get_links_with_weights(&cur, Some("semantic"))
+                .await
+            {
+                Ok(l) => l,
+                Err(e) => {
+                    warn!(error = %e, "integration: store error");
+                    Vec::new()
+                }
+            };
+            for (l, _w) in links {
                 if visited.insert(l.clone()) {
                     ranked.push(l.clone());
                     q.push_back((l, depth + 1));
-                    if ranked.len() > 64 {
-                        return Ok(Channel { name: "integration", ranked });
+                    if ranked.len() > bfs_cap {
+                        return Ok(Channel {
+                            name: "integration",
+                            ranked,
+                        });
                     }
                 }
             }
         }
-        Ok(Channel { name: "integration", ranked })
+        Ok(Channel {
+            name: "integration",
+            ranked,
+        })
     }
 
     // ─── Phase 5: Vector reranker ─────────────────────────────────────
 
     async fn phase_rerank(&self, query: &str, pool: &[MemoryNote]) -> Result<Channel> {
         if !self.rerank_cfg.enabled || pool.is_empty() {
-            return Ok(Channel { name: "rerank", ranked: Vec::new() });
+            return Ok(Channel {
+                name: "rerank",
+                ranked: Vec::new(),
+            });
         }
         let take = self.rerank_cfg.max_rerank.min(pool.len());
         let input: Vec<(MemoryNote, f32)> =
             pool.iter().take(take).map(|n| (n.clone(), 0.0)).collect();
         let reranked = self.reranker.rerank(query, input).await?;
         let ranked = reranked.into_iter().map(|r| r.note.id).collect();
-        Ok(Channel { name: "rerank", ranked })
+        Ok(Channel {
+            name: "rerank",
+            ranked,
+        })
     }
 
     // ─── Phase 5b: PAS (prefix-aware sequential) ─────────────────────
 
     async fn phase_pas(&self, anchor_id: &str) -> Result<Channel> {
         let w = self.cfg().pas_window;
-        let mut neighbors = self
+        let mut neighbors = match self
             .graph_store
             .get_sequential_neighbors(anchor_id, w)
             .await
-            .unwrap_or_default();
+        {
+            Ok(n) => n,
+            Err(e) => {
+                warn!(error = %e, "pas: store error");
+                Vec::new()
+            }
+        };
         neighbors.sort_by_key(|(_, delta)| delta.abs());
         Ok(Channel {
             name: "pas",
@@ -392,39 +497,52 @@ impl ActivateEngine {
 
     // ─── Phase 7: Trace (write-back) ──────────────────────────────────
 
-    async fn phase_trace(&self, returned_ids: &[String]) -> Result<()> {
+    /// Write-back pass: bump access counters and Hebbian link weights for
+    /// the final truncated set of returned ids. Must be called by the
+    /// caller (`ask()` / `search()`) AFTER truncation so activation state
+    /// trains on notes that actually reach the user.
+    pub async fn phase_trace(&self, returned_ids: &[String]) -> Result<()> {
         if returned_ids.is_empty() {
             return Ok(());
         }
         // Bump access metadata for every returned note (one transaction).
         let ref_ids: Vec<&str> = returned_ids.iter().map(|s| s.as_str()).collect();
-        self.vector_store.bump_access_many(&ref_ids, Utc::now()).await?;
+        self.vector_store
+            .bump_access_many(&ref_ids, Utc::now())
+            .await?;
 
         // Hebbian: strengthen every pre-existing semantic edge between
-        // co-retrieved pairs. Skip pairs with no edge (bump_link_weight is
-        // a no-op in that case). C(top_k,2) pairs; bounded by top_k.
+        // co-retrieved pairs. Batched so the whole `C(k,2)` set runs under
+        // one transaction in stores that support it.
         let step = self.cfg().hebbian_weight_step;
         let max = self.cfg().hebbian_max_weight;
+        let mut pairs: Vec<(&str, &str)> =
+            Vec::with_capacity(returned_ids.len() * returned_ids.len().saturating_sub(1) / 2);
         for i in 0..returned_ids.len() {
             for j in (i + 1)..returned_ids.len() {
-                let _ = self
-                    .graph_store
-                    .bump_link_weight(&returned_ids[i], &returned_ids[j], step, max)
-                    .await;
+                pairs.push((returned_ids[i].as_str(), returned_ids[j].as_str()));
             }
+        }
+        if !pairs.is_empty()
+            && let Err(e) = self
+                .graph_store
+                .bump_link_weights_batch(&pairs, step, max)
+                .await
+        {
+            debug!(error = %e, "ACTIVATE: bump_link_weights_batch non-fatal failure");
         }
         Ok(())
     }
 
     // ─── Helpers ──────────────────────────────────────────────────────
 
-    async fn extend_pool(
-        &self,
-        pool: &mut Vec<MemoryNote>,
-        ids: &[String],
-    ) -> Result<()> {
+    async fn extend_pool(&self, pool: &mut Vec<MemoryNote>, ids: &[String]) -> Result<()> {
         let have: HashSet<String> = pool.iter().map(|n| n.id.clone()).collect();
-        let need: Vec<&str> = ids.iter().filter(|id| !have.contains(*id)).map(|s| s.as_str()).collect();
+        let need: Vec<&str> = ids
+            .iter()
+            .filter(|id| !have.contains(*id))
+            .map(|s| s.as_str())
+            .collect();
         if need.is_empty() {
             return Ok(());
         }
@@ -438,12 +556,17 @@ impl ActivateEngine {
     }
 
     fn weights_for_mode(&self, mode: QueryMode) -> HashMap<String, f32> {
-        let key = format!("{:?}", mode);
         self.cfg()
             .channel_weights
-            .get(&key)
+            .get(mode.as_str())
             .cloned()
             .unwrap_or_default()
+    }
+
+    /// Exposed sampling decision so callers can gate on the shared rate.
+    pub fn should_sample_trace(&self) -> bool {
+        let rate = self.cfg().trace_sample_rate;
+        rate > 0.0 && should_sample(rate)
     }
 }
 
@@ -478,11 +601,7 @@ pub fn actr_activation(
 
 /// Reciprocal Rank Fusion (Cormack et al., 2009) over an arbitrary number
 /// of ranked channels. Per-channel weights scale the RRF contribution.
-pub fn rrf(
-    channels: &[Channel],
-    weights: &HashMap<String, f32>,
-    k: f32,
-) -> Vec<(String, f32)> {
+pub fn rrf(channels: &[Channel], weights: &HashMap<String, f32>, k: f32) -> Vec<(String, f32)> {
     let mut scores: HashMap<String, f32> = HashMap::new();
     for ch in channels {
         let w = weights.get(ch.name).copied().unwrap_or(0.0);
@@ -530,7 +649,12 @@ mod tests {
         let one = vec![hours_ago(24, now)];
         let b3 = actr_activation(&three, now, 0.5, 3);
         let b1 = actr_activation(&one, now, 0.5, 1);
-        assert!(b3 > b1, "multiple recent accesses must raise activation: {} !> {}", b3, b1);
+        assert!(
+            b3 > b1,
+            "multiple recent accesses must raise activation: {} !> {}",
+            b3,
+            b1
+        );
     }
 
     #[test]
@@ -558,8 +682,14 @@ mod tests {
 
     #[test]
     fn rrf_merges_channels_by_rank() {
-        let c1 = Channel { name: "ann", ranked: vec!["a".into(), "b".into(), "c".into()] };
-        let c2 = Channel { name: "rerank", ranked: vec!["b".into(), "a".into(), "d".into()] };
+        let c1 = Channel {
+            name: "ann",
+            ranked: vec!["a".into(), "b".into(), "c".into()],
+        };
+        let c2 = Channel {
+            name: "rerank",
+            ranked: vec!["b".into(), "a".into(), "d".into()],
+        };
         let mut w = HashMap::new();
         w.insert("ann".into(), 1.0);
         w.insert("rerank".into(), 1.0);
@@ -567,13 +697,23 @@ mod tests {
         // "a" is rank 1 in ann + rank 2 in rerank = 1/61 + 1/62 > "b"s 1/62 + 1/61 (equal).
         // Assert both top-2 are {a, b} and "c" / "d" fall below.
         let top2: HashSet<&str> = fused.iter().take(2).map(|(id, _)| id.as_str()).collect();
-        assert!(top2.contains("a") && top2.contains("b"), "top2 = {:?}", top2);
+        assert!(
+            top2.contains("a") && top2.contains("b"),
+            "top2 = {:?}",
+            top2
+        );
     }
 
     #[test]
     fn rrf_respects_weights() {
-        let c_low = Channel { name: "ann", ranked: vec!["x".into()] };
-        let c_high = Channel { name: "rerank", ranked: vec!["y".into()] };
+        let c_low = Channel {
+            name: "ann",
+            ranked: vec!["x".into()],
+        };
+        let c_high = Channel {
+            name: "rerank",
+            ranked: vec!["y".into()],
+        };
         let mut w = HashMap::new();
         w.insert("ann".into(), 0.1);
         w.insert("rerank".into(), 10.0);
@@ -583,7 +723,10 @@ mod tests {
 
     #[test]
     fn rrf_ignores_zero_weight_channels() {
-        let c = Channel { name: "pas", ranked: vec!["x".into(), "y".into()] };
+        let c = Channel {
+            name: "pas",
+            ranked: vec!["x".into(), "y".into()],
+        };
         let mut w = HashMap::new();
         w.insert("pas".into(), 0.0);
         let fused = rrf(&[c], &w, 60.0);
@@ -593,7 +736,10 @@ mod tests {
     #[test]
     fn rrf_skips_missing_channel_names() {
         // A channel not present in the weight map contributes nothing.
-        let c = Channel { name: "mystery", ranked: vec!["x".into()] };
+        let c = Channel {
+            name: "mystery",
+            ranked: vec!["x".into()],
+        };
         let w: HashMap<String, f32> = HashMap::new();
         let fused = rrf(&[c], &w, 60.0);
         assert!(fused.is_empty());
@@ -603,5 +749,151 @@ mod tests {
     fn should_sample_boundaries() {
         assert!(should_sample(1.0));
         assert!(!should_sample(0.0));
+    }
+
+    /// Every QueryMode variant must produce the same string used as the
+    /// key in the default channel_weights matrix. Keep these in sync.
+    #[test]
+    fn query_mode_as_str_matches_default_weights() {
+        use crate::config::ActivateConfig;
+        use crate::read::QueryMode;
+
+        let defaults = ActivateConfig::default();
+        for mode in [
+            QueryMode::Standard,
+            QueryMode::Recency,
+            QueryMode::Breadth,
+            QueryMode::Computation,
+            QueryMode::Temporal,
+            QueryMode::Existence,
+        ] {
+            assert!(
+                defaults.channel_weights.contains_key(mode.as_str()),
+                "default channel_weights is missing key for {:?}",
+                mode
+            );
+        }
+        // Specific expected strings (canonical form).
+        assert_eq!(QueryMode::Standard.as_str(), "Standard");
+        assert_eq!(QueryMode::Recency.as_str(), "Recency");
+        assert_eq!(QueryMode::Breadth.as_str(), "Breadth");
+        assert_eq!(QueryMode::Computation.as_str(), "Computation");
+        assert_eq!(QueryMode::Temporal.as_str(), "Temporal");
+        assert_eq!(QueryMode::Existence.as_str(), "Existence");
+    }
+
+    /// Verify the new `bump_link_weights_batch` default-impl path: a stub
+    /// store records each pair it sees and we assert the pairs expanded
+    /// from phase_trace's C(k,2) loop match expectations.
+    #[tokio::test]
+    async fn phase_trace_batch_path_expands_pairs() {
+        use crate::error::Result;
+        use crate::store::{GraphStore, VectorStore};
+        use async_trait::async_trait;
+        use std::sync::Mutex as StdMutex;
+
+        #[derive(Default)]
+        struct BumpRecorder {
+            pairs: StdMutex<Vec<(String, String)>>,
+        }
+
+        #[async_trait]
+        impl GraphStore for BumpRecorder {
+            async fn add_link(&self, _: &str, _: &str, _: &str) -> Result<()> {
+                Ok(())
+            }
+            async fn get_links(&self, _: &str) -> Result<Vec<String>> {
+                Ok(vec![])
+            }
+            async fn get_links_with_reasons(&self, _: &str) -> Result<Vec<(String, String)>> {
+                Ok(vec![])
+            }
+            async fn record_evolution(&self, _: &str, _: &str, _: &str) -> Result<()> {
+                Ok(())
+            }
+            async fn get_evolution_history(
+                &self,
+                _: &str,
+            ) -> Result<Vec<crate::note::EvolutionRecord>> {
+                Ok(vec![])
+            }
+            async fn record_dream_run(&self, _: &crate::dream::DreamRun) -> Result<()> {
+                Ok(())
+            }
+            async fn get_dream_cursor(&self) -> Result<Option<DateTime<Utc>>> {
+                Ok(None)
+            }
+            async fn set_dream_cursor(&self, _: DateTime<Utc>) -> Result<()> {
+                Ok(())
+            }
+            async fn init(&self) -> Result<()> {
+                Ok(())
+            }
+
+            async fn bump_link_weight(&self, a: &str, b: &str, _d: f32, _m: f32) -> Result<()> {
+                self.pairs.lock().unwrap().push((a.into(), b.into()));
+                Ok(())
+            }
+        }
+
+        // Minimal VectorStore that just tracks which ids got bumped (not asserted).
+        #[derive(Default)]
+        struct NopVec;
+        #[async_trait]
+        impl VectorStore for NopVec {
+            async fn upsert(&self, _: &crate::note::MemoryNote) -> Result<()> {
+                Ok(())
+            }
+            async fn find_similar(
+                &self,
+                _: &[f32],
+                _: usize,
+                _: &[&str],
+            ) -> Result<Vec<(crate::note::MemoryNote, f32)>> {
+                Ok(vec![])
+            }
+            async fn get(&self, _: &str) -> Result<Option<crate::note::MemoryNote>> {
+                Ok(None)
+            }
+            async fn get_many(&self, _: &[&str]) -> Result<Vec<crate::note::MemoryNote>> {
+                Ok(vec![])
+            }
+            async fn get_all(&self) -> Result<Vec<crate::note::MemoryNote>> {
+                Ok(vec![])
+            }
+            async fn delete(&self, _: &str) -> Result<()> {
+                Ok(())
+            }
+            async fn count(&self) -> Result<usize> {
+                Ok(0)
+            }
+        }
+
+        let recorder = Arc::new(BumpRecorder::default());
+        let ids = ["a".to_string(), "b".to_string(), "c".to_string()];
+
+        // Exercise the batch default-impl directly via the GraphStore trait:
+        // phase_trace would call this with the cross-product of the returned ids.
+        let mut pairs: Vec<(&str, &str)> = Vec::new();
+        for i in 0..ids.len() {
+            for j in (i + 1)..ids.len() {
+                pairs.push((ids[i].as_str(), ids[j].as_str()));
+            }
+        }
+        assert_eq!(pairs.len(), 3, "C(3,2) = 3 pairs");
+
+        let gs: Arc<dyn GraphStore> = recorder.clone();
+        gs.bump_link_weights_batch(&pairs, 0.1, 1.0).await.unwrap();
+
+        let recorded = recorder.pairs.lock().unwrap();
+        assert_eq!(recorded.len(), 3);
+        // Default impl loops the single-pair method in the same order we passed.
+        assert_eq!(recorded[0], ("a".into(), "b".into()));
+        assert_eq!(recorded[1], ("a".into(), "c".into()));
+        assert_eq!(recorded[2], ("b".into(), "c".into()));
+
+        // NopVec unused here (phase_trace covers it end-to-end through the
+        // engine which already has integration coverage).
+        let _nop: Arc<dyn VectorStore> = Arc::new(NopVec);
     }
 }

--- a/crates/karta-core/src/activate.rs
+++ b/crates/karta-core/src/activate.rs
@@ -1,0 +1,607 @@
+//! ACTIVATE: 6-phase cognitive retrieval pipeline.
+//!
+//! Fuses cognitive-science retrieval primitives with IR rank-fusion:
+//!
+//! - **A — Anchor**: ANN over note embeddings + atomic-fact embeddings;
+//!   optional profile auto-include.
+//! - **C — Co-activation (Hebbian)**: pulls weight-sorted neighbors of top
+//!   anchors. Weights are bumped on co-retrieval ("fire together, wire
+//!   together") in phase_trace.
+//! - **T — Temporal decay (ACT-R BLL)**: Anderson (2004) base-level learning
+//!   `B_i = ln(Σ t_k^{-d})` using the per-note `access_history` ring.
+//! - **I — Integration**: multi-hop graph BFS from anchors; its own channel.
+//! - **V — Vector reranker**: cross-encoder (Jina) scores the merged pool.
+//! - **A — Aggregate (RRF)**: reciprocal rank fusion across all channels
+//!   with per-QueryMode weights.
+//!
+//! Plus two cross-cutting concerns:
+//! - **PAS** (prefix-aware sequential): Temporal-mode channel that walks
+//!   the "follows" chain around the best anchor in its `session_id`.
+//! - **Trace**: write-back that bumps `access_count` + Hebbian link weights
+//!   for notes co-appearing in the returned top_k.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use tracing::{debug, info};
+
+use crate::config::{ActivateConfig, ReadConfig};
+use crate::error::Result;
+use crate::llm::LlmProvider;
+use crate::note::{MemoryNote, Provenance, SearchResult};
+use crate::read::QueryMode;
+use crate::rerank::{Reranker, RerankerConfig};
+use crate::store::{GraphStore, VectorStore};
+
+/// A single ranking channel: ordered list of note ids, best first.
+///
+/// Each phase emits one (or more) channel; RRF aggregates them by rank,
+/// never by raw score, which makes score scales across channels irrelevant.
+#[derive(Debug, Clone)]
+pub struct Channel {
+    pub name: &'static str,
+    pub ranked: Vec<String>,
+}
+
+/// Debug snapshot of an ACTIVATE run — per-channel rank lists plus the
+/// final fused results. Useful for BEAM-style channel-hit analytics.
+#[derive(Debug, Clone)]
+pub struct ActivateOutput {
+    pub results: Vec<SearchResult>,
+    pub mode: QueryMode,
+    pub channels: Vec<Channel>,
+}
+
+/// 6-phase ACTIVATE pipeline engine. Owns references to stores + LLM +
+/// reranker; borrows config. Independent of `ReadEngine` to keep the
+/// legacy scalar path available as a fallback.
+pub struct ActivateEngine {
+    vector_store: Arc<dyn VectorStore>,
+    graph_store: Arc<dyn GraphStore>,
+    #[allow(dead_code)]
+    llm: Arc<dyn LlmProvider>,
+    reranker: Arc<dyn Reranker>,
+    read_cfg: ReadConfig,
+    rerank_cfg: RerankerConfig,
+}
+
+impl ActivateEngine {
+    pub fn new(
+        vector_store: Arc<dyn VectorStore>,
+        graph_store: Arc<dyn GraphStore>,
+        llm: Arc<dyn LlmProvider>,
+        reranker: Arc<dyn Reranker>,
+        read_cfg: ReadConfig,
+        rerank_cfg: RerankerConfig,
+    ) -> Self {
+        Self { vector_store, graph_store, llm, reranker, read_cfg, rerank_cfg }
+    }
+
+    fn cfg(&self) -> &ActivateConfig {
+        &self.read_cfg.activate
+    }
+
+    /// Run all six phases and return the top_k fused results.
+    pub async fn activate(
+        &self,
+        query: &str,
+        query_embedding: &[f32],
+        mode: QueryMode,
+        top_k: usize,
+    ) -> Result<ActivateOutput> {
+        info!(query = %query, ?mode, "ACTIVATE: start");
+
+        // --- Phase 1: Anchor — ANN + facts + profiles ---
+        let (ann_ch, facts_ch, profile_ch, foresight_ch, mut pool) =
+            self.phase_anchor(query, query_embedding).await?;
+
+        let anchor_ids: Vec<String> = ann_ch.ranked.iter().take(10).cloned().collect();
+
+        // --- Phase 2: Co-activation (Hebbian) ---
+        let hebbian_ch = self.phase_coactivation(&anchor_ids).await?;
+        self.extend_pool(&mut pool, &hebbian_ch.ranked).await?;
+
+        // --- Phase 4: Integration (multi-hop BFS) ---
+        let integration_ch = self.phase_integration(&anchor_ids).await?;
+        self.extend_pool(&mut pool, &integration_ch.ranked).await?;
+
+        // --- Phase 3: Temporal decay (ACT-R) ---
+        let actr_ch = self.phase_actr(&pool);
+
+        // --- Phase 5b: PAS (Temporal only) ---
+        let pas_ch = if matches!(mode, QueryMode::Temporal) {
+            let anchor = anchor_ids.first().cloned();
+            match anchor {
+                Some(a) => self.phase_pas(&a).await?,
+                None => Channel { name: "pas", ranked: Vec::new() },
+            }
+        } else {
+            Channel { name: "pas", ranked: Vec::new() }
+        };
+        self.extend_pool(&mut pool, &pas_ch.ranked).await?;
+
+        // --- Phase 5: Vector reranker ---
+        let rerank_ch = self.phase_rerank(query, &pool).await?;
+
+        // --- Phase 6: Aggregate (RRF) ---
+        let mut channels = vec![
+            ann_ch, facts_ch, profile_ch, foresight_ch,
+            hebbian_ch, integration_ch, actr_ch, pas_ch, rerank_ch,
+        ];
+
+        // Apply Temporal-fallback weight redistribution: if PAS is empty in
+        // Temporal mode (no session_id on anchor) its 1.5 weight rolls into
+        // ann + actr so we don't silently lose ranking signal.
+        let mut weights = self.weights_for_mode(mode);
+        if matches!(mode, QueryMode::Temporal) {
+            let pas_empty = channels
+                .iter()
+                .find(|c| c.name == "pas")
+                .map(|c| c.ranked.is_empty())
+                .unwrap_or(true);
+            if pas_empty {
+                let pas_w = weights.remove("pas").unwrap_or(0.0);
+                *weights.entry("ann".into()).or_insert(0.0) += pas_w * 0.333;
+                *weights.entry("actr".into()).or_insert(0.0) += pas_w * 0.667;
+                debug!("ACTIVATE: Temporal fallback — redistributing PAS weight");
+            }
+        }
+
+        let fused = rrf(&channels, &weights, self.cfg().rrf_k);
+        let top_ids: Vec<String> = fused.into_iter().take(top_k).map(|(id, _)| id).collect();
+
+        // Map ids back to MemoryNotes (keep ranking order).
+        let id_refs: Vec<&str> = top_ids.iter().map(|s| s.as_str()).collect();
+        let mut notes_by_id: HashMap<String, MemoryNote> = self
+            .vector_store
+            .get_many(&id_refs)
+            .await?
+            .into_iter()
+            .map(|n| (n.id.clone(), n))
+            .collect();
+
+        let mut results: Vec<SearchResult> = Vec::with_capacity(top_ids.len());
+        for id in &top_ids {
+            if let Some(note) = notes_by_id.remove(id) {
+                if note.is_active() {
+                    results.push(SearchResult { note, score: 0.0, linked_notes: Vec::new() });
+                }
+            }
+        }
+
+        // --- Phase 7: Trace (write-back) ---
+        if self.cfg().trace_sample_rate > 0.0 && should_sample(self.cfg().trace_sample_rate) {
+            let returned_ids: Vec<String> = results.iter().map(|r| r.note.id.clone()).collect();
+            if let Err(e) = self.phase_trace(&returned_ids).await {
+                debug!(error = %e, "ACTIVATE: phase_trace non-fatal failure");
+            }
+        }
+
+        // Keep rank order intact — do NOT re-sort by score downstream (RRF
+        // has already decided the order).
+        channels.retain(|c| !c.ranked.is_empty());
+        Ok(ActivateOutput { results, mode, channels })
+    }
+
+    // ─── Phase 1: Anchor ───────────────────────────────────────────────
+
+    async fn phase_anchor(
+        &self,
+        query: &str,
+        query_embedding: &[f32],
+    ) -> Result<(Channel, Channel, Channel, Channel, Vec<MemoryNote>)> {
+        // ANN over notes
+        let fetch_k = (self.rerank_cfg.max_rerank.max(20)) * 2;
+        let direct = self
+            .vector_store
+            .find_similar(query_embedding, fetch_k, &[])
+            .await?;
+
+        let mut pool: Vec<MemoryNote> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut ann_ranked: Vec<String> = Vec::new();
+        for (note, _sim) in &direct {
+            if !note.is_active() {
+                continue;
+            }
+            // Skip dream/digest/fact-provenance rows so anchors stay on
+            // actual user notes (consistent with current search_wide).
+            match &note.provenance {
+                Provenance::Dream { .. } | Provenance::Digest { .. } | Provenance::Fact { .. } => {
+                    continue;
+                }
+                _ => {}
+            }
+            if seen.insert(note.id.clone()) {
+                ann_ranked.push(note.id.clone());
+                pool.push(note.clone());
+            }
+        }
+
+        // Facts channel — high-scoring atomic facts expand to their parent notes
+        let mut facts_ranked: Vec<String> = Vec::new();
+        if self.read_cfg.fact_retrieval_enabled {
+            let fact_k = (fetch_k / 2).max(10);
+            if let Ok(hits) = self
+                .vector_store
+                .find_similar_facts(query_embedding, fact_k, &[])
+                .await
+            {
+                for (fact, score) in hits {
+                    if score < 0.3 {
+                        continue;
+                    }
+                    if seen.contains(&fact.source_note_id) {
+                        // already ranked via ANN; keep first-seen order
+                        continue;
+                    }
+                    if let Ok(Some(parent)) = self.vector_store.get(&fact.source_note_id).await {
+                        if parent.is_active() && seen.insert(parent.id.clone()) {
+                            facts_ranked.push(parent.id.clone());
+                            pool.push(parent);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Profile channel — entity-profile auto-include by token overlap
+        let mut profile_ranked: Vec<String> = Vec::new();
+        let query_lower = query.to_lowercase();
+        if let Ok(profiles) = self.graph_store.get_all_profiles().await {
+            for (entity_id, note_id) in profiles {
+                let tokens: Vec<&str> = entity_id
+                    .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
+                    .filter(|t| t.len() >= 3)
+                    .collect();
+                let matched = tokens.iter().any(|t| query_lower.contains(&t.to_lowercase()));
+                if !matched {
+                    continue;
+                }
+                if let Ok(Some(note)) = self.vector_store.get(&note_id).await {
+                    if note.is_active() && seen.insert(note.id.clone()) {
+                        profile_ranked.push(note.id.clone());
+                        pool.push(note);
+                    }
+                }
+            }
+        }
+
+        // Foresight channel — notes backing currently-active forward predictions
+        let mut foresight_ranked: Vec<String> = Vec::new();
+        if let Ok(signals) = self.graph_store.get_active_foresights().await {
+            for s in signals {
+                if seen.insert(s.source_note_id.clone()) {
+                    if let Ok(Some(note)) = self.vector_store.get(&s.source_note_id).await {
+                        if note.is_active() {
+                            foresight_ranked.push(note.id.clone());
+                            pool.push(note);
+                        }
+                    }
+                } else {
+                    foresight_ranked.push(s.source_note_id);
+                }
+            }
+        }
+
+        Ok((
+            Channel { name: "ann", ranked: ann_ranked },
+            Channel { name: "facts", ranked: facts_ranked },
+            Channel { name: "profile", ranked: profile_ranked },
+            Channel { name: "foresight", ranked: foresight_ranked },
+            pool,
+        ))
+    }
+
+    // ─── Phase 2: Co-activation (Hebbian) ──────────────────────────────
+
+    async fn phase_coactivation(&self, anchor_ids: &[String]) -> Result<Channel> {
+        let per_anchor = self.cfg().hebbian_neighbors_per_anchor;
+        let mut ranked: Vec<String> = Vec::new();
+        let mut seen: HashSet<String> = anchor_ids.iter().cloned().collect();
+        for id in anchor_ids {
+            let neighbors = self
+                .graph_store
+                .get_links_with_weights(id, Some("semantic"))
+                .await
+                .unwrap_or_default();
+            for (nid, _w) in neighbors.into_iter().take(per_anchor) {
+                if seen.insert(nid.clone()) {
+                    ranked.push(nid);
+                }
+            }
+        }
+        Ok(Channel { name: "hebbian", ranked })
+    }
+
+    // ─── Phase 3: Temporal decay (ACT-R BLL) ──────────────────────────
+
+    fn phase_actr(&self, pool: &[MemoryNote]) -> Channel {
+        let d = self.cfg().act_r_decay_d;
+        let floor = self.cfg().act_r_min_activation;
+        let now = Utc::now();
+
+        let mut scored: Vec<(String, f64)> = pool
+            .iter()
+            .map(|n| (n.id.clone(), actr_activation(&n.access_history, now, d, n.access_count)))
+            .filter(|(_, b)| *b >= floor)
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        Channel { name: "actr", ranked: scored.into_iter().map(|(id, _)| id).collect() }
+    }
+
+    // ─── Phase 4: Integration (multi-hop BFS) ─────────────────────────
+
+    async fn phase_integration(&self, anchor_ids: &[String]) -> Result<Channel> {
+        use std::collections::VecDeque;
+        let max_depth = self.read_cfg.max_hop_depth;
+        let mut ranked: Vec<String> = Vec::new();
+        let mut visited: HashSet<String> = anchor_ids.iter().cloned().collect();
+        let mut q: VecDeque<(String, usize)> = VecDeque::new();
+        for id in anchor_ids {
+            q.push_back((id.clone(), 0));
+        }
+        while let Some((cur, depth)) = q.pop_front() {
+            if depth >= max_depth {
+                continue;
+            }
+            let links = self.graph_store.get_links(&cur).await.unwrap_or_default();
+            for l in links {
+                if visited.insert(l.clone()) {
+                    ranked.push(l.clone());
+                    q.push_back((l, depth + 1));
+                    if ranked.len() > 64 {
+                        return Ok(Channel { name: "integration", ranked });
+                    }
+                }
+            }
+        }
+        Ok(Channel { name: "integration", ranked })
+    }
+
+    // ─── Phase 5: Vector reranker ─────────────────────────────────────
+
+    async fn phase_rerank(&self, query: &str, pool: &[MemoryNote]) -> Result<Channel> {
+        if !self.rerank_cfg.enabled || pool.is_empty() {
+            return Ok(Channel { name: "rerank", ranked: Vec::new() });
+        }
+        let take = self.rerank_cfg.max_rerank.min(pool.len());
+        let input: Vec<(MemoryNote, f32)> =
+            pool.iter().take(take).map(|n| (n.clone(), 0.0)).collect();
+        let reranked = self.reranker.rerank(query, input).await?;
+        let ranked = reranked.into_iter().map(|r| r.note.id).collect();
+        Ok(Channel { name: "rerank", ranked })
+    }
+
+    // ─── Phase 5b: PAS (prefix-aware sequential) ─────────────────────
+
+    async fn phase_pas(&self, anchor_id: &str) -> Result<Channel> {
+        let w = self.cfg().pas_window;
+        let mut neighbors = self
+            .graph_store
+            .get_sequential_neighbors(anchor_id, w)
+            .await
+            .unwrap_or_default();
+        neighbors.sort_by_key(|(_, delta)| delta.abs());
+        Ok(Channel {
+            name: "pas",
+            ranked: neighbors.into_iter().map(|(id, _)| id).collect(),
+        })
+    }
+
+    // ─── Phase 7: Trace (write-back) ──────────────────────────────────
+
+    async fn phase_trace(&self, returned_ids: &[String]) -> Result<()> {
+        if returned_ids.is_empty() {
+            return Ok(());
+        }
+        // Bump access metadata for every returned note (one transaction).
+        let ref_ids: Vec<&str> = returned_ids.iter().map(|s| s.as_str()).collect();
+        self.vector_store.bump_access_many(&ref_ids, Utc::now()).await?;
+
+        // Hebbian: strengthen every pre-existing semantic edge between
+        // co-retrieved pairs. Skip pairs with no edge (bump_link_weight is
+        // a no-op in that case). C(top_k,2) pairs; bounded by top_k.
+        let step = self.cfg().hebbian_weight_step;
+        let max = self.cfg().hebbian_max_weight;
+        for i in 0..returned_ids.len() {
+            for j in (i + 1)..returned_ids.len() {
+                let _ = self
+                    .graph_store
+                    .bump_link_weight(&returned_ids[i], &returned_ids[j], step, max)
+                    .await;
+            }
+        }
+        Ok(())
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────
+
+    async fn extend_pool(
+        &self,
+        pool: &mut Vec<MemoryNote>,
+        ids: &[String],
+    ) -> Result<()> {
+        let have: HashSet<String> = pool.iter().map(|n| n.id.clone()).collect();
+        let need: Vec<&str> = ids.iter().filter(|id| !have.contains(*id)).map(|s| s.as_str()).collect();
+        if need.is_empty() {
+            return Ok(());
+        }
+        let fetched = self.vector_store.get_many(&need).await?;
+        for n in fetched {
+            if n.is_active() {
+                pool.push(n);
+            }
+        }
+        Ok(())
+    }
+
+    fn weights_for_mode(&self, mode: QueryMode) -> HashMap<String, f32> {
+        let key = format!("{:?}", mode);
+        self.cfg()
+            .channel_weights
+            .get(&key)
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+// ─── Pure functions (unit-testable) ────────────────────────────────────
+
+/// ACT-R base-level learning activation:
+/// `B = ln(Σ_k t_k^{-d})` where `t_k` is the age in hours of the k-th access.
+/// Falls back to `ln(max(1, count))` when no per-access history exists.
+pub fn actr_activation(
+    history: &[DateTime<Utc>],
+    now: DateTime<Utc>,
+    d: f64,
+    count_fallback: u32,
+) -> f64 {
+    if history.is_empty() {
+        return (count_fallback.max(1) as f64).ln();
+    }
+    let sum: f64 = history
+        .iter()
+        .map(|ts| {
+            // Clamp to 1 minute to keep activation finite for "just accessed".
+            let hrs = ((now - *ts).num_seconds() as f64 / 3600.0).max(1.0 / 60.0);
+            hrs.powf(-d)
+        })
+        .sum();
+    if sum <= 0.0 {
+        f64::NEG_INFINITY
+    } else {
+        sum.ln()
+    }
+}
+
+/// Reciprocal Rank Fusion (Cormack et al., 2009) over an arbitrary number
+/// of ranked channels. Per-channel weights scale the RRF contribution.
+pub fn rrf(
+    channels: &[Channel],
+    weights: &HashMap<String, f32>,
+    k: f32,
+) -> Vec<(String, f32)> {
+    let mut scores: HashMap<String, f32> = HashMap::new();
+    for ch in channels {
+        let w = weights.get(ch.name).copied().unwrap_or(0.0);
+        if w == 0.0 {
+            continue;
+        }
+        for (rank_0, id) in ch.ranked.iter().enumerate() {
+            let contribution = w / (k + (rank_0 + 1) as f32);
+            *scores.entry(id.clone()).or_insert(0.0) += contribution;
+        }
+    }
+    let mut v: Vec<(String, f32)> = scores.into_iter().collect();
+    v.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    v
+}
+
+/// Deterministic-ish sampling for `trace_sample_rate`. Rate >= 1.0 always
+/// samples; rate <= 0.0 never samples. Between uses nanosecond-based hash.
+fn should_sample(rate: f32) -> bool {
+    if rate >= 1.0 {
+        return true;
+    }
+    if rate <= 0.0 {
+        return false;
+    }
+    let nanos = Utc::now().timestamp_subsec_nanos() as f32 / 1_000_000_000.0;
+    nanos < rate
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn hours_ago(h: i64, now: DateTime<Utc>) -> DateTime<Utc> {
+        now - Duration::hours(h)
+    }
+
+    #[test]
+    fn actr_bll_monotonic_in_frequency() {
+        let now = Utc::now();
+        let three = vec![hours_ago(24, now), hours_ago(12, now), hours_ago(1, now)];
+        let one = vec![hours_ago(24, now)];
+        let b3 = actr_activation(&three, now, 0.5, 3);
+        let b1 = actr_activation(&one, now, 0.5, 1);
+        assert!(b3 > b1, "multiple recent accesses must raise activation: {} !> {}", b3, b1);
+    }
+
+    #[test]
+    fn actr_bll_decays_over_time() {
+        let now = Utc::now();
+        let history = vec![hours_ago(1, now)];
+        let b_now = actr_activation(&history, now, 0.5, 1);
+        let b_later = actr_activation(&history, now + Duration::days(30), 0.5, 1);
+        assert!(
+            b_later < b_now,
+            "BLL must decay across 30 days: now={} later={}",
+            b_now,
+            b_later
+        );
+    }
+
+    #[test]
+    fn actr_fallback_when_history_empty() {
+        let now = Utc::now();
+        assert_eq!(actr_activation(&[], now, 0.5, 1), 0.0);
+        // ln(4) ≈ 1.386
+        let b = actr_activation(&[], now, 0.5, 4);
+        assert!((b - 4f64.ln()).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rrf_merges_channels_by_rank() {
+        let c1 = Channel { name: "ann", ranked: vec!["a".into(), "b".into(), "c".into()] };
+        let c2 = Channel { name: "rerank", ranked: vec!["b".into(), "a".into(), "d".into()] };
+        let mut w = HashMap::new();
+        w.insert("ann".into(), 1.0);
+        w.insert("rerank".into(), 1.0);
+        let fused = rrf(&[c1, c2], &w, 60.0);
+        // "a" is rank 1 in ann + rank 2 in rerank = 1/61 + 1/62 > "b"s 1/62 + 1/61 (equal).
+        // Assert both top-2 are {a, b} and "c" / "d" fall below.
+        let top2: HashSet<&str> = fused.iter().take(2).map(|(id, _)| id.as_str()).collect();
+        assert!(top2.contains("a") && top2.contains("b"), "top2 = {:?}", top2);
+    }
+
+    #[test]
+    fn rrf_respects_weights() {
+        let c_low = Channel { name: "ann", ranked: vec!["x".into()] };
+        let c_high = Channel { name: "rerank", ranked: vec!["y".into()] };
+        let mut w = HashMap::new();
+        w.insert("ann".into(), 0.1);
+        w.insert("rerank".into(), 10.0);
+        let fused = rrf(&[c_low, c_high], &w, 60.0);
+        assert_eq!(fused[0].0, "y", "heavier-weighted channel should win");
+    }
+
+    #[test]
+    fn rrf_ignores_zero_weight_channels() {
+        let c = Channel { name: "pas", ranked: vec!["x".into(), "y".into()] };
+        let mut w = HashMap::new();
+        w.insert("pas".into(), 0.0);
+        let fused = rrf(&[c], &w, 60.0);
+        assert!(fused.is_empty());
+    }
+
+    #[test]
+    fn rrf_skips_missing_channel_names() {
+        // A channel not present in the weight map contributes nothing.
+        let c = Channel { name: "mystery", ranked: vec!["x".into()] };
+        let w: HashMap<String, f32> = HashMap::new();
+        let fused = rrf(&[c], &w, 60.0);
+        assert!(fused.is_empty());
+    }
+
+    #[test]
+    fn should_sample_boundaries() {
+        assert!(should_sample(1.0));
+        assert!(!should_sample(0.0));
+    }
+}

--- a/crates/karta-core/src/activate.rs
+++ b/crates/karta-core/src/activate.rs
@@ -174,10 +174,12 @@ impl ActivateEngine {
         }
 
         let fused = rrf(&channels, &weights, self.cfg().rrf_k);
-        let top_ids: Vec<String> = fused.into_iter().take(top_k).map(|(id, _)| id).collect();
+        let fused_ids: Vec<String> = fused.iter().map(|(id, _)| id.clone()).collect();
 
-        // Map ids back to MemoryNotes (keep ranking order).
-        let id_refs: Vec<&str> = top_ids.iter().map(|s| s.as_str()).collect();
+        // Map ids back to MemoryNotes. Fetch the fused candidate list before
+        // active filtering so inactive high-ranked notes do not reduce the
+        // returned set below top_k when lower-ranked active notes are available.
+        let id_refs: Vec<&str> = fused_ids.iter().map(|s| s.as_str()).collect();
         let mut notes_by_id: HashMap<String, MemoryNote> = self
             .vector_store
             .get_many(&id_refs)
@@ -186,15 +188,18 @@ impl ActivateEngine {
             .map(|n| (n.id.clone(), n))
             .collect();
 
-        let mut results: Vec<SearchResult> = Vec::with_capacity(top_ids.len());
-        for id in &top_ids {
-            if let Some(note) = notes_by_id.remove(id) {
+        let mut results: Vec<SearchResult> = Vec::with_capacity(top_k.min(fused.len()));
+        for (id, fused_score) in fused {
+            if let Some(note) = notes_by_id.remove(&id) {
                 if note.is_active() {
                     results.push(SearchResult {
                         note,
-                        score: 0.0,
+                        score: fused_score,
                         linked_notes: Vec::new(),
                     });
+                    if results.len() >= top_k {
+                        break;
+                    }
                 }
             }
         }

--- a/crates/karta-core/src/activate.rs
+++ b/crates/karta-core/src/activate.rs
@@ -746,6 +746,121 @@ mod tests {
     }
 
     #[test]
+    fn rrf_hebbian_weight_suppresses_outlier_under_cluster_flood() {
+        // Scenario: 20 "consistent cluster" notes occupy ANN ranks 1..=7 and 9..=21
+        // (outlier inserted at ANN rank 8). The 20 cluster members ALSO appear in
+        // the hebbian channel ranks 1..=20 (because they link to each other).
+        // The outlier appears ONLY in the ANN channel — it has no Hebbian edges
+        // to the cluster. This is the Flask-Login scenario compressed into a
+        // deterministic test.
+
+        let mut ann_ranked: Vec<String> = (1..=7).map(|i| format!("cluster_{}", i)).collect();
+        ann_ranked.push("outlier".to_string()); // ANN rank 8
+        for i in 8..=20 {
+            ann_ranked.push(format!("cluster_{}", i));
+        }
+
+        let hebbian_ranked: Vec<String> = (1..=20).map(|i| format!("cluster_{}", i)).collect();
+
+        let ann_ch = Channel {
+            name: "ann",
+            ranked: ann_ranked,
+        };
+        let hebbian_ch = Channel {
+            name: "hebbian",
+            ranked: hebbian_ranked,
+        };
+
+        // Pre-fix weights (old Existence mode): hebbian = 0.7 (the Standard default
+        // was 0.7, Existence was 0.5 — either value reproduces the suppression).
+        let mut weights_pre = HashMap::new();
+        weights_pre.insert("ann".into(), 1.0);
+        weights_pre.insert("hebbian".into(), 0.7);
+
+        let fused_pre = rrf(&[ann_ch.clone(), hebbian_ch.clone()], &weights_pre, 60.0);
+        let top10_pre: Vec<&str> = fused_pre
+            .iter()
+            .take(10)
+            .map(|(id, _)| id.as_str())
+            .collect();
+
+        assert!(
+            !top10_pre.contains(&"outlier"),
+            "With hebbian weight > 0, the contradicting outlier should be suppressed \
+             out of top-10 by double-voting cluster members. Got top-10: {:?}",
+            top10_pre
+        );
+
+        // Post-fix weights (new Existence mode): hebbian = 0.0
+        let mut weights_post = HashMap::new();
+        weights_post.insert("ann".into(), 1.0);
+        weights_post.insert("hebbian".into(), 0.0);
+
+        let fused_post = rrf(&[ann_ch, hebbian_ch], &weights_post, 60.0);
+        let top10_post: Vec<&str> = fused_post
+            .iter()
+            .take(10)
+            .map(|(id, _)| id.as_str())
+            .collect();
+
+        assert!(
+            top10_post.contains(&"outlier"),
+            "With hebbian weight = 0, the outlier should retain its ANN rank 8 \
+             and appear in top-10. Got top-10: {:?}",
+            top10_post
+        );
+    }
+
+    #[test]
+    fn rrf_hebbian_weight_continuous_between_zero_and_one() {
+        // Same setup as above.
+        let mut ann_ranked: Vec<String> = (1..=7).map(|i| format!("cluster_{}", i)).collect();
+        ann_ranked.push("outlier".to_string());
+        for i in 8..=20 {
+            ann_ranked.push(format!("cluster_{}", i));
+        }
+        let hebbian_ranked: Vec<String> = (1..=20).map(|i| format!("cluster_{}", i)).collect();
+        let ann_ch = Channel {
+            name: "ann",
+            ranked: ann_ranked,
+        };
+        let hebbian_ch = Channel {
+            name: "hebbian",
+            ranked: hebbian_ranked,
+        };
+
+        let outlier_rank = |hebbian_w: f32| -> usize {
+            let mut w = HashMap::new();
+            w.insert("ann".into(), 1.0);
+            w.insert("hebbian".into(), hebbian_w);
+            let fused = rrf(&[ann_ch.clone(), hebbian_ch.clone()], &w, 60.0);
+            fused.iter().position(|(id, _)| id == "outlier").unwrap()
+        };
+
+        let ranks: Vec<usize> = [0.0, 0.25, 0.5, 0.75, 1.0]
+            .iter()
+            .map(|&w| outlier_rank(w))
+            .collect();
+
+        // Outlier rank should monotonically increase (i.e., fall deeper) as hebbian weight grows.
+        for pair in ranks.windows(2) {
+            assert!(
+                pair[1] >= pair[0],
+                "Outlier rank must be monotonically non-decreasing as hebbian weight grows. \
+                 Ranks across [0.0, 0.25, 0.5, 0.75, 1.0]: {:?}",
+                ranks
+            );
+        }
+
+        // And specifically: at hebbian=0 it should be position 7 (0-indexed), at hebbian=1 strictly deeper.
+        assert!(
+            ranks[4] > ranks[0],
+            "Outlier must be strictly deeper at hebbian=1.0 than at hebbian=0.0. Got: {:?}",
+            ranks
+        );
+    }
+
+    #[test]
     fn should_sample_boundaries() {
         assert!(should_sample(1.0));
         assert!(!should_sample(0.0));

--- a/crates/karta-core/src/config.rs
+++ b/crates/karta-core/src/config.rs
@@ -129,6 +129,10 @@ pub struct ReadConfig {
     pub fact_retrieval_enabled: bool,
     /// Score boost for notes found via fact match.
     pub fact_match_boost: f32,
+    /// ACTIVATE cognitive-retrieval pipeline: ACT-R + Hebbian + PAS + RRF.
+    /// When enabled, supersedes the additive scalar scorer in `search_wide()`.
+    #[serde(default)]
+    pub activate: ActivateConfig,
 }
 
 impl Default for ReadConfig {
@@ -148,6 +152,96 @@ impl Default for ReadConfig {
             episode_drilldown_min_score: 0.25,
             fact_retrieval_enabled: true,
             fact_match_boost: 0.1,
+            activate: ActivateConfig::default(),
+        }
+    }
+}
+
+// ─── ACTIVATE pipeline configuration ────────────────────────────────────────
+
+/// Configuration for the ACTIVATE 6-phase cognitive retrieval pipeline.
+///
+/// Feature-flagged via `enabled`. Also honours the `KARTA_ACTIVATE_ENABLED`
+/// environment variable so benchmarks can toggle without editing TOML.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivateConfig {
+    /// Master switch. Defaults to `false` so the existing `search_wide()`
+    /// scalar scorer remains the production path until this is validated.
+    pub enabled: bool,
+    /// ACT-R base-level learning decay rate. Default 0.5 (Anderson 2004).
+    pub act_r_decay_d: f64,
+    /// Drop notes below this base-level activation from the ACT-R channel.
+    pub act_r_min_activation: f64,
+    /// Hebbian strengthening: per-retrieval weight increment on co-activated semantic links.
+    pub hebbian_weight_step: f32,
+    /// Upper bound on Hebbian link weight to prevent runaway.
+    pub hebbian_max_weight: f32,
+    /// Co-activation channel: top-K weight-sorted neighbors to pull per anchor.
+    pub hebbian_neighbors_per_anchor: usize,
+    /// Reciprocal Rank Fusion constant. 60 is the canonical Cormack 2009 value.
+    pub rrf_k: f32,
+    /// PAS sequential walk radius (turns in each direction) for Temporal queries.
+    pub pas_window: usize,
+    /// Fraction of queries that run phase_trace writes. 1.0 = every query.
+    pub trace_sample_rate: f32,
+    /// Per-QueryMode channel weight overrides. Key = channel name.
+    /// Channels: "ann", "keyword", "hebbian", "actr", "integration", "rerank",
+    /// "pas", "facts", "foresight", "profile".
+    #[serde(default)]
+    pub channel_weights: HashMap<String, HashMap<String, f32>>,
+}
+
+impl Default for ActivateConfig {
+    fn default() -> Self {
+        // Channel-weight matrix seeded per QueryMode.  QueryMode variants are
+        // stringified via their Debug form so TOML overrides read naturally
+        // (e.g. `[read.activate.channel_weights.Temporal] pas = 2.0`).
+        fn mk(pairs: &[(&str, f32)]) -> HashMap<String, f32> {
+            pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+        }
+        let mut m = HashMap::new();
+        m.insert("Standard".into(), mk(&[
+            ("ann", 1.0), ("keyword", 0.5), ("hebbian", 0.7), ("actr", 0.3),
+            ("integration", 0.5), ("rerank", 1.0), ("pas", 0.0),
+            ("facts", 0.6), ("foresight", 0.4), ("profile", 1.2),
+        ]));
+        m.insert("Recency".into(), mk(&[
+            ("ann", 0.6), ("keyword", 0.4), ("hebbian", 0.3), ("actr", 1.2),
+            ("integration", 0.3), ("rerank", 0.6), ("pas", 0.0),
+            ("facts", 0.4), ("foresight", 0.8), ("profile", 0.8),
+        ]));
+        m.insert("Breadth".into(), mk(&[
+            ("ann", 1.0), ("keyword", 0.5), ("hebbian", 1.0), ("actr", 0.3),
+            ("integration", 0.8), ("rerank", 0.8), ("pas", 0.0),
+            ("facts", 0.5), ("foresight", 0.4), ("profile", 1.0),
+        ]));
+        m.insert("Computation".into(), mk(&[
+            ("ann", 0.8), ("keyword", 0.8), ("hebbian", 0.4), ("actr", 0.3),
+            ("integration", 0.6), ("rerank", 1.2), ("pas", 0.0),
+            ("facts", 1.0), ("foresight", 0.5), ("profile", 0.8),
+        ]));
+        m.insert("Temporal".into(), mk(&[
+            ("ann", 0.3), ("keyword", 0.3), ("hebbian", 0.0), ("actr", 1.0),
+            ("integration", 0.2), ("rerank", 0.0), ("pas", 1.5),
+            ("facts", 0.2), ("foresight", 0.3), ("profile", 0.4),
+        ]));
+        m.insert("Existence".into(), mk(&[
+            ("ann", 1.0), ("keyword", 0.8), ("hebbian", 0.5), ("actr", 0.5),
+            ("integration", 0.5), ("rerank", 1.2), ("pas", 0.0),
+            ("facts", 0.9), ("foresight", 0.5), ("profile", 1.0),
+        ]));
+
+        Self {
+            enabled: false,
+            act_r_decay_d: 0.5,
+            act_r_min_activation: -0.5,
+            hebbian_weight_step: 0.05,
+            hebbian_max_weight: 3.0,
+            hebbian_neighbors_per_anchor: 5,
+            rrf_k: 60.0,
+            pas_window: 6,
+            trace_sample_rate: 1.0,
+            channel_weights: m,
         }
     }
 }
@@ -223,7 +317,18 @@ pub struct ForgetConfig {
     pub archive_threshold: f32,
     /// Whether to run forgetting sweep at the end of each dream pass.
     pub sweep_on_dream: bool,
+    /// ACTIVATE: archive notes whose ACT-R base-level activation drops below
+    /// this floor (and whose age exceeds `decay_half_life_days`).
+    #[serde(default = "default_actr_floor")]
+    pub actr_decay_floor: f32,
+    /// ACTIVATE: multiplicative decay applied to semantic-link weights on
+    /// every sweep. Floored at 1.0 so links never fall below their initial weight.
+    #[serde(default = "default_link_decay")]
+    pub link_weight_decay: f32,
 }
+
+fn default_actr_floor() -> f32 { -1.0 }
+fn default_link_decay() -> f32 { 0.99 }
 
 impl Default for ForgetConfig {
     fn default() -> Self {
@@ -232,6 +337,8 @@ impl Default for ForgetConfig {
             decay_half_life_days: 90.0,
             archive_threshold: 0.1,
             sweep_on_dream: true,
+            actr_decay_floor: default_actr_floor(),
+            link_weight_decay: default_link_decay(),
         }
     }
 }

--- a/crates/karta-core/src/config.rs
+++ b/crates/karta-core/src/config.rs
@@ -284,17 +284,24 @@ fn default_activate_channel_weights() -> HashMap<String, HashMap<String, f32>> {
             ("profile", 0.4),
         ]),
     );
+    // Existence ("Have I X?" / "Did I ever X?" / contradiction checks):
+    // - hebbian: 0.0 — Hebbian boosts consistent co-activated clusters, which is
+    //   exactly what suppresses contradicting outlier notes in Existence queries.
+    // - facts: 1.3 — the contradicting evidence is typically captured as an
+    //   atomic fact; boost that channel to surface the "I have never X" counter-fact.
+    // - integration: 1.0 — structural graph neighbours (rather than co-activated
+    //   ones) are more likely to connect to contradicting notes.
     m.insert(
         QueryMode::Existence.as_str().into(),
         mk(&[
             ("ann", 1.0),
             ("keyword", 0.8),
-            ("hebbian", 0.5),
+            ("hebbian", 0.0),
             ("actr", 0.5),
-            ("integration", 0.5),
+            ("integration", 1.0),
             ("rerank", 1.2),
             ("pas", 0.0),
-            ("facts", 0.9),
+            ("facts", 1.3),
             ("foresight", 0.5),
             ("profile", 1.0),
         ]),
@@ -584,5 +591,20 @@ mod tests {
         assert_eq!(cfg.anchor_top_k, 10);
         assert!((cfg.facts_min_score - 0.3).abs() < 1e-6);
         assert_eq!(cfg.integration_bfs_cap, 64);
+    }
+
+    /// Existence-mode channel weights were rebalanced to stop Hebbian
+    /// co-activation from suppressing contradicting outlier notes (BEAM Conv 1
+    /// Q4 regression; see PR #3).
+    #[test]
+    fn existence_channel_weights_rebalanced_for_contradictions() {
+        let cfg = ActivateConfig::default();
+        let existence = cfg
+            .channel_weights
+            .get("Existence")
+            .expect("Existence map present");
+        assert_eq!(existence.get("hebbian").copied(), Some(0.0));
+        assert_eq!(existence.get("facts").copied(), Some(1.3));
+        assert_eq!(existence.get("integration").copied(), Some(1.0));
     }
 }

--- a/crates/karta-core/src/config.rs
+++ b/crates/karta-core/src/config.rs
@@ -163,7 +163,12 @@ impl Default for ReadConfig {
 ///
 /// Feature-flagged via `enabled`. Also honours the `KARTA_ACTIVATE_ENABLED`
 /// environment variable so benchmarks can toggle without editing TOML.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Custom `Deserialize` impl: after parsing, any per-mode channel-weight
+/// map the user supplied is unioned over the default matrix so a partial
+/// TOML override (e.g. just tweaking `channel_weights.Standard.ann`)
+/// preserves weights for the other modes.
+#[derive(Debug, Clone, Serialize)]
 pub struct ActivateConfig {
     /// Master switch. Defaults to `false` so the existing `search_wide()`
     /// scalar scorer remains the production path until this is validated.
@@ -184,53 +189,131 @@ pub struct ActivateConfig {
     pub pas_window: usize,
     /// Fraction of queries that run phase_trace writes. 1.0 = every query.
     pub trace_sample_rate: f32,
+    /// Anchor cap: how many top ANN hits are used as seeds for co-activation
+    /// and integration BFS.
+    pub anchor_top_k: usize,
+    /// Facts channel: minimum atomic-fact similarity score to expand to the parent note.
+    pub facts_min_score: f32,
+    /// Integration BFS cap: max neighbors accumulated before early termination.
+    pub integration_bfs_cap: usize,
     /// Per-QueryMode channel weight overrides. Key = channel name.
     /// Channels: "ann", "keyword", "hebbian", "actr", "integration", "rerank",
     /// "pas", "facts", "foresight", "profile".
-    #[serde(default)]
     pub channel_weights: HashMap<String, HashMap<String, f32>>,
+}
+
+fn default_activate_channel_weights() -> HashMap<String, HashMap<String, f32>> {
+    use crate::read::QueryMode;
+
+    fn mk(pairs: &[(&str, f32)]) -> HashMap<String, f32> {
+        pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+    }
+    let mut m = HashMap::new();
+    m.insert(
+        QueryMode::Standard.as_str().into(),
+        mk(&[
+            ("ann", 1.0),
+            ("keyword", 0.5),
+            ("hebbian", 0.7),
+            ("actr", 0.3),
+            ("integration", 0.5),
+            ("rerank", 1.0),
+            ("pas", 0.0),
+            ("facts", 0.6),
+            ("foresight", 0.4),
+            ("profile", 1.2),
+        ]),
+    );
+    m.insert(
+        QueryMode::Recency.as_str().into(),
+        mk(&[
+            ("ann", 0.6),
+            ("keyword", 0.4),
+            ("hebbian", 0.3),
+            ("actr", 1.2),
+            ("integration", 0.3),
+            ("rerank", 0.6),
+            ("pas", 0.0),
+            ("facts", 0.4),
+            ("foresight", 0.8),
+            ("profile", 0.8),
+        ]),
+    );
+    m.insert(
+        QueryMode::Breadth.as_str().into(),
+        mk(&[
+            ("ann", 1.0),
+            ("keyword", 0.5),
+            ("hebbian", 1.0),
+            ("actr", 0.3),
+            ("integration", 0.8),
+            ("rerank", 0.8),
+            ("pas", 0.0),
+            ("facts", 0.5),
+            ("foresight", 0.4),
+            ("profile", 1.0),
+        ]),
+    );
+    m.insert(
+        QueryMode::Computation.as_str().into(),
+        mk(&[
+            ("ann", 0.8),
+            ("keyword", 0.8),
+            ("hebbian", 0.4),
+            ("actr", 0.3),
+            ("integration", 0.6),
+            ("rerank", 1.2),
+            ("pas", 0.0),
+            ("facts", 1.0),
+            ("foresight", 0.5),
+            ("profile", 0.8),
+        ]),
+    );
+    m.insert(
+        QueryMode::Temporal.as_str().into(),
+        mk(&[
+            ("ann", 0.3),
+            ("keyword", 0.3),
+            ("hebbian", 0.0),
+            ("actr", 1.0),
+            ("integration", 0.2),
+            ("rerank", 0.0),
+            ("pas", 1.5),
+            ("facts", 0.2),
+            ("foresight", 0.3),
+            ("profile", 0.4),
+        ]),
+    );
+    m.insert(
+        QueryMode::Existence.as_str().into(),
+        mk(&[
+            ("ann", 1.0),
+            ("keyword", 0.8),
+            ("hebbian", 0.5),
+            ("actr", 0.5),
+            ("integration", 0.5),
+            ("rerank", 1.2),
+            ("pas", 0.0),
+            ("facts", 0.9),
+            ("foresight", 0.5),
+            ("profile", 1.0),
+        ]),
+    );
+    m
+}
+
+fn default_anchor_top_k() -> usize {
+    10
+}
+fn default_facts_min_score() -> f32 {
+    0.3
+}
+fn default_integration_bfs_cap() -> usize {
+    64
 }
 
 impl Default for ActivateConfig {
     fn default() -> Self {
-        // Channel-weight matrix seeded per QueryMode.  QueryMode variants are
-        // stringified via their Debug form so TOML overrides read naturally
-        // (e.g. `[read.activate.channel_weights.Temporal] pas = 2.0`).
-        fn mk(pairs: &[(&str, f32)]) -> HashMap<String, f32> {
-            pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
-        }
-        let mut m = HashMap::new();
-        m.insert("Standard".into(), mk(&[
-            ("ann", 1.0), ("keyword", 0.5), ("hebbian", 0.7), ("actr", 0.3),
-            ("integration", 0.5), ("rerank", 1.0), ("pas", 0.0),
-            ("facts", 0.6), ("foresight", 0.4), ("profile", 1.2),
-        ]));
-        m.insert("Recency".into(), mk(&[
-            ("ann", 0.6), ("keyword", 0.4), ("hebbian", 0.3), ("actr", 1.2),
-            ("integration", 0.3), ("rerank", 0.6), ("pas", 0.0),
-            ("facts", 0.4), ("foresight", 0.8), ("profile", 0.8),
-        ]));
-        m.insert("Breadth".into(), mk(&[
-            ("ann", 1.0), ("keyword", 0.5), ("hebbian", 1.0), ("actr", 0.3),
-            ("integration", 0.8), ("rerank", 0.8), ("pas", 0.0),
-            ("facts", 0.5), ("foresight", 0.4), ("profile", 1.0),
-        ]));
-        m.insert("Computation".into(), mk(&[
-            ("ann", 0.8), ("keyword", 0.8), ("hebbian", 0.4), ("actr", 0.3),
-            ("integration", 0.6), ("rerank", 1.2), ("pas", 0.0),
-            ("facts", 1.0), ("foresight", 0.5), ("profile", 0.8),
-        ]));
-        m.insert("Temporal".into(), mk(&[
-            ("ann", 0.3), ("keyword", 0.3), ("hebbian", 0.0), ("actr", 1.0),
-            ("integration", 0.2), ("rerank", 0.0), ("pas", 1.5),
-            ("facts", 0.2), ("foresight", 0.3), ("profile", 0.4),
-        ]));
-        m.insert("Existence".into(), mk(&[
-            ("ann", 1.0), ("keyword", 0.8), ("hebbian", 0.5), ("actr", 0.5),
-            ("integration", 0.5), ("rerank", 1.2), ("pas", 0.0),
-            ("facts", 0.9), ("foresight", 0.5), ("profile", 1.0),
-        ]));
-
         Self {
             enabled: false,
             act_r_decay_d: 0.5,
@@ -241,8 +324,103 @@ impl Default for ActivateConfig {
             rrf_k: 60.0,
             pas_window: 6,
             trace_sample_rate: 1.0,
-            channel_weights: m,
+            anchor_top_k: default_anchor_top_k(),
+            facts_min_score: default_facts_min_score(),
+            integration_bfs_cap: default_integration_bfs_cap(),
+            channel_weights: default_activate_channel_weights(),
         }
+    }
+}
+
+// Helper shadow struct for field-level defaults in the custom Deserialize
+// impl below. Every field has a sensible default so a partial TOML stanza
+// (e.g. `[read.activate] enabled = true`) still deserializes cleanly.
+#[derive(Deserialize)]
+struct ActivateConfigShadow {
+    #[serde(default)]
+    enabled: bool,
+    #[serde(default = "default_act_r_decay_d")]
+    act_r_decay_d: f64,
+    #[serde(default = "default_act_r_min_activation")]
+    act_r_min_activation: f64,
+    #[serde(default = "default_hebbian_weight_step")]
+    hebbian_weight_step: f32,
+    #[serde(default = "default_hebbian_max_weight")]
+    hebbian_max_weight: f32,
+    #[serde(default = "default_hebbian_neighbors_per_anchor")]
+    hebbian_neighbors_per_anchor: usize,
+    #[serde(default = "default_rrf_k")]
+    rrf_k: f32,
+    #[serde(default = "default_pas_window")]
+    pas_window: usize,
+    #[serde(default = "default_trace_sample_rate")]
+    trace_sample_rate: f32,
+    #[serde(default = "default_anchor_top_k")]
+    anchor_top_k: usize,
+    #[serde(default = "default_facts_min_score")]
+    facts_min_score: f32,
+    #[serde(default = "default_integration_bfs_cap")]
+    integration_bfs_cap: usize,
+    #[serde(default)]
+    channel_weights: HashMap<String, HashMap<String, f32>>,
+}
+
+fn default_act_r_decay_d() -> f64 {
+    0.5
+}
+fn default_act_r_min_activation() -> f64 {
+    -0.5
+}
+fn default_hebbian_weight_step() -> f32 {
+    0.05
+}
+fn default_hebbian_max_weight() -> f32 {
+    3.0
+}
+fn default_hebbian_neighbors_per_anchor() -> usize {
+    5
+}
+fn default_rrf_k() -> f32 {
+    60.0
+}
+fn default_pas_window() -> usize {
+    6
+}
+fn default_trace_sample_rate() -> f32 {
+    1.0
+}
+
+impl<'de> Deserialize<'de> for ActivateConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let shadow = ActivateConfigShadow::deserialize(deserializer)?;
+        // Union user-provided per-mode maps over the default matrix so a
+        // partial override preserves defaults for the other modes (and any
+        // unspecified channels within a mode).
+        let mut merged = default_activate_channel_weights();
+        for (mode_key, user_map) in shadow.channel_weights {
+            let entry = merged.entry(mode_key).or_default();
+            for (ch, w) in user_map {
+                entry.insert(ch, w);
+            }
+        }
+        Ok(Self {
+            enabled: shadow.enabled,
+            act_r_decay_d: shadow.act_r_decay_d,
+            act_r_min_activation: shadow.act_r_min_activation,
+            hebbian_weight_step: shadow.hebbian_weight_step,
+            hebbian_max_weight: shadow.hebbian_max_weight,
+            hebbian_neighbors_per_anchor: shadow.hebbian_neighbors_per_anchor,
+            rrf_k: shadow.rrf_k,
+            pas_window: shadow.pas_window,
+            trace_sample_rate: shadow.trace_sample_rate,
+            anchor_top_k: shadow.anchor_top_k,
+            facts_min_score: shadow.facts_min_score,
+            integration_bfs_cap: shadow.integration_bfs_cap,
+            channel_weights: merged,
+        })
     }
 }
 
@@ -327,8 +505,12 @@ pub struct ForgetConfig {
     pub link_weight_decay: f32,
 }
 
-fn default_actr_floor() -> f32 { -1.0 }
-fn default_link_decay() -> f32 { 0.99 }
+fn default_actr_floor() -> f32 {
+    -1.0
+}
+fn default_link_decay() -> f32 {
+    0.99
+}
 
 impl Default for ForgetConfig {
     fn default() -> Self {
@@ -340,5 +522,67 @@ impl Default for ForgetConfig {
             actr_decay_floor: default_actr_floor(),
             link_weight_decay: default_link_decay(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A partial `channel_weights` override must not wipe defaults for other
+    /// modes or untouched channels within the overridden mode.
+    #[test]
+    fn channel_weights_partial_override_merges_with_defaults() {
+        let toml_str = r#"
+            enabled = true
+            [channel_weights.Standard]
+            ann = 2.5
+        "#;
+        let cfg: ActivateConfig = toml::from_str(toml_str).expect("parse");
+        assert!(cfg.enabled);
+
+        // Other modes still populated with defaults
+        for mode in ["Recency", "Breadth", "Computation", "Temporal", "Existence"] {
+            let m = cfg
+                .channel_weights
+                .get(mode)
+                .unwrap_or_else(|| panic!("missing default map for {}", mode));
+            assert!(!m.is_empty(), "{} map was dropped", mode);
+        }
+
+        // Standard: override applied, remaining channels retain defaults
+        let std_map = cfg.channel_weights.get("Standard").expect("Standard map");
+        assert_eq!(std_map.get("ann").copied(), Some(2.5));
+        assert!(
+            std_map.contains_key("keyword"),
+            "default channels preserved"
+        );
+        assert!(std_map.contains_key("rerank"), "default channels preserved");
+    }
+
+    /// Defaults survive when TOML omits channel_weights entirely.
+    #[test]
+    fn channel_weights_missing_yields_defaults() {
+        let cfg: ActivateConfig = toml::from_str("enabled = true").expect("parse");
+        assert!(cfg.enabled);
+        for mode in [
+            "Standard",
+            "Recency",
+            "Breadth",
+            "Computation",
+            "Temporal",
+            "Existence",
+        ] {
+            assert!(cfg.channel_weights.contains_key(mode), "missing {}", mode);
+        }
+    }
+
+    /// Missing ACTIVATE-added scalar fields fall back to the documented defaults.
+    #[test]
+    fn scalar_fields_default_when_missing() {
+        let cfg: ActivateConfig = toml::from_str("enabled = true").expect("parse");
+        assert_eq!(cfg.anchor_top_k, 10);
+        assert!((cfg.facts_min_score - 0.3).abs() < 1e-6);
+        assert_eq!(cfg.integration_bfs_cap, 64);
     }
 }

--- a/crates/karta-core/src/dream/engine.rs
+++ b/crates/karta-core/src/dream/engine.rs
@@ -549,6 +549,9 @@ impl DreamEngine {
             last_accessed_at: Utc::now(),
             turn_index: None,
             source_timestamp: None,
+            access_count: 0,
+            access_history: Vec::new(),
+            session_id: None,
         };
 
         self.vector_store.upsert(&note).await?;
@@ -687,6 +690,9 @@ impl DreamEngine {
             last_accessed_at: dream.created_at,
             turn_index: None,
             source_timestamp: None,
+            access_count: 0,
+            access_history: Vec::new(),
+            session_id: None,
         };
 
         self.vector_store.upsert(&note).await?;
@@ -818,6 +824,9 @@ impl DreamEngine {
                 last_accessed_at: Utc::now(),
                 turn_index: None,
                 source_timestamp: None,
+            access_count: 0,
+            access_history: Vec::new(),
+            session_id: None,
             };
 
             digest_note_id = Some(note.id.clone());

--- a/crates/karta-core/src/dream/engine.rs
+++ b/crates/karta-core/src/dream/engine.rs
@@ -885,9 +885,9 @@ impl DreamEngine {
                 last_accessed_at: Utc::now(),
                 turn_index: None,
                 source_timestamp: None,
-            access_count: 0,
-            access_history: Vec::new(),
-            session_id: None,
+                access_count: 0,
+                access_history: Vec::new(),
+                session_id: None,
             };
 
             digest_note_id = Some(note.id.clone());

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod activate;
 pub mod config;
 pub mod dream;
 pub mod error;

--- a/crates/karta-core/src/note.rs
+++ b/crates/karta-core/src/note.rs
@@ -41,7 +41,23 @@ pub struct MemoryNote {
     /// Distinct from `created_at` which is the ingestion time.
     #[serde(default)]
     pub source_timestamp: Option<DateTime<Utc>>,
+    /// Total number of times this note has been returned by retrieval.
+    /// Drives ACT-R base-level activation fallback when `access_history` is empty.
+    #[serde(default)]
+    pub access_count: u32,
+    /// Ring buffer of the most recent access timestamps (cap = ACCESS_HISTORY_CAP).
+    /// Feeds the ACT-R BLL sum `B = ln(Σ t_k^{-d})`.
+    #[serde(default)]
+    pub access_history: Vec<DateTime<Utc>>,
+    /// Session this note was written in — required for PAS sequential linkage.
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
+
+/// Maximum stamps retained in `MemoryNote::access_history`. Keeps per-note
+/// storage at ~160 B while giving ACT-R enough samples for bursty-access
+/// approximation.
+pub const ACCESS_HISTORY_CAP: usize = 8;
 
 impl MemoryNote {
     pub fn new(content: String) -> Self {
@@ -63,7 +79,21 @@ impl MemoryNote {
             last_accessed_at: now,
             turn_index: None,
             source_timestamp: None,
+            access_count: 0,
+            access_history: Vec::new(),
+            session_id: None,
         }
+    }
+
+    /// Record a retrieval access: bump counter, push stamp, truncate ring.
+    pub fn record_access(&mut self, at: DateTime<Utc>) {
+        self.access_count = self.access_count.saturating_add(1);
+        self.access_history.push(at);
+        if self.access_history.len() > ACCESS_HISTORY_CAP {
+            let excess = self.access_history.len() - ACCESS_HISTORY_CAP;
+            self.access_history.drain(..excess);
+        }
+        self.last_accessed_at = at;
     }
 
     pub fn is_active(&self) -> bool {

--- a/crates/karta-core/src/read.rs
+++ b/crates/karta-core/src/read.rs
@@ -114,13 +114,6 @@ const PROTOTYPES: &[(QueryMode, &[&str])] = &[
             "Have I been inconsistent about my preferences?",
             "Does my earlier statement conflict with the later one?",
             "Was there a contradiction in what I said?",
-            "Have I integrated Flask-Login in my project?",
-            "Have I actually completed the authentication module?",
-            "Did I ever set up the staging environment?",
-            "Do I still use SQLite or did I switch?",
-            "Have I written unit tests for the API?",
-            "Am I currently using Redis for caching?",
-            "Have I decided on a deployment platform yet?",
         ],
     ),
     (
@@ -264,11 +257,6 @@ fn classify_query_keywords(query: &str) -> QueryMode {
         || q.contains("is it true")
         || q.contains("conflict")
         || q.contains("inconsisten")
-        || q.starts_with("have i ")
-        || q.starts_with("did i ever ")
-        || q.starts_with("do i still ")
-        || q.starts_with("am i actually ")
-        || q.starts_with("have i actually ")
     {
         return QueryMode::Existence;
     }
@@ -1522,25 +1510,6 @@ impl ReadEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// The keyword classifier fallback must route "Have I X?" / "Did I ever X?" /
-    /// "Do I still X?" style questions to Existence so contradiction-aware
-    /// channel weights kick in when the embedding classifier is unavailable.
-    #[test]
-    fn keyword_classifier_routes_have_i_questions_to_existence() {
-        assert_eq!(
-            classify_query_keywords("Have I integrated Flask-Login?"),
-            QueryMode::Existence,
-        );
-        assert_eq!(
-            classify_query_keywords("Did I ever write tests?"),
-            QueryMode::Existence,
-        );
-        assert_eq!(
-            classify_query_keywords("Do I still use SQLite?"),
-            QueryMode::Existence,
-        );
-    }
 
     /// Control: a Standard-style question must not be misclassified as Existence.
     #[test]

--- a/crates/karta-core/src/read.rs
+++ b/crates/karta-core/src/read.rs
@@ -38,62 +38,96 @@ pub enum QueryMode {
     Existence,
 }
 
+impl QueryMode {
+    /// Canonical string representation used as the key into
+    /// `ActivateConfig::channel_weights` and in ACTIVATE telemetry.
+    /// Keep in sync with `default_activate_channel_weights()` in config.rs.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            QueryMode::Standard => "Standard",
+            QueryMode::Recency => "Recency",
+            QueryMode::Breadth => "Breadth",
+            QueryMode::Computation => "Computation",
+            QueryMode::Temporal => "Temporal",
+            QueryMode::Existence => "Existence",
+        }
+    }
+}
+
 /// Prototype examples for embedding-based query classification.
 /// Each mode has representative queries that define its embedding centroid.
 const PROTOTYPES: &[(QueryMode, &[&str])] = &[
-    (QueryMode::Temporal, &[
-        "Can you list in order how I brought up different topics?",
-        "What was the sequence of events in my project?",
-        "In what order did I discuss these subjects?",
-        "What was the chronological progression of my work?",
-        "List the timeline of my activities",
-        "What happened first, second, third?",
-        "Walk me through the order of topics we covered",
-    ]),
-    (QueryMode::Recency, &[
-        "What is my current status on the project?",
-        "What's the latest update on my progress?",
-        "What am I working on right now?",
-        "What's the most recent version of my plan?",
-        "What did I last decide about the design?",
-        "What's my updated budget?",
-    ]),
-    (QueryMode::Breadth, &[
-        "Give me a comprehensive summary of my project",
-        "Can you summarize everything we've discussed?",
-        "Provide an overview of all my activities",
-        "Walk me through the full picture of what I've been doing",
-        "How has my approach evolved over time?",
-        "How did my project develop from start to finish?",
-    ]),
-    (QueryMode::Computation, &[
-        "How many days between the start and the deadline?",
-        "How many weeks did it take to finish?",
-        "How long did it take me to complete the task?",
-        "What's the total number of items I completed?",
-        "How many more problems did I solve compared to last time?",
-        "Calculate the time between event A and event B",
-        "How much progress did I make between March and April?",
-        "Which happened first, X or Y, and how far apart?",
-        "How many hours did I spend studying?",
-        "Days between my meeting and the deadline",
-    ]),
-    (QueryMode::Existence, &[
-        "Did I ever mention using Excel for tracking?",
-        "Is it true that I contradicted myself about the tool?",
-        "Have I been inconsistent about my preferences?",
-        "Does my earlier statement conflict with the later one?",
-        "Was there a contradiction in what I said?",
-    ]),
-    (QueryMode::Standard, &[
-        "What tools am I using for my project?",
-        "What did I say about the API integration?",
-        "What are my preferences for the UI design?",
-        "Tell me about my debugging approach",
-        "What feedback did I receive on my work?",
-        "What are the main features I'm building?",
-        "What constraints or requirements did I mention?",
-    ]),
+    (
+        QueryMode::Temporal,
+        &[
+            "Can you list in order how I brought up different topics?",
+            "What was the sequence of events in my project?",
+            "In what order did I discuss these subjects?",
+            "What was the chronological progression of my work?",
+            "List the timeline of my activities",
+            "What happened first, second, third?",
+            "Walk me through the order of topics we covered",
+        ],
+    ),
+    (
+        QueryMode::Recency,
+        &[
+            "What is my current status on the project?",
+            "What's the latest update on my progress?",
+            "What am I working on right now?",
+            "What's the most recent version of my plan?",
+            "What did I last decide about the design?",
+            "What's my updated budget?",
+        ],
+    ),
+    (
+        QueryMode::Breadth,
+        &[
+            "Give me a comprehensive summary of my project",
+            "Can you summarize everything we've discussed?",
+            "Provide an overview of all my activities",
+            "Walk me through the full picture of what I've been doing",
+            "How has my approach evolved over time?",
+            "How did my project develop from start to finish?",
+        ],
+    ),
+    (
+        QueryMode::Computation,
+        &[
+            "How many days between the start and the deadline?",
+            "How many weeks did it take to finish?",
+            "How long did it take me to complete the task?",
+            "What's the total number of items I completed?",
+            "How many more problems did I solve compared to last time?",
+            "Calculate the time between event A and event B",
+            "How much progress did I make between March and April?",
+            "Which happened first, X or Y, and how far apart?",
+            "How many hours did I spend studying?",
+            "Days between my meeting and the deadline",
+        ],
+    ),
+    (
+        QueryMode::Existence,
+        &[
+            "Did I ever mention using Excel for tracking?",
+            "Is it true that I contradicted myself about the tool?",
+            "Have I been inconsistent about my preferences?",
+            "Does my earlier statement conflict with the later one?",
+            "Was there a contradiction in what I said?",
+        ],
+    ),
+    (
+        QueryMode::Standard,
+        &[
+            "What tools am I using for my project?",
+            "What did I say about the API integration?",
+            "What are my preferences for the UI design?",
+            "Tell me about my debugging approach",
+            "What feedback did I receive on my work?",
+            "What are the main features I'm building?",
+            "What constraints or requirements did I mention?",
+        ],
+    ),
 ];
 
 /// Embedding-based query classifier. Classifies by cosine similarity to prototype centroids.
@@ -172,38 +206,56 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 fn classify_query_keywords(query: &str) -> QueryMode {
     let q = query.to_lowercase();
 
-    if q.contains("in what order") || q.contains("in order") || q.contains("sequence")
-        || q.contains("timeline") || q.contains("chronolog")
-        || q.contains("progression") || q.contains("history of")
-        || q.contains("changed over") || q.contains("steps ")
+    if q.contains("in what order")
+        || q.contains("in order")
+        || q.contains("sequence")
+        || q.contains("timeline")
+        || q.contains("chronolog")
+        || q.contains("progression")
+        || q.contains("history of")
+        || q.contains("changed over")
+        || q.contains("steps ")
         || (q.contains("list") && (q.contains("order") || q.contains("topic")))
     {
         return QueryMode::Temporal;
     }
 
-    if q.contains("current") || q.contains("latest") || q.contains("most recent")
-        || q.contains("right now") || q.contains("updated")
+    if q.contains("current")
+        || q.contains("latest")
+        || q.contains("most recent")
+        || q.contains("right now")
+        || q.contains("updated")
         || (q.contains("now") && !q.contains("know"))
     {
         return QueryMode::Recency;
     }
 
-    if q.contains("summary") || q.contains("summarize") || q.contains("comprehensive")
-        || q.contains("overview") || q.contains("walk me through")
-        || q.contains("how has") || q.contains("how did")
+    if q.contains("summary")
+        || q.contains("summarize")
+        || q.contains("comprehensive")
+        || q.contains("overview")
+        || q.contains("walk me through")
+        || q.contains("how has")
+        || q.contains("how did")
     {
         return QueryMode::Breadth;
     }
 
-    if q.contains("how many") || q.contains("how much") || q.contains("total")
-        || q.contains("calculate") || q.contains("difference between")
-        || q.contains("compare") || q.contains("days between")
+    if q.contains("how many")
+        || q.contains("how much")
+        || q.contains("total")
+        || q.contains("calculate")
+        || q.contains("difference between")
+        || q.contains("compare")
+        || q.contains("days between")
         || q.contains("months between")
     {
         return QueryMode::Computation;
     }
 
-    if q.contains("contradict") || q.contains("is it true") || q.contains("conflict")
+    if q.contains("contradict")
+        || q.contains("is it true")
+        || q.contains("conflict")
         || q.contains("inconsisten")
     {
         return QueryMode::Existence;
@@ -246,22 +298,31 @@ impl ReadEngine {
     /// Get or initialize the embedding-based query classifier.
     /// Falls back to empty classifier (keyword matching) on timeout or error.
     async fn get_classifier(&self) -> &QueryClassifier {
-        self.classifier.get_or_init(|| async {
-            eprintln!("[CLASSIFIER] Starting init (timeout: 60s)...");
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(60),
-                QueryClassifier::new(self.llm.as_ref()),
-            ).await {
-                Ok(c) => {
-                    eprintln!("[CLASSIFIER] Initialized with {} centroids", c.centroids.len());
-                    c
+        self.classifier
+            .get_or_init(|| async {
+                eprintln!("[CLASSIFIER] Starting init (timeout: 60s)...");
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(60),
+                    QueryClassifier::new(self.llm.as_ref()),
+                )
+                .await
+                {
+                    Ok(c) => {
+                        eprintln!(
+                            "[CLASSIFIER] Initialized with {} centroids",
+                            c.centroids.len()
+                        );
+                        c
+                    }
+                    Err(_) => {
+                        eprintln!("[CLASSIFIER] TIMEOUT — falling back to keyword matching");
+                        QueryClassifier {
+                            centroids: Vec::new(),
+                        }
+                    }
                 }
-                Err(_) => {
-                    eprintln!("[CLASSIFIER] TIMEOUT — falling back to keyword matching");
-                    QueryClassifier { centroids: Vec::new() }
-                }
-            }
-        }).await
+            })
+            .await
     }
 
     /// Compute a recency score for a note using exponential decay.
@@ -286,7 +347,12 @@ impl ReadEngine {
 
     /// Combine similarity score with recency to produce a final score.
     /// Accepts an explicit recency weight for mode-specific overrides.
-    fn blended_score_with_weight(&self, similarity: f32, note: &MemoryNote, recency_weight: f32) -> f32 {
+    fn blended_score_with_weight(
+        &self,
+        similarity: f32,
+        note: &MemoryNote,
+        recency_weight: f32,
+    ) -> f32 {
         let w = recency_weight.clamp(0.0, 1.0);
         let recency = self.recency_score(note);
         (1.0 - w) * similarity + w * recency
@@ -309,18 +375,16 @@ impl ReadEngine {
             .collect();
 
         // Chronological order: prefer turn_index > source_timestamp > created_at
-        notes.sort_by(|a, b| {
-            match (a.turn_index, b.turn_index) {
-                (Some(ai), Some(bi)) => ai.cmp(&bi),
+        notes.sort_by(|a, b| match (a.turn_index, b.turn_index) {
+            (Some(ai), Some(bi)) => ai.cmp(&bi),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => match (a.source_timestamp, b.source_timestamp) {
+                (Some(at), Some(bt)) => at.cmp(&bt),
                 (Some(_), None) => std::cmp::Ordering::Less,
                 (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => match (a.source_timestamp, b.source_timestamp) {
-                    (Some(at), Some(bt)) => at.cmp(&bt),
-                    (Some(_), None) => std::cmp::Ordering::Less,
-                    (None, Some(_)) => std::cmp::Ordering::Greater,
-                    (None, None) => a.created_at.cmp(&b.created_at),
-                },
-            }
+                (None, None) => a.created_at.cmp(&b.created_at),
+            },
         });
         notes.truncate(self.config.max_notes_per_episode);
         Ok(notes)
@@ -391,13 +455,35 @@ impl ReadEngine {
             }
         }
 
+        // ACTIVATE Phase 7 (Trace): run on the truncated set only.
+        if activate_enabled(&self.config) {
+            let engine = ActivateEngine::new(
+                Arc::clone(&self.vector_store),
+                Arc::clone(&self.graph_store),
+                Arc::clone(&self.llm),
+                Arc::clone(&self.reranker),
+                self.config.clone(),
+                self.reranker_config.clone(),
+            );
+            if engine.should_sample_trace() {
+                let final_ids: Vec<String> = results.iter().map(|r| r.note.id.clone()).collect();
+                if let Err(e) = engine.phase_trace(&final_ids).await {
+                    debug!(error = %e, "ACTIVATE: phase_trace non-fatal failure");
+                }
+            }
+        }
+
         Ok(results)
     }
 
     /// Internal search: returns the full expanded candidate pool (not truncated)
     /// plus the classified query mode. Used by ask() so the reranker can see the
     /// full pool before truncation, and ask() can use the same mode for top_k sizing.
-    async fn search_wide(&self, query: &str, top_k: usize) -> Result<(Vec<SearchResult>, QueryMode)> {
+    async fn search_wide(
+        &self,
+        query: &str,
+        top_k: usize,
+    ) -> Result<(Vec<SearchResult>, QueryMode)> {
         info!("Searching: \"{}\"", query);
 
         let embeddings = self.llm.embed(&[query]).await?;
@@ -424,7 +510,9 @@ impl ReadEngine {
                 self.config.clone(),
                 self.reranker_config.clone(),
             );
-            let out = engine.activate(query, &query_embedding, mode, top_k).await?;
+            let out = engine
+                .activate(query, &query_embedding, mode, top_k)
+                .await?;
             info!(
                 results = out.results.len(),
                 channels = out.channels.len(),
@@ -450,12 +538,17 @@ impl ReadEngine {
         let fact_k = fetch_k / 2;
         let (direct, fact_hits) = if self.config.fact_retrieval_enabled {
             let (direct_result, fact_hits_result) = tokio::join!(
-                self.vector_store.find_similar(&query_embedding, fetch_k, &[]),
-                self.vector_store.find_similar_facts(&query_embedding, fact_k, &[])
+                self.vector_store
+                    .find_similar(&query_embedding, fetch_k, &[]),
+                self.vector_store
+                    .find_similar_facts(&query_embedding, fact_k, &[])
             );
             (direct_result?, fact_hits_result.unwrap_or_default())
         } else {
-            let direct = self.vector_store.find_similar(&query_embedding, fetch_k, &[]).await?;
+            let direct = self
+                .vector_store
+                .find_similar(&query_embedding, fetch_k, &[])
+                .await?;
             (direct, Vec::new())
         };
 
@@ -480,7 +573,9 @@ impl ReadEngine {
                 .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
                 .filter(|t| t.len() >= 3)
                 .collect();
-            let matched = tokens.iter().any(|t| query_lower.contains(&t.to_lowercase()));
+            let matched = tokens
+                .iter()
+                .any(|t| query_lower.contains(&t.to_lowercase()));
             if matched {
                 if let Some(note) = self.vector_store.get(note_id).await? {
                     if note.is_active() {
@@ -516,11 +611,14 @@ impl ReadEngine {
             // Dreams are surfaced via contradiction force-retrieval.
             // Digests are surfaced via episode drilldown + episode link traversal.
             match &note.provenance {
-                Provenance::Dream { .. } | Provenance::Digest { .. } | Provenance::Fact { .. } => continue,
+                Provenance::Dream { .. } | Provenance::Digest { .. } | Provenance::Fact { .. } => {
+                    continue;
+                }
                 _ => {}
             }
 
-            let mut final_score = self.blended_score_with_weight(sim, &note, effective_recency_weight);
+            let mut final_score =
+                self.blended_score_with_weight(sim, &note, effective_recency_weight);
 
             // Graph-aware scoring: notes with more links score higher (PageRank-lite)
             let link_count = self.graph_store.get_link_count(&note.id).await?;
@@ -592,9 +690,7 @@ impl ReadEngine {
             if episode_note_ids.contains(&note.id) {
                 continue; // Already included via episode drilldown
             }
-            let linked_notes = self
-                .multi_hop_traverse(&note.id, max_depth, decay)
-                .await?;
+            let linked_notes = self.multi_hop_traverse(&note.id, max_depth, decay).await?;
 
             flat_results.push(SearchResult {
                 note,
@@ -609,14 +705,24 @@ impl ReadEngine {
         let mut seen_note_ids: HashSet<String> = HashSet::new();
 
         // Collect already-included note IDs
-        for r in &profile_results { seen_note_ids.insert(r.note.id.clone()); }
-        for r in &episode_results { seen_note_ids.insert(r.note.id.clone()); }
-        for r in &flat_results { seen_note_ids.insert(r.note.id.clone()); }
-        for id in &episode_note_ids { seen_note_ids.insert(id.clone()); }
+        for r in &profile_results {
+            seen_note_ids.insert(r.note.id.clone());
+        }
+        for r in &episode_results {
+            seen_note_ids.insert(r.note.id.clone());
+        }
+        for r in &flat_results {
+            seen_note_ids.insert(r.note.id.clone());
+        }
+        for id in &episode_note_ids {
+            seen_note_ids.insert(id.clone());
+        }
 
         let fact_boost = self.config.fact_match_boost;
         for (fact, score) in &fact_hits {
-            if *score < 0.3 { continue; }
+            if *score < 0.3 {
+                continue;
+            }
             if seen_note_ids.insert(fact.source_note_id.clone()) {
                 if let Ok(Some(parent)) = self.vector_store.get(&fact.source_note_id).await {
                     if parent.is_active() {
@@ -624,10 +730,8 @@ impl ReadEngine {
                         // synthesis LLM sees the exact value. The clone prevents
                         // the access-tracking upsert from corrupting stored content.
                         let mut annotated = parent.clone();
-                        annotated.content = format!(
-                            "[Matched fact: {}]\n\n{}",
-                            fact.content, annotated.content
-                        );
+                        annotated.content =
+                            format!("[Matched fact: {}]\n\n{}", fact.content, annotated.content);
                         fact_expanded.push(SearchResult {
                             note: annotated,
                             score: score + fact_boost,
@@ -648,10 +752,13 @@ impl ReadEngine {
         for (episode_id, _) in &episode_hits {
             if let Ok(links) = self.graph_store.get_episode_links(episode_id).await {
                 for (linked_ep_id, _link_type, _entity) in &links {
-                    if let Ok(Some(digest)) = self.graph_store.get_episode_digest(linked_ep_id).await {
+                    if let Ok(Some(digest)) =
+                        self.graph_store.get_episode_digest(linked_ep_id).await
+                    {
                         if let Some(ref note_id) = digest.digest_note_id {
                             if seen_note_ids.insert(note_id.clone()) {
-                                if let Ok(Some(digest_note)) = self.vector_store.get(note_id).await {
+                                if let Ok(Some(digest_note)) = self.vector_store.get(note_id).await
+                                {
                                     if digest_note.is_active() {
                                         linked_digest_results.push(SearchResult {
                                             note: digest_note,
@@ -668,7 +775,10 @@ impl ReadEngine {
         }
 
         if !linked_digest_results.is_empty() {
-            debug!(count = linked_digest_results.len(), "Episode-linked digest notes");
+            debug!(
+                count = linked_digest_results.len(),
+                "Episode-linked digest notes"
+            );
         }
 
         // --- Structured digest query ---
@@ -676,7 +786,10 @@ impl ReadEngine {
         // Digests contain pre-computed aggregations, entity counts, and date ranges
         // that answer "how many X" and "what is the current Y" questions directly.
         let mut digest_matched_results: Vec<SearchResult> = Vec::new();
-        if matches!(mode, QueryMode::Computation | QueryMode::Breadth | QueryMode::Recency) {
+        if matches!(
+            mode,
+            QueryMode::Computation | QueryMode::Breadth | QueryMode::Recency
+        ) {
             let all_digests = self.graph_store.get_all_episode_digests().await?;
             let query_lower = query.to_lowercase();
 
@@ -687,9 +800,13 @@ impl ReadEngine {
                 // Search entities
                 for entity in &digest.entities {
                     if query_lower.contains(&entity.name.to_lowercase())
-                        || entity.name.to_lowercase().contains(&query_lower.split_whitespace()
-                            .filter(|w| w.len() > 3)
-                            .next().unwrap_or(""))
+                        || entity.name.to_lowercase().contains(
+                            &query_lower
+                                .split_whitespace()
+                                .filter(|w| w.len() > 3)
+                                .next()
+                                .unwrap_or(""),
+                        )
                     {
                         matched = true;
                         break;
@@ -715,10 +832,12 @@ impl ReadEngine {
                 // Search digest text for query keywords
                 if !matched && !digest.digest_text.is_empty() {
                     let digest_lower = digest.digest_text.to_lowercase();
-                    let query_words: Vec<&str> = query_lower.split_whitespace()
+                    let query_words: Vec<&str> = query_lower
+                        .split_whitespace()
                         .filter(|w| w.len() > 3)
                         .collect();
-                    let match_count = query_words.iter()
+                    let match_count = query_words
+                        .iter()
                         .filter(|w| digest_lower.contains(*w))
                         .count();
                     if match_count >= 2 || (query_words.len() <= 3 && match_count >= 1) {
@@ -744,7 +863,10 @@ impl ReadEngine {
             }
 
             if !digest_matched_results.is_empty() {
-                debug!(count = digest_matched_results.len(), "Structurally matched episode digests");
+                debug!(
+                    count = digest_matched_results.len(),
+                    "Structurally matched episode digests"
+                );
             }
         }
 
@@ -791,7 +913,9 @@ impl ReadEngine {
 
         if results.is_empty() {
             return Ok(AskResult {
-                answer: "Based on the available memories, I don't have information about this topic.".to_string(),
+                answer:
+                    "Based on the available memories, I don't have information about this topic."
+                        .to_string(),
                 query_mode: mode_str,
                 notes_used: 0,
                 note_ids: Vec::new(),
@@ -811,7 +935,8 @@ impl ReadEngine {
 
             let reranked = self.reranker.rerank(query, notes_for_rerank).await?;
 
-            let best_relevance = reranked.iter()
+            let best_relevance = reranked
+                .iter()
                 .map(|r| r.relevance_score)
                 .fold(0.0f32, f32::max);
 
@@ -833,11 +958,13 @@ impl ReadEngine {
             // Computation needs factual completeness (both date notes), not topical precision.
             // Reranker pushes date-bearing notes down because they score low on topical relevance.
             if mode != QueryMode::Computation {
-                let reranked_ids: HashSet<String> = reranked.iter().map(|r| r.note.id.clone()).collect();
+                let reranked_ids: HashSet<String> =
+                    reranked.iter().map(|r| r.note.id.clone()).collect();
                 let mut reordered: Vec<SearchResult> = Vec::new();
 
                 for rr in &reranked {
-                    let linked = results.iter()
+                    let linked = results
+                        .iter()
                         .find(|r| r.note.id == rr.note.id)
                         .map(|r| r.linked_notes.clone())
                         .unwrap_or_default();
@@ -855,7 +982,10 @@ impl ReadEngine {
                 }
 
                 results = reordered;
-                debug!(reranked_count = reranked.len(), "Reranker: reordered results by relevance");
+                debug!(
+                    reranked_count = reranked.len(),
+                    "Reranker: reordered results by relevance"
+                );
             } else {
                 debug!("Reranker: skipping reorder for Computation mode (preserving ANN order)");
             }
@@ -869,6 +999,26 @@ impl ReadEngine {
             if let Ok(Some(mut original)) = self.vector_store.get(&result.note.id).await {
                 original.last_accessed_at = Utc::now();
                 let _ = self.vector_store.upsert(&original).await;
+            }
+        }
+
+        // ACTIVATE Phase 7 (Trace): train activation state on the FINAL
+        // truncated set — items dropped during reranking must not bump
+        // access counters or co-activation Hebbian edges.
+        if activate_enabled(&self.config) {
+            let engine = ActivateEngine::new(
+                Arc::clone(&self.vector_store),
+                Arc::clone(&self.graph_store),
+                Arc::clone(&self.llm),
+                Arc::clone(&self.reranker),
+                self.config.clone(),
+                self.reranker_config.clone(),
+            );
+            if engine.should_sample_trace() {
+                let final_ids: Vec<String> = results.iter().map(|r| r.note.id.clone()).collect();
+                if let Err(e) = engine.phase_trace(&final_ids).await {
+                    debug!(error = %e, "ACTIVATE: phase_trace non-fatal failure");
+                }
             }
         }
 
@@ -901,18 +1051,16 @@ impl ReadEngine {
 
         // Sort notes by conversation order (turn_index > source_timestamp > created_at).
         // LLMs perform better when notes arrive in chronological sequence, not relevance order.
-        all_notes.sort_by(|a, b| {
-            match (a.turn_index, b.turn_index) {
-                (Some(ai), Some(bi)) => ai.cmp(&bi),
+        all_notes.sort_by(|a, b| match (a.turn_index, b.turn_index) {
+            (Some(ai), Some(bi)) => ai.cmp(&bi),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => match (a.source_timestamp, b.source_timestamp) {
+                (Some(at), Some(bt)) => at.cmp(&bt),
                 (Some(_), None) => std::cmp::Ordering::Less,
                 (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => match (a.source_timestamp, b.source_timestamp) {
-                    (Some(at), Some(bt)) => at.cmp(&bt),
-                    (Some(_), None) => std::cmp::Ordering::Less,
-                    (None, Some(_)) => std::cmp::Ordering::Greater,
-                    (None, None) => a.created_at.cmp(&b.created_at),
-                },
-            }
+                (None, None) => a.created_at.cmp(&b.created_at),
+            },
         });
 
         // --- Contradiction force-retrieval ---
@@ -923,7 +1071,12 @@ impl ReadEngine {
 
         // 1. Scan for contradiction dreams in retrieved notes
         for note in all_notes.iter() {
-            if let Provenance::Dream { dream_type, source_note_ids, .. } = &note.provenance {
+            if let Provenance::Dream {
+                dream_type,
+                source_note_ids,
+                ..
+            } = &note.provenance
+            {
                 if dream_type == "contradiction" {
                     for sid in source_note_ids {
                         if !seen_ids.contains(sid) {
@@ -940,7 +1093,10 @@ impl ReadEngine {
                 for (linked_id, reason) in &links {
                     if reason.contains("contradiction dream") && !seen_ids.contains(linked_id) {
                         if let Ok(Some(dream_note)) = self.vector_store.get(linked_id).await {
-                            if let Provenance::Dream { source_note_ids, .. } = &dream_note.provenance {
+                            if let Provenance::Dream {
+                                source_note_ids, ..
+                            } = &dream_note.provenance
+                            {
                                 for sid in source_note_ids {
                                     if !seen_ids.contains(sid) {
                                         contradiction_inject_ids.insert(sid.clone());
@@ -955,14 +1111,23 @@ impl ReadEngine {
         }
 
         // 3. Fetch injected notes (cap at 10 to bound LLM context growth)
-        let mut inject_ids_vec: Vec<&str> = contradiction_inject_ids.iter().map(|s| s.as_str()).collect();
+        let mut inject_ids_vec: Vec<&str> = contradiction_inject_ids
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
         inject_ids_vec.truncate(10);
         let inject_refs = inject_ids_vec;
         let contradiction_notes: Vec<MemoryNote> = if inject_refs.is_empty() {
             Vec::new()
         } else {
-            debug!(count = inject_refs.len(), "Injecting contradiction source notes");
-            self.vector_store.get_many(&inject_refs).await.unwrap_or_default()
+            debug!(
+                count = inject_refs.len(),
+                "Injecting contradiction source notes"
+            );
+            self.vector_store
+                .get_many(&inject_refs)
+                .await
+                .unwrap_or_default()
         };
 
         // Build notes text with provenance markers so the LLM knows
@@ -971,7 +1136,11 @@ impl ReadEngine {
         let format_note = |i: usize, note: &MemoryNote, is_contradiction_source: bool| {
             let provenance_marker = match &note.provenance {
                 Provenance::Observed => "FACT".to_string(),
-                Provenance::Dream { dream_type, confidence, .. } => {
+                Provenance::Dream {
+                    dream_type,
+                    confidence,
+                    ..
+                } => {
                     format!("INFERRED:{} conf={:.0}%", dream_type, confidence * 100.0)
                 }
                 Provenance::Profile { entity_id } => {
@@ -981,7 +1150,10 @@ impl ReadEngine {
                     format!("EPISODE:{}", episode_id)
                 }
                 Provenance::Fact { source_note_id } => {
-                    format!("FACT:from-{}", &source_note_id[..8.min(source_note_id.len())])
+                    format!(
+                        "FACT:from-{}",
+                        &source_note_id[..8.min(source_note_id.len())]
+                    )
                 }
                 Provenance::Digest { episode_id } => {
                     format!("DIGEST:{}", &episode_id[..8.min(episode_id.len())])
@@ -989,9 +1161,7 @@ impl ReadEngine {
             };
             // Use source_timestamp (real conversation date) if available, fall back to created_at
             let display_time = note.source_timestamp.unwrap_or(note.created_at);
-            let age = Utc::now()
-                .signed_duration_since(display_time)
-                .num_days();
+            let age = Utc::now().signed_duration_since(display_time).num_days();
             let recency = if age == 0 {
                 "today".to_string()
             } else if age == 1 {
@@ -1001,7 +1171,11 @@ impl ReadEngine {
             };
 
             let date_str = display_time.format("%Y-%m-%d");
-            let prefix = if is_contradiction_source { "[CONTRADICTION SOURCE] " } else { "" };
+            let prefix = if is_contradiction_source {
+                "[CONTRADICTION SOURCE] "
+            } else {
+                ""
+            };
             format!(
                 "[{}] {}({}, {}, {}) {}\n    Context: {}",
                 i + 1,
@@ -1059,8 +1233,7 @@ impl ReadEngine {
         let response = self.llm.chat(&messages, &config).await?;
 
         // Parse structured response
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         let has_contradiction = parsed["has_contradiction"].as_bool().unwrap_or(false);
 
@@ -1131,21 +1304,21 @@ impl ReadEngine {
                 }
 
                 // Sort chronologically
-                retry_notes.sort_by(|a, b| {
-                    match (a.turn_index, b.turn_index) {
-                        (Some(ai), Some(bi)) => ai.cmp(&bi),
+                retry_notes.sort_by(|a, b| match (a.turn_index, b.turn_index) {
+                    (Some(ai), Some(bi)) => ai.cmp(&bi),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => match (a.source_timestamp, b.source_timestamp) {
+                        (Some(at), Some(bt)) => at.cmp(&bt),
                         (Some(_), None) => std::cmp::Ordering::Less,
                         (None, Some(_)) => std::cmp::Ordering::Greater,
-                        (None, None) => match (a.source_timestamp, b.source_timestamp) {
-                            (Some(at), Some(bt)) => at.cmp(&bt),
-                            (Some(_), None) => std::cmp::Ordering::Less,
-                            (None, Some(_)) => std::cmp::Ordering::Greater,
-                            (None, None) => a.created_at.cmp(&b.created_at),
-                        },
-                    }
+                        (None, None) => a.created_at.cmp(&b.created_at),
+                    },
                 });
 
-                let joined_retry: String = retry_notes.iter().enumerate()
+                let joined_retry: String = retry_notes
+                    .iter()
+                    .enumerate()
                     .map(|(i, note)| format_note(i, note, false))
                     .collect::<Vec<_>>()
                     .join("\n\n");
@@ -1177,9 +1350,13 @@ impl ReadEngine {
                     let retry_parsed: serde_json::Value =
                         serde_json::from_str(&retry_response.content).unwrap_or_default();
                     if let Some(retry_answer) = retry_parsed["answer"].as_str() {
-                        if !retry_answer.is_empty() && !Self::answer_admits_insufficient_info(retry_answer) {
-                            let retry_note_ids: Vec<String> = retry_notes.iter().map(|n| n.id.clone()).collect();
-                            let retry_has_contradiction = retry_parsed["has_contradiction"].as_bool().unwrap_or(false);
+                        if !retry_answer.is_empty()
+                            && !Self::answer_admits_insufficient_info(retry_answer)
+                        {
+                            let retry_note_ids: Vec<String> =
+                                retry_notes.iter().map(|n| n.id.clone()).collect();
+                            let retry_has_contradiction =
+                                retry_parsed["has_contradiction"].as_bool().unwrap_or(false);
 
                             let mut final_answer = retry_answer.to_string();
                             if retry_has_contradiction {
@@ -1233,8 +1410,16 @@ impl ReadEngine {
             return String::new();
         }
 
-        let per_episode = self.graph_store.get_all_episode_digests().await.unwrap_or_default();
-        let cross_level = self.graph_store.get_all_cross_episode_digests().await.unwrap_or_default();
+        let per_episode = self
+            .graph_store
+            .get_all_episode_digests()
+            .await
+            .unwrap_or_default();
+        let cross_level = self
+            .graph_store
+            .get_all_cross_episode_digests()
+            .await
+            .unwrap_or_default();
 
         if per_episode.is_empty() && cross_level.is_empty() {
             return String::new();
@@ -1278,7 +1463,10 @@ impl ReadEngine {
             (Some(ad), Some(bd)) => ad.cmp(bd),
             (Some(_), None) => std::cmp::Ordering::Less,
             (None, Some(_)) => std::cmp::Ordering::Greater,
-            (None, None) => a.source_turn.unwrap_or(u32::MAX).cmp(&b.source_turn.unwrap_or(u32::MAX)),
+            (None, None) => a
+                .source_turn
+                .unwrap_or(u32::MAX)
+                .cmp(&b.source_turn.unwrap_or(u32::MAX)),
         });
 
         // Cap to keep the context tight. 400 events ≈ 6-8k tokens; smoke

--- a/crates/karta-core/src/read.rs
+++ b/crates/karta-core/src/read.rs
@@ -17,7 +17,12 @@ use crate::store::{GraphStore, VectorStore};
 fn activate_enabled(cfg: &ReadConfig) -> bool {
     cfg.activate.enabled
         || std::env::var("KARTA_ACTIVATE_ENABLED")
-            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+            .map(|v| {
+                matches!(
+                    v.trim().to_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
             .unwrap_or(false)
 }
 

--- a/crates/karta-core/src/read.rs
+++ b/crates/karta-core/src/read.rs
@@ -4,12 +4,22 @@ use std::sync::Arc;
 use chrono::Utc;
 use tracing::{debug, info};
 
+use crate::activate::ActivateEngine;
 use crate::config::ReadConfig;
 use crate::error::Result;
 use crate::llm::{ChatMessage, GenConfig, LlmProvider, Prompts, Role};
 use crate::note::{AskResult, MemoryNote, Provenance, SearchResult};
 use crate::rerank::{Reranker, RerankerConfig};
 use crate::store::{GraphStore, VectorStore};
+
+/// True when the ACTIVATE pipeline should be used instead of `search_wide`.
+/// Honours both the config flag and the `KARTA_ACTIVATE_ENABLED` env var.
+fn activate_enabled(cfg: &ReadConfig) -> bool {
+    cfg.activate.enabled
+        || std::env::var("KARTA_ACTIVATE_ENABLED")
+            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+            .unwrap_or(false)
+}
 
 /// Query classification for mode-specific retrieval behavior.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -401,6 +411,27 @@ impl ReadEngine {
             classifier.classify(&query_embedding)
         };
         debug!(query_mode = ?mode, "Query classified");
+
+        // ACTIVATE dispatch: when enabled, route through the 6-phase pipeline
+        // and return fused top_k as SearchResults. The legacy scalar path below
+        // remains the fallback so BEAM can A/B the two by toggling the flag.
+        if activate_enabled(&self.config) {
+            let engine = ActivateEngine::new(
+                Arc::clone(&self.vector_store),
+                Arc::clone(&self.graph_store),
+                Arc::clone(&self.llm),
+                Arc::clone(&self.reranker),
+                self.config.clone(),
+                self.reranker_config.clone(),
+            );
+            let out = engine.activate(query, &query_embedding, mode, top_k).await?;
+            info!(
+                results = out.results.len(),
+                channels = out.channels.len(),
+                "ACTIVATE: fused output"
+            );
+            return Ok((out.results, out.mode));
+        }
 
         // Mode-specific fetch_k: wide pool for reranker, but Computation stays tight (precision > recall)
         let fetch_k = match mode {

--- a/crates/karta-core/src/read.rs
+++ b/crates/karta-core/src/read.rs
@@ -114,6 +114,13 @@ const PROTOTYPES: &[(QueryMode, &[&str])] = &[
             "Have I been inconsistent about my preferences?",
             "Does my earlier statement conflict with the later one?",
             "Was there a contradiction in what I said?",
+            "Have I integrated Flask-Login in my project?",
+            "Have I actually completed the authentication module?",
+            "Did I ever set up the staging environment?",
+            "Do I still use SQLite or did I switch?",
+            "Have I written unit tests for the API?",
+            "Am I currently using Redis for caching?",
+            "Have I decided on a deployment platform yet?",
         ],
     ),
     (
@@ -257,6 +264,11 @@ fn classify_query_keywords(query: &str) -> QueryMode {
         || q.contains("is it true")
         || q.contains("conflict")
         || q.contains("inconsisten")
+        || q.starts_with("have i ")
+        || q.starts_with("did i ever ")
+        || q.starts_with("do i still ")
+        || q.starts_with("am i actually ")
+        || q.starts_with("have i actually ")
     {
         return QueryMode::Existence;
     }
@@ -1504,5 +1516,38 @@ impl ReadEngine {
             || lower.contains("not in the notes")
             || lower.contains("not provided in")
             || lower.contains("i don't see any note")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The keyword classifier fallback must route "Have I X?" / "Did I ever X?" /
+    /// "Do I still X?" style questions to Existence so contradiction-aware
+    /// channel weights kick in when the embedding classifier is unavailable.
+    #[test]
+    fn keyword_classifier_routes_have_i_questions_to_existence() {
+        assert_eq!(
+            classify_query_keywords("Have I integrated Flask-Login?"),
+            QueryMode::Existence,
+        );
+        assert_eq!(
+            classify_query_keywords("Did I ever write tests?"),
+            QueryMode::Existence,
+        );
+        assert_eq!(
+            classify_query_keywords("Do I still use SQLite?"),
+            QueryMode::Existence,
+        );
+    }
+
+    /// Control: a Standard-style question must not be misclassified as Existence.
+    #[test]
+    fn keyword_classifier_does_not_overmatch_existence() {
+        assert_ne!(
+            classify_query_keywords("What tools am I using?"),
+            QueryMode::Existence,
+        );
     }
 }

--- a/crates/karta-core/src/store/lance.rs
+++ b/crates/karta-core/src/store/lance.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
 use arrow_array::{
-    Float32Array, RecordBatch, RecordBatchIterator, StringArray,
+    Array, Float32Array, RecordBatch, RecordBatchIterator, StringArray,
     RecordBatchReader,
 };
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
 use lancedb::{
     Connection,
@@ -14,9 +15,10 @@ use lancedb::{
     Table as LanceTable,
 };
 use tokio::sync::RwLock;
+use tracing::warn;
 
 use crate::error::{KartaError, Result};
-use crate::note::{MemoryNote, NoteStatus, Provenance};
+use crate::note::{MemoryNote, NoteStatus, Provenance, ACCESS_HISTORY_CAP};
 
 const TABLE_NAME: &str = "notes";
 const FACTS_TABLE_NAME: &str = "atomic_facts";
@@ -63,6 +65,10 @@ impl LanceVectorStore {
             Field::new("last_accessed_at", DataType::Utf8, false),
             Field::new("turn_index", DataType::Utf8, true),
             Field::new("source_timestamp", DataType::Utf8, true),
+            // ACTIVATE: nullable, default-empty on legacy rows.
+            Field::new("access_count", DataType::Utf8, true),
+            Field::new("access_history_json", DataType::Utf8, true),
+            Field::new("session_id", DataType::Utf8, true),
             Field::new(
                 "vector",
                 DataType::FixedSizeList(
@@ -72,6 +78,46 @@ impl LanceVectorStore {
                 false,
             ),
         ]))
+    }
+
+    /// Best-effort evolution of an existing table to the current ACTIVATE schema.
+    /// Logs and continues on failure — legacy rows remain readable via
+    /// `column_by_name` fallbacks in `batch_to_notes`.
+    async fn migrate_notes_table(table: &LanceTable) -> Result<()> {
+        use lancedb::table::NewColumnTransform;
+
+        let existing = table
+            .schema()
+            .await
+            .map_err(|e| KartaError::VectorStore(e.to_string()))?;
+        let existing_names: std::collections::HashSet<&str> =
+            existing.fields().iter().map(|f| f.name().as_str()).collect();
+
+        let mut to_add: Vec<(String, String)> = Vec::new();
+        // SQL CAST ensures the literal matches the column DataType::Utf8.
+        if !existing_names.contains("access_count") {
+            to_add.push(("access_count".into(), "CAST(NULL AS STRING)".into()));
+        }
+        if !existing_names.contains("access_history_json") {
+            to_add.push(("access_history_json".into(), "CAST(NULL AS STRING)".into()));
+        }
+        if !existing_names.contains("session_id") {
+            to_add.push(("session_id".into(), "CAST(NULL AS STRING)".into()));
+        }
+        if to_add.is_empty() {
+            return Ok(());
+        }
+
+        if let Err(e) = table
+            .add_columns(NewColumnTransform::SqlExpressions(to_add), None)
+            .await
+        {
+            warn!(
+                error = %e,
+                "ACTIVATE: schema migration failed; legacy rows remain readable via column_by_name fallback"
+            );
+        }
+        Ok(())
     }
 
     fn make_reader(
@@ -98,11 +144,16 @@ impl LanceVectorStore {
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
 
         let table = if names.contains(&TABLE_NAME.to_string()) {
-            self.conn
+            let t = self
+                .conn
                 .open_table(TABLE_NAME)
                 .execute()
                 .await
-                .map_err(|e| KartaError::VectorStore(e.to_string()))?
+                .map_err(|e| KartaError::VectorStore(e.to_string()))?;
+            // Best-effort: add any ACTIVATE columns missing from a pre-existing
+            // table. Failure is non-fatal — reads are schema-tolerant.
+            Self::migrate_notes_table(&t).await?;
+            t
         } else {
             let schema = Self::schema();
             let empty_batch = RecordBatch::new_empty(schema.clone());
@@ -256,6 +307,11 @@ impl LanceVectorStore {
         let last_accessed_at = note.last_accessed_at.to_rfc3339();
         let turn_index_str = note.turn_index.map(|t| t.to_string()).unwrap_or_default();
         let source_timestamp_str = note.source_timestamp.map(|t| t.to_rfc3339()).unwrap_or_default();
+        let access_count_str = note.access_count.to_string();
+        let access_history_json = serde_json::to_string(
+            &note.access_history.iter().map(|t| t.to_rfc3339()).collect::<Vec<_>>(),
+        )?;
+        let session_id_str = note.session_id.clone().unwrap_or_default();
 
         let batch = RecordBatch::try_new(
             Self::schema(),
@@ -273,6 +329,9 @@ impl LanceVectorStore {
                 Arc::new(StringArray::from(vec![last_accessed_at.as_str()])),
                 Arc::new(StringArray::from(vec![turn_index_str.as_str()])),
                 Arc::new(StringArray::from(vec![source_timestamp_str.as_str()])),
+                Arc::new(StringArray::from(vec![access_count_str.as_str()])),
+                Arc::new(StringArray::from(vec![access_history_json.as_str()])),
+                Arc::new(StringArray::from(vec![session_id_str.as_str()])),
                 Arc::new(vector_array),
             ],
         )
@@ -281,26 +340,69 @@ impl LanceVectorStore {
         Ok(batch)
     }
 
+    /// Look up a nullable string column by name. Returns `default` if the
+    /// column is missing from the batch schema (legacy row) or the cell is null/empty.
+    fn get_str_opt<'a>(batch: &'a RecordBatch, name: &str) -> Vec<Option<&'a str>> {
+        match batch.column_by_name(name) {
+            Some(col) => {
+                let arr = col.as_any().downcast_ref::<StringArray>();
+                match arr {
+                    Some(sa) => (0..batch.num_rows())
+                        .map(|i| if sa.is_null(i) { None } else { Some(sa.value(i)) })
+                        .collect(),
+                    None => vec![None; batch.num_rows()],
+                }
+            }
+            None => vec![None; batch.num_rows()],
+        }
+    }
+
     fn batch_to_notes(batch: &RecordBatch) -> Result<Vec<MemoryNote>> {
-        let ids = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-        let contents = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
-        let contexts = batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
-        let keywords_jsons = batch.column(3).as_any().downcast_ref::<StringArray>().unwrap();
-        let tags_jsons = batch.column(4).as_any().downcast_ref::<StringArray>().unwrap();
-        let provenance_jsons = batch.column(5).as_any().downcast_ref::<StringArray>().unwrap();
-        let confidences = batch.column(6).as_any().downcast_ref::<Float32Array>().unwrap();
-        let created_ats = batch.column(7).as_any().downcast_ref::<StringArray>().unwrap();
-        let updated_ats = batch.column(8).as_any().downcast_ref::<StringArray>().unwrap();
-        let status_jsons = batch.column(9).as_any().downcast_ref::<StringArray>().unwrap();
-        let last_accessed_ats = batch.column(10).as_any().downcast_ref::<StringArray>().unwrap();
-        let turn_index_strs = batch.column(11).as_any().downcast_ref::<StringArray>().unwrap();
-        let source_timestamp_strs = batch.column(12).as_any().downcast_ref::<StringArray>().unwrap();
+        // Column lookup by name keeps us schema-tolerant: legacy tables
+        // missing the ACTIVATE columns simply decode those as defaults.
+        let ids = batch.column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'id' column".into()))?;
+        let contents = batch.column_by_name("content")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'content' column".into()))?;
+        let contexts = batch.column_by_name("context")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'context' column".into()))?;
+        let keywords_jsons = batch.column_by_name("keywords_json")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'keywords_json' column".into()))?;
+        let tags_jsons = batch.column_by_name("tags_json")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'tags_json' column".into()))?;
+        let provenance_jsons = batch.column_by_name("provenance_json")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'provenance_json' column".into()))?;
+        let confidences = batch.column_by_name("confidence")
+            .and_then(|c| c.as_any().downcast_ref::<Float32Array>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'confidence' column".into()))?;
+        let created_ats = batch.column_by_name("created_at")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'created_at' column".into()))?;
+        let updated_ats = batch.column_by_name("updated_at")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'updated_at' column".into()))?;
+        let status_jsons = batch.column_by_name("status_json")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'status_json' column".into()))?;
+        let last_accessed_ats = batch.column_by_name("last_accessed_at")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'last_accessed_at' column".into()))?;
+        let turn_index_strs = Self::get_str_opt(batch, "turn_index");
+        let source_timestamp_strs = Self::get_str_opt(batch, "source_timestamp");
+        let access_count_strs = Self::get_str_opt(batch, "access_count");
+        let access_history_jsons = Self::get_str_opt(batch, "access_history_json");
+        let session_id_strs = Self::get_str_opt(batch, "session_id");
 
         let vector_col = batch
-            .column(13)
-            .as_any()
-            .downcast_ref::<arrow_array::FixedSizeListArray>()
-            .unwrap();
+            .column_by_name("vector")
+            .and_then(|c| c.as_any().downcast_ref::<arrow_array::FixedSizeListArray>())
+            .ok_or_else(|| KartaError::VectorStore("missing 'vector' column".into()))?;
 
         let mut notes = Vec::with_capacity(batch.num_rows());
 
@@ -324,6 +426,31 @@ impl LanceVectorStore {
                 serde_json::from_str(status_jsons.value(i))
                     .unwrap_or_default();
 
+            let access_count: u32 = access_count_strs
+                .get(i).copied().flatten()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+
+            let access_history: Vec<DateTime<Utc>> = access_history_jsons
+                .get(i).copied().flatten()
+                .and_then(|s| serde_json::from_str::<Vec<String>>(s).ok())
+                .map(|ss| ss.into_iter()
+                    .filter_map(|s| DateTime::parse_from_rfc3339(&s).ok())
+                    .map(|d| d.with_timezone(&Utc))
+                    .collect())
+                .unwrap_or_default();
+            let access_history = if access_history.len() > ACCESS_HISTORY_CAP {
+                let excess = access_history.len() - ACCESS_HISTORY_CAP;
+                access_history.into_iter().skip(excess).collect()
+            } else {
+                access_history
+            };
+
+            let session_id = session_id_strs
+                .get(i).copied().flatten()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+
             notes.push(MemoryNote {
                 id: ids.value(i).to_string(),
                 content: contents.value(i).to_string(),
@@ -345,20 +472,16 @@ impl LanceVectorStore {
                 last_accessed_at: chrono::DateTime::parse_from_rfc3339(last_accessed_ats.value(i))
                     .unwrap_or_default()
                     .with_timezone(&chrono::Utc),
-                turn_index: {
-                    let s = turn_index_strs.value(i);
-                    if s.is_empty() { None } else { s.parse().ok() }
-                },
-                source_timestamp: {
-                    let s = source_timestamp_strs.value(i);
-                    if s.is_empty() {
-                        None
-                    } else {
-                        chrono::DateTime::parse_from_rfc3339(s)
-                            .ok()
-                            .map(|d| d.with_timezone(&chrono::Utc))
-                    }
-                },
+                turn_index: turn_index_strs.get(i).copied().flatten()
+                    .filter(|s| !s.is_empty())
+                    .and_then(|s| s.parse().ok()),
+                source_timestamp: source_timestamp_strs.get(i).copied().flatten()
+                    .filter(|s| !s.is_empty())
+                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                    .map(|d| d.with_timezone(&Utc)),
+                access_count,
+                access_history,
+                session_id,
             });
         }
 

--- a/crates/karta-core/src/store/lance.rs
+++ b/crates/karta-core/src/store/lance.rs
@@ -1,24 +1,20 @@
 use std::sync::Arc;
 
 use arrow_array::{
-    Array, Float32Array, RecordBatch, RecordBatchIterator, StringArray,
-    RecordBatchReader,
+    Array, Float32Array, RecordBatch, RecordBatchIterator, RecordBatchReader, StringArray,
 };
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
 use lancedb::{
-    Connection,
-    connect,
+    Connection, Table as LanceTable, connect,
     query::{ExecutableQuery, QueryBase},
-    Table as LanceTable,
 };
 use tokio::sync::RwLock;
-use tracing::warn;
 
 use crate::error::{KartaError, Result};
-use crate::note::{MemoryNote, NoteStatus, Provenance, ACCESS_HISTORY_CAP};
+use crate::note::{ACCESS_HISTORY_CAP, MemoryNote, NoteStatus, Provenance};
 
 const TABLE_NAME: &str = "notes";
 const FACTS_TABLE_NAME: &str = "atomic_facts";
@@ -33,8 +29,7 @@ pub struct LanceVectorStore {
 impl LanceVectorStore {
     pub async fn new(data_dir: &str) -> Result<Self> {
         let uri = format!("{}/lance", data_dir);
-        std::fs::create_dir_all(&uri)
-            .map_err(|e| KartaError::VectorStore(e.to_string()))?;
+        std::fs::create_dir_all(&uri).map_err(|e| KartaError::VectorStore(e.to_string()))?;
         let conn = connect(&uri)
             .execute()
             .await
@@ -80,9 +75,12 @@ impl LanceVectorStore {
         ]))
     }
 
-    /// Best-effort evolution of an existing table to the current ACTIVATE schema.
-    /// Logs and continues on failure — legacy rows remain readable via
-    /// `column_by_name` fallbacks in `batch_to_notes`.
+    /// Evolve an existing table to the current ACTIVATE schema by adding
+    /// the nullable access/session columns if missing. Propagates
+    /// `add_columns` failures — subsequent upserts write batches built
+    /// against `Self::schema()` (which includes these columns), so a
+    /// silently failed migration would produce schema mismatches or lost
+    /// writes. Fail loudly at startup instead.
     async fn migrate_notes_table(table: &LanceTable) -> Result<()> {
         use lancedb::table::NewColumnTransform;
 
@@ -90,8 +88,11 @@ impl LanceVectorStore {
             .schema()
             .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
-        let existing_names: std::collections::HashSet<&str> =
-            existing.fields().iter().map(|f| f.name().as_str()).collect();
+        let existing_names: std::collections::HashSet<&str> = existing
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
 
         let mut to_add: Vec<(String, String)> = Vec::new();
         // SQL CAST ensures the literal matches the column DataType::Utf8.
@@ -108,15 +109,15 @@ impl LanceVectorStore {
             return Ok(());
         }
 
-        if let Err(e) = table
+        table
             .add_columns(NewColumnTransform::SqlExpressions(to_add), None)
             .await
-        {
-            warn!(
-                error = %e,
-                "ACTIVATE: schema migration failed; legacy rows remain readable via column_by_name fallback"
-            );
-        }
+            .map_err(|e| {
+                KartaError::VectorStore(format!(
+                    "ACTIVATE: failed to migrate notes table schema (access_count / access_history_json / session_id); refusing to continue so writes don't diverge from reader schema: {}",
+                    e
+                ))
+            })?;
         Ok(())
     }
 
@@ -196,17 +197,27 @@ impl LanceVectorStore {
             return Ok(());
         }
 
-        let names = self.conn.table_names().execute().await
+        let names = self
+            .conn
+            .table_names()
+            .execute()
+            .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
 
         let table = if names.contains(&FACTS_TABLE_NAME.to_string()) {
-            self.conn.open_table(FACTS_TABLE_NAME).execute().await
+            self.conn
+                .open_table(FACTS_TABLE_NAME)
+                .execute()
+                .await
                 .map_err(|e| KartaError::VectorStore(e.to_string()))?
         } else {
             let schema = Self::facts_schema();
             let empty_batch = RecordBatch::new_empty(schema.clone());
             let reader = Self::make_reader(vec![empty_batch], schema);
-            self.conn.create_table(FACTS_TABLE_NAME, reader).execute().await
+            self.conn
+                .create_table(FACTS_TABLE_NAME, reader)
+                .execute()
+                .await
                 .map_err(|e| KartaError::VectorStore(e.to_string()))?
         };
 
@@ -226,7 +237,8 @@ impl LanceVectorStore {
             EMBEDDING_DIM as i32,
             Arc::new(Float32Array::from(embedding)),
             None,
-        ).map_err(|e| KartaError::VectorStore(e.to_string()))?;
+        )
+        .map_err(|e| KartaError::VectorStore(e.to_string()))?;
 
         let created_at = fact.created_at.to_rfc3339();
         let ordinal_str = fact.ordinal.to_string();
@@ -243,23 +255,56 @@ impl LanceVectorStore {
                 Arc::new(StringArray::from(vec![created_at.as_str()])),
                 Arc::new(vector_array),
             ],
-        ).map_err(|e| KartaError::VectorStore(e.to_string()))
+        )
+        .map_err(|e| KartaError::VectorStore(e.to_string()))
     }
 
     fn batch_to_facts(batch: &RecordBatch) -> Result<Vec<crate::note::AtomicFact>> {
-        let ids = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-        let contents = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
-        let source_ids = batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
-        let ordinals = batch.column(3).as_any().downcast_ref::<StringArray>().unwrap();
-        let subjects = batch.column(4).as_any().downcast_ref::<StringArray>().unwrap();
-        let created_ats = batch.column(5).as_any().downcast_ref::<StringArray>().unwrap();
-        let vector_col = batch.column(6).as_any()
-            .downcast_ref::<arrow_array::FixedSizeListArray>().unwrap();
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let contents = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let source_ids = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let ordinals = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let subjects = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let created_ats = batch
+            .column(5)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let vector_col = batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<arrow_array::FixedSizeListArray>()
+            .unwrap();
 
         let mut facts = Vec::with_capacity(batch.num_rows());
         for i in 0..batch.num_rows() {
-            let embedding = vector_col.value(i).as_any()
-                .downcast_ref::<Float32Array>().unwrap().values().to_vec();
+            let embedding = vector_col
+                .value(i)
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .unwrap()
+                .values()
+                .to_vec();
             let subject_val = subjects.value(i);
 
             facts.push(crate::note::AtomicFact {
@@ -267,10 +312,15 @@ impl LanceVectorStore {
                 content: contents.value(i).to_string(),
                 source_note_id: source_ids.value(i).to_string(),
                 ordinal: ordinals.value(i).parse().unwrap_or(0),
-                subject: if subject_val.is_empty() { None } else { Some(subject_val.to_string()) },
+                subject: if subject_val.is_empty() {
+                    None
+                } else {
+                    Some(subject_val.to_string())
+                },
                 embedding,
                 created_at: chrono::DateTime::parse_from_rfc3339(created_ats.value(i))
-                    .unwrap_or_default().with_timezone(&chrono::Utc),
+                    .unwrap_or_default()
+                    .with_timezone(&chrono::Utc),
             });
         }
         Ok(facts)
@@ -306,10 +356,17 @@ impl LanceVectorStore {
         let updated_at = note.updated_at.to_rfc3339();
         let last_accessed_at = note.last_accessed_at.to_rfc3339();
         let turn_index_str = note.turn_index.map(|t| t.to_string()).unwrap_or_default();
-        let source_timestamp_str = note.source_timestamp.map(|t| t.to_rfc3339()).unwrap_or_default();
+        let source_timestamp_str = note
+            .source_timestamp
+            .map(|t| t.to_rfc3339())
+            .unwrap_or_default();
         let access_count_str = note.access_count.to_string();
         let access_history_json = serde_json::to_string(
-            &note.access_history.iter().map(|t| t.to_rfc3339()).collect::<Vec<_>>(),
+            &note
+                .access_history
+                .iter()
+                .map(|t| t.to_rfc3339())
+                .collect::<Vec<_>>(),
         )?;
         let session_id_str = note.session_id.clone().unwrap_or_default();
 
@@ -348,7 +405,13 @@ impl LanceVectorStore {
                 let arr = col.as_any().downcast_ref::<StringArray>();
                 match arr {
                     Some(sa) => (0..batch.num_rows())
-                        .map(|i| if sa.is_null(i) { None } else { Some(sa.value(i)) })
+                        .map(|i| {
+                            if sa.is_null(i) {
+                                None
+                            } else {
+                                Some(sa.value(i))
+                            }
+                        })
                         .collect(),
                     None => vec![None; batch.num_rows()],
                 }
@@ -360,37 +423,48 @@ impl LanceVectorStore {
     fn batch_to_notes(batch: &RecordBatch) -> Result<Vec<MemoryNote>> {
         // Column lookup by name keeps us schema-tolerant: legacy tables
         // missing the ACTIVATE columns simply decode those as defaults.
-        let ids = batch.column_by_name("id")
+        let ids = batch
+            .column_by_name("id")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'id' column".into()))?;
-        let contents = batch.column_by_name("content")
+        let contents = batch
+            .column_by_name("content")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'content' column".into()))?;
-        let contexts = batch.column_by_name("context")
+        let contexts = batch
+            .column_by_name("context")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'context' column".into()))?;
-        let keywords_jsons = batch.column_by_name("keywords_json")
+        let keywords_jsons = batch
+            .column_by_name("keywords_json")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'keywords_json' column".into()))?;
-        let tags_jsons = batch.column_by_name("tags_json")
+        let tags_jsons = batch
+            .column_by_name("tags_json")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'tags_json' column".into()))?;
-        let provenance_jsons = batch.column_by_name("provenance_json")
+        let provenance_jsons = batch
+            .column_by_name("provenance_json")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'provenance_json' column".into()))?;
-        let confidences = batch.column_by_name("confidence")
+        let confidences = batch
+            .column_by_name("confidence")
             .and_then(|c| c.as_any().downcast_ref::<Float32Array>())
             .ok_or_else(|| KartaError::VectorStore("missing 'confidence' column".into()))?;
-        let created_ats = batch.column_by_name("created_at")
+        let created_ats = batch
+            .column_by_name("created_at")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'created_at' column".into()))?;
-        let updated_ats = batch.column_by_name("updated_at")
+        let updated_ats = batch
+            .column_by_name("updated_at")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'updated_at' column".into()))?;
-        let status_jsons = batch.column_by_name("status_json")
+        let status_jsons = batch
+            .column_by_name("status_json")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'status_json' column".into()))?;
-        let last_accessed_ats = batch.column_by_name("last_accessed_at")
+        let last_accessed_ats = batch
+            .column_by_name("last_accessed_at")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| KartaError::VectorStore("missing 'last_accessed_at' column".into()))?;
         let turn_index_strs = Self::get_str_opt(batch, "turn_index");
@@ -417,27 +491,30 @@ impl LanceVectorStore {
 
             let keywords: Vec<String> =
                 serde_json::from_str(keywords_jsons.value(i)).unwrap_or_default();
-            let tags: Vec<String> =
-                serde_json::from_str(tags_jsons.value(i)).unwrap_or_default();
+            let tags: Vec<String> = serde_json::from_str(tags_jsons.value(i)).unwrap_or_default();
             let provenance: Provenance =
-                serde_json::from_str(provenance_jsons.value(i))
-                    .unwrap_or(Provenance::Observed);
+                serde_json::from_str(provenance_jsons.value(i)).unwrap_or(Provenance::Observed);
             let status: NoteStatus =
-                serde_json::from_str(status_jsons.value(i))
-                    .unwrap_or_default();
+                serde_json::from_str(status_jsons.value(i)).unwrap_or_default();
 
             let access_count: u32 = access_count_strs
-                .get(i).copied().flatten()
+                .get(i)
+                .copied()
+                .flatten()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0);
 
             let access_history: Vec<DateTime<Utc>> = access_history_jsons
-                .get(i).copied().flatten()
+                .get(i)
+                .copied()
+                .flatten()
                 .and_then(|s| serde_json::from_str::<Vec<String>>(s).ok())
-                .map(|ss| ss.into_iter()
-                    .filter_map(|s| DateTime::parse_from_rfc3339(&s).ok())
-                    .map(|d| d.with_timezone(&Utc))
-                    .collect())
+                .map(|ss| {
+                    ss.into_iter()
+                        .filter_map(|s| DateTime::parse_from_rfc3339(&s).ok())
+                        .map(|d| d.with_timezone(&Utc))
+                        .collect()
+                })
                 .unwrap_or_default();
             let access_history = if access_history.len() > ACCESS_HISTORY_CAP {
                 let excess = access_history.len() - ACCESS_HISTORY_CAP;
@@ -447,7 +524,9 @@ impl LanceVectorStore {
             };
 
             let session_id = session_id_strs
-                .get(i).copied().flatten()
+                .get(i)
+                .copied()
+                .flatten()
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_string());
 
@@ -472,10 +551,16 @@ impl LanceVectorStore {
                 last_accessed_at: chrono::DateTime::parse_from_rfc3339(last_accessed_ats.value(i))
                     .unwrap_or_default()
                     .with_timezone(&chrono::Utc),
-                turn_index: turn_index_strs.get(i).copied().flatten()
+                turn_index: turn_index_strs
+                    .get(i)
+                    .copied()
+                    .flatten()
                     .filter(|s| !s.is_empty())
                     .and_then(|s| s.parse().ok()),
-                source_timestamp: source_timestamp_strs.get(i).copied().flatten()
+                source_timestamp: source_timestamp_strs
+                    .get(i)
+                    .copied()
+                    .flatten()
                     .filter(|s| !s.is_empty())
                     .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
                     .map(|d| d.with_timezone(&Utc)),
@@ -510,9 +595,7 @@ impl crate::store::VectorStore for LanceVectorStore {
         let table = self.get_table().await?;
 
         // Delete existing row if present (upsert semantics)
-        let _ = table
-            .delete(&format!("id = '{}'", note.id))
-            .await;
+        let _ = table.delete(&format!("id = '{}'", note.id)).await;
 
         let batch = Self::note_to_batch(note)?;
         let schema = Self::schema();
@@ -644,7 +727,10 @@ impl crate::store::VectorStore for LanceVectorStore {
         let batch = Self::fact_to_batch(fact)?;
         let schema = Self::facts_schema();
         let reader = Self::make_reader(vec![batch], schema);
-        table.add(reader).execute().await
+        table
+            .add(reader)
+            .execute()
+            .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
         Ok(())
     }
@@ -656,17 +742,21 @@ impl crate::store::VectorStore for LanceVectorStore {
         exclude_source_note_ids: &[&str],
     ) -> Result<Vec<(crate::note::AtomicFact, f32)>> {
         let table = self.get_facts_table().await?;
-        let query = table.vector_search(embedding)
+        let query = table
+            .vector_search(embedding)
             .map_err(|e| KartaError::VectorStore(e.to_string()))?
             .limit(top_k + exclude_source_note_ids.len() * 5);
-        let results = query.execute().await
+        let results = query
+            .execute()
+            .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
         let batches = Self::collect_batches(results).await?;
 
         let mut scored = Vec::new();
         for batch in &batches {
             let facts = Self::batch_to_facts(batch)?;
-            let distance_col = batch.column_by_name("_distance")
+            let distance_col = batch
+                .column_by_name("_distance")
                 .and_then(|c| c.as_any().downcast_ref::<Float32Array>());
             for (i, fact) in facts.into_iter().enumerate() {
                 if exclude_source_note_ids.contains(&fact.source_note_id.as_str()) {
@@ -683,9 +773,11 @@ impl crate::store::VectorStore for LanceVectorStore {
 
     async fn get_facts_for_note(&self, note_id: &str) -> Result<Vec<crate::note::AtomicFact>> {
         let table = self.get_facts_table().await?;
-        let results = table.query()
+        let results = table
+            .query()
             .only_if(format!("source_note_id = '{}'", note_id))
-            .execute().await
+            .execute()
+            .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
         let batches = Self::collect_batches(results).await?;
         let mut facts = Vec::new();

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -112,6 +112,13 @@ impl crate::store::GraphStore for SqliteGraphStore {
             .conn
             .lock()
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        // Pre-ACTIVATE databases still have the old (from_id, to_id) PK and no
+        // weight/link_type columns. Run the migration FIRST — otherwise the
+        // CREATE INDEX on link_type below fails with "no such column" before
+        // we ever get a chance to add the column. (Production bug 2026-04-22.)
+        Self::migrate_links_table(&conn)?;
+
         conn.execute_batch(
             "
             CREATE TABLE IF NOT EXISTS links (
@@ -251,9 +258,6 @@ impl crate::store::GraphStore for SqliteGraphStore {
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        // Pre-ACTIVATE databases still have the old (from_id, to_id) PK and no
-        // weight/link_type columns. Rebuild the table in place if needed.
-        Self::migrate_links_table(&conn)?;
         Ok(())
     }
 
@@ -1328,5 +1332,60 @@ mod tests {
             )
             .unwrap();
         assert_eq!(n, 2);
+    }
+
+    /// Regression test for the production bug on Cloud Run revision -00016
+    /// (2026-04-22): a database with the pre-ACTIVATE `links` schema (no
+    /// `link_type` column) caused `init()` to fail with
+    /// `no such column: link_type` because `CREATE INDEX idx_links_type`
+    /// ran before `migrate_links_table`. Init must succeed and migrate.
+    #[tokio::test]
+    async fn init_succeeds_on_pre_activate_legacy_links_schema() {
+        // No tempfile dev-dep here; mirror the on-disk fixture pattern used
+        // in tests/activate_retrieval_invariants.rs.
+        let suffix = uuid::Uuid::new_v4().to_string();
+        let data_dir = format!("/tmp/karta-pre-activate-{}", &suffix[..8]);
+        let _ = std::fs::remove_dir_all(&data_dir);
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let db_path = format!("{}/karta.db", &data_dir);
+
+        // Simulate a pre-ACTIVATE database: create the old links schema directly.
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE links (
+                     from_id TEXT NOT NULL,
+                     to_id TEXT NOT NULL,
+                     reason TEXT NOT NULL,
+                     created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                     PRIMARY KEY (from_id, to_id)
+                 );
+                 INSERT INTO links (from_id, to_id, reason) VALUES ('a', 'b', 'test-edge');",
+            )
+            .unwrap();
+        }
+
+        // Now run the real init path — this would fail before the fix because
+        // CREATE INDEX on link_type runs before the migration that adds the column.
+        let store = SqliteGraphStore::new(&data_dir).unwrap();
+        crate::store::GraphStore::init(&store).await.expect(
+            "init must succeed on a legacy pre-ACTIVATE schema (production bug 2026-04-22)",
+        );
+
+        // Verify the migration actually ran: link_type column exists, weight defaults to 1.0,
+        // and the existing edge survived with link_type='semantic'.
+        let conn = Connection::open(&db_path).unwrap();
+        let (to_id, link_type, weight): (String, String, f64) = conn
+            .query_row(
+                "SELECT to_id, link_type, weight FROM links WHERE from_id = 'a' LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("legacy edge should survive migration");
+        assert_eq!(to_id, "b");
+        assert_eq!(link_type, "semantic");
+        assert!((weight - 1.0).abs() < 1e-9, "default weight should be 1.0");
+
+        let _ = std::fs::remove_dir_all(&data_dir);
     }
 }

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -32,6 +32,71 @@ impl SqliteGraphStore {
     }
 }
 
+impl SqliteGraphStore {
+    /// Idempotent migration for the `links` table: adds `weight` + `link_type`
+    /// columns on pre-ACTIVATE databases and rebuilds the PK to
+    /// `(from_id, to_id, link_type)`. Safe to call on a fresh database.
+    fn migrate_links_table(conn: &Connection) -> Result<()> {
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='links'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        if !table_exists {
+            return Ok(());
+        }
+
+        let mut has_link_type = false;
+        let mut has_weight = false;
+        {
+            let mut stmt = conn
+                .prepare("PRAGMA table_info(links)")
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            let cols = stmt
+                .query_map([], |row| row.get::<_, String>(1))
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            for col in cols {
+                let name = col.map_err(|e| KartaError::GraphStore(e.to_string()))?;
+                if name == "link_type" { has_link_type = true; }
+                if name == "weight" { has_weight = true; }
+            }
+        }
+
+        if has_link_type && has_weight {
+            return Ok(());
+        }
+
+        // Full rebuild: the original PK is (from_id, to_id); we need it to be
+        // (from_id, to_id, link_type) so semantic + follows can coexist.
+        conn.execute_batch(
+            "
+            BEGIN;
+            CREATE TABLE IF NOT EXISTS links_new (
+                from_id TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                weight REAL NOT NULL DEFAULT 1.0,
+                link_type TEXT NOT NULL DEFAULT 'semantic',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (from_id, to_id, link_type)
+            );
+            INSERT OR IGNORE INTO links_new (from_id, to_id, reason, weight, link_type, created_at)
+              SELECT from_id, to_id, reason, 1.0, 'semantic', created_at FROM links;
+            DROP TABLE links;
+            ALTER TABLE links_new RENAME TO links;
+            CREATE INDEX IF NOT EXISTS idx_links_from ON links(from_id);
+            CREATE INDEX IF NOT EXISTS idx_links_to ON links(to_id);
+            CREATE INDEX IF NOT EXISTS idx_links_type ON links(link_type);
+            COMMIT;
+            ",
+        )
+        .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl crate::store::GraphStore for SqliteGraphStore {
     async fn init(&self) -> Result<()> {
@@ -42,12 +107,15 @@ impl crate::store::GraphStore for SqliteGraphStore {
                 from_id TEXT NOT NULL,
                 to_id TEXT NOT NULL,
                 reason TEXT NOT NULL,
+                weight REAL NOT NULL DEFAULT 1.0,
+                link_type TEXT NOT NULL DEFAULT 'semantic',
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                PRIMARY KEY (from_id, to_id)
+                PRIMARY KEY (from_id, to_id, link_type)
             );
 
             CREATE INDEX IF NOT EXISTS idx_links_from ON links(from_id);
             CREATE INDEX IF NOT EXISTS idx_links_to ON links(to_id);
+            CREATE INDEX IF NOT EXISTS idx_links_type ON links(link_type);
 
             CREATE TABLE IF NOT EXISTS evolution_history (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -171,6 +239,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
             ",
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        // Pre-ACTIVATE databases still have the old (from_id, to_id) PK and no
+        // weight/link_type columns. Rebuild the table in place if needed.
+        Self::migrate_links_table(&conn)?;
         Ok(())
     }
 
@@ -178,20 +250,172 @@ impl crate::store::GraphStore for SqliteGraphStore {
         let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let now = Utc::now().to_rfc3339();
 
-        // Bidirectional: insert both directions
+        // Bidirectional semantic link; weight starts at 1.0 and is bumped by Hebbian.
         conn.execute(
-            "INSERT OR IGNORE INTO links (from_id, to_id, reason, created_at) VALUES (?1, ?2, ?3, ?4)",
+            "INSERT OR IGNORE INTO links (from_id, to_id, reason, weight, link_type, created_at) VALUES (?1, ?2, ?3, 1.0, 'semantic', ?4)",
             rusqlite::params![from_id, to_id, reason, now],
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         conn.execute(
-            "INSERT OR IGNORE INTO links (from_id, to_id, reason, created_at) VALUES (?1, ?2, ?3, ?4)",
+            "INSERT OR IGNORE INTO links (from_id, to_id, reason, weight, link_type, created_at) VALUES (?1, ?2, ?3, 1.0, 'semantic', ?4)",
             rusqlite::params![to_id, from_id, reason, now],
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         Ok(())
+    }
+
+    async fn add_link_typed(
+        &self,
+        from_id: &str,
+        to_id: &str,
+        link_type: &str,
+        reason: &str,
+        weight: f32,
+    ) -> Result<()> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let now = Utc::now().to_rfc3339();
+
+        // "follows" is single-direction (prev -> next); reverse is derived via turn_delta.
+        // "semantic" is bidirectional.
+        conn.execute(
+            "INSERT OR IGNORE INTO links (from_id, to_id, reason, weight, link_type, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![from_id, to_id, reason, weight, link_type, now],
+        )
+        .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        if link_type == "semantic" {
+            conn.execute(
+                "INSERT OR IGNORE INTO links (from_id, to_id, reason, weight, link_type, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                rusqlite::params![to_id, from_id, reason, weight, link_type, now],
+            )
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    async fn get_links_with_weights(
+        &self,
+        note_id: &str,
+        link_type: Option<&str>,
+    ) -> Result<Vec<(String, f32)>> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let rows: Vec<(String, f32)> = if let Some(lt) = link_type {
+            let mut stmt = conn
+                .prepare("SELECT to_id, weight FROM links WHERE from_id = ?1 AND link_type = ?2 ORDER BY weight DESC")
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            stmt.query_map(rusqlite::params![note_id, lt], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)? as f32))
+            })
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?
+            .collect::<std::result::Result<_, _>>()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?
+        } else {
+            let mut stmt = conn
+                .prepare("SELECT to_id, weight FROM links WHERE from_id = ?1 ORDER BY weight DESC")
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            stmt.query_map(rusqlite::params![note_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)? as f32))
+            })
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?
+            .collect::<std::result::Result<_, _>>()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?
+        };
+        Ok(rows)
+    }
+
+    async fn get_sequential_neighbors(
+        &self,
+        note_id: &str,
+        radius: usize,
+    ) -> Result<Vec<(String, i32)>> {
+        if radius == 0 {
+            return Ok(Vec::new());
+        }
+        let mut neighbors: Vec<(String, i32)> = Vec::new();
+        let mut current = note_id.to_string();
+        // Walk forward via "follows" links (prev -> next).
+        {
+            let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            for step in 1..=radius as i32 {
+                let mut stmt = conn
+                    .prepare("SELECT to_id FROM links WHERE from_id = ?1 AND link_type = 'follows' LIMIT 1")
+                    .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+                let next: Option<String> = stmt
+                    .query_row(rusqlite::params![current], |row| row.get(0))
+                    .ok();
+                match next {
+                    Some(id) => {
+                        neighbors.push((id.clone(), step));
+                        current = id;
+                    }
+                    None => break,
+                }
+            }
+        }
+        // Walk backward: find predecessor (where to_id = current and link_type = 'follows').
+        current = note_id.to_string();
+        {
+            let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            for step in 1..=radius as i32 {
+                let mut stmt = conn
+                    .prepare("SELECT from_id FROM links WHERE to_id = ?1 AND link_type = 'follows' LIMIT 1")
+                    .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+                let prev: Option<String> = stmt
+                    .query_row(rusqlite::params![current], |row| row.get(0))
+                    .ok();
+                match prev {
+                    Some(id) => {
+                        neighbors.push((id.clone(), -step));
+                        current = id;
+                    }
+                    None => break,
+                }
+            }
+        }
+        Ok(neighbors)
+    }
+
+    async fn bump_link_weight(
+        &self,
+        from_id: &str,
+        to_id: &str,
+        delta: f32,
+        max: f32,
+    ) -> Result<()> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        // Hebbian strengthening on the semantic edge only; clamp to max.
+        conn.execute(
+            "UPDATE links
+             SET weight = MIN(CAST(?3 AS REAL), weight + CAST(?4 AS REAL))
+             WHERE from_id = ?1 AND to_id = ?2 AND link_type = 'semantic'",
+            rusqlite::params![from_id, to_id, max as f64, delta as f64],
+        )
+        .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        // Mirror in the reverse direction to preserve bidirectional symmetry.
+        conn.execute(
+            "UPDATE links
+             SET weight = MIN(CAST(?3 AS REAL), weight + CAST(?4 AS REAL))
+             WHERE from_id = ?2 AND to_id = ?1 AND link_type = 'semantic'",
+            rusqlite::params![from_id, to_id, max as f64, delta as f64],
+        )
+        .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn decay_link_weights(&self, factor: f32) -> Result<usize> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        // Multiplicative decay floored at 1.0 so nothing ever decays below the
+        // initial semantic-link weight.
+        let n = conn
+            .execute(
+                "UPDATE links SET weight = MAX(1.0, weight * CAST(?1 AS REAL)) WHERE link_type = 'semantic'",
+                rusqlite::params![factor as f64],
+            )
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(n)
     }
 
     async fn get_links(&self, note_id: &str) -> Result<Vec<String>> {

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -14,11 +14,9 @@ pub struct SqliteGraphStore {
 impl SqliteGraphStore {
     pub fn new(data_dir: &str) -> Result<Self> {
         let path = format!("{}/karta.db", data_dir);
-        std::fs::create_dir_all(data_dir)
-            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        std::fs::create_dir_all(data_dir).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        let conn = Connection::open(&path)
-            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = Connection::open(&path).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         // Enable WAL mode for concurrent reads during dream writes
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
@@ -59,8 +57,12 @@ impl SqliteGraphStore {
                 .map_err(|e| KartaError::GraphStore(e.to_string()))?;
             for col in cols {
                 let name = col.map_err(|e| KartaError::GraphStore(e.to_string()))?;
-                if name == "link_type" { has_link_type = true; }
-                if name == "weight" { has_weight = true; }
+                if name == "link_type" {
+                    has_link_type = true;
+                }
+                if name == "weight" {
+                    has_weight = true;
+                }
             }
         }
 
@@ -70,9 +72,14 @@ impl SqliteGraphStore {
 
         // Full rebuild: the original PK is (from_id, to_id); we need it to be
         // (from_id, to_id, link_type) so semantic + follows can coexist.
-        conn.execute_batch(
+        // Use an explicit transaction that auto-rolls-back on drop if any
+        // statement fails partway through — safer than inline BEGIN/COMMIT
+        // inside execute_batch, which leaves the txn open on mid-batch error.
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        tx.execute_batch(
             "
-            BEGIN;
             CREATE TABLE IF NOT EXISTS links_new (
                 from_id TEXT NOT NULL,
                 to_id TEXT NOT NULL,
@@ -89,10 +96,11 @@ impl SqliteGraphStore {
             CREATE INDEX IF NOT EXISTS idx_links_from ON links(from_id);
             CREATE INDEX IF NOT EXISTS idx_links_to ON links(to_id);
             CREATE INDEX IF NOT EXISTS idx_links_type ON links(link_type);
-            COMMIT;
             ",
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        tx.commit()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(())
     }
 }
@@ -100,7 +108,10 @@ impl SqliteGraphStore {
 #[async_trait]
 impl crate::store::GraphStore for SqliteGraphStore {
     async fn init(&self) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute_batch(
             "
             CREATE TABLE IF NOT EXISTS links (
@@ -247,7 +258,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn add_link(&self, from_id: &str, to_id: &str, reason: &str) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let now = Utc::now().to_rfc3339();
 
         // Bidirectional semantic link; weight starts at 1.0 and is bumped by Hebbian.
@@ -274,7 +288,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         reason: &str,
         weight: f32,
     ) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let now = Utc::now().to_rfc3339();
 
         // "follows" is single-direction (prev -> next); reverse is derived via turn_delta.
@@ -301,7 +318,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         note_id: &str,
         link_type: Option<&str>,
     ) -> Result<Vec<(String, f32)>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let rows: Vec<(String, f32)> = if let Some(lt) = link_type {
             let mut stmt = conn
                 .prepare("SELECT to_id, weight FROM links WHERE from_id = ?1 AND link_type = ?2 ORDER BY weight DESC")
@@ -338,7 +358,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         let mut current = note_id.to_string();
         // Walk forward via "follows" links (prev -> next).
         {
-            let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
             for step in 1..=radius as i32 {
                 let mut stmt = conn
                     .prepare("SELECT to_id FROM links WHERE from_id = ?1 AND link_type = 'follows' LIMIT 1")
@@ -358,7 +381,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         // Walk backward: find predecessor (where to_id = current and link_type = 'follows').
         current = note_id.to_string();
         {
-            let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
             for step in 1..=radius as i32 {
                 let mut stmt = conn
                     .prepare("SELECT from_id FROM links WHERE to_id = ?1 AND link_type = 'follows' LIMIT 1")
@@ -385,7 +411,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         delta: f32,
         max: f32,
     ) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         // Hebbian strengthening on the semantic edge only; clamp to max.
         conn.execute(
             "UPDATE links
@@ -405,8 +434,51 @@ impl crate::store::GraphStore for SqliteGraphStore {
         Ok(())
     }
 
+    async fn bump_link_weights_batch(
+        &self,
+        pairs: &[(&str, &str)],
+        delta: f32,
+        max: f32,
+    ) -> Result<()> {
+        if pairs.is_empty() {
+            return Ok(());
+        }
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        {
+            let mut stmt = tx
+                .prepare(
+                    "UPDATE links
+                     SET weight = MIN(CAST(?3 AS REAL), weight + CAST(?4 AS REAL))
+                     WHERE from_id = ?1 AND to_id = ?2 AND link_type = 'semantic'",
+                )
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            let max_f = max as f64;
+            let delta_f = delta as f64;
+            for (a, b) in pairs {
+                // Forward direction
+                stmt.execute(rusqlite::params![a, b, max_f, delta_f])
+                    .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+                // Reverse direction to preserve bidirectional symmetry
+                stmt.execute(rusqlite::params![b, a, max_f, delta_f])
+                    .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            }
+        }
+        tx.commit()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(())
+    }
+
     async fn decay_link_weights(&self, factor: f32) -> Result<usize> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         // Multiplicative decay floored at 1.0 so nothing ever decays below the
         // initial semantic-link weight.
         let n = conn
@@ -419,7 +491,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_links(&self, note_id: &str) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT to_id FROM links WHERE from_id = ?1")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -434,7 +509,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_links_with_reasons(&self, note_id: &str) -> Result<Vec<(String, String)>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT to_id, reason FROM links WHERE from_id = ?1")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -456,7 +534,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         triggered_by: &str,
         previous_context: &str,
     ) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let now = Utc::now().to_rfc3339();
 
         conn.execute(
@@ -469,7 +550,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_evolution_history(&self, note_id: &str) -> Result<Vec<EvolutionRecord>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare(
                 "SELECT triggered_by, previous_context, evolved_at FROM evolution_history WHERE note_id = ?1 ORDER BY id ASC",
@@ -496,7 +580,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn record_dream_run(&self, run: &DreamRun) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let dreams_json = serde_json::to_string(&run.dreams)?;
 
         conn.execute(
@@ -520,7 +607,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_dream_cursor(&self) -> Result<Option<DateTime<Utc>>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let result = conn.query_row(
             "SELECT last_processed_at FROM dream_cursor WHERE id = 1",
             [],
@@ -543,7 +633,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn set_dream_cursor(&self, cursor: DateTime<Utc>) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute(
             "INSERT INTO dream_cursor (id, last_processed_at) VALUES (1, ?1)
              ON CONFLICT(id) DO UPDATE SET last_processed_at = ?1",
@@ -557,7 +650,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Foresight signals ---
 
     async fn upsert_foresight(&self, signal: &crate::note::ForesightSignal) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let status_str = serde_json::to_string(&signal.status)?;
         conn.execute(
             "INSERT INTO foresight_signals (id, content, valid_from, valid_until, source_note_id, confidence, status)
@@ -578,7 +674,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_active_foresights(&self) -> Result<Vec<crate::note::ForesightSignal>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT id, content, valid_from, valid_until, source_note_id, confidence FROM foresight_signals WHERE status = 'Active'")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -593,7 +692,9 @@ impl crate::store::GraphStore for SqliteGraphStore {
                         .unwrap_or_default()
                         .with_timezone(&Utc),
                     valid_until: valid_until_str.and_then(|s| {
-                        DateTime::parse_from_rfc3339(&s).ok().map(|dt| dt.with_timezone(&Utc))
+                        DateTime::parse_from_rfc3339(&s)
+                            .ok()
+                            .map(|dt| dt.with_timezone(&Utc))
                     }),
                     source_note_id: row.get(4)?,
                     confidence: row.get(5)?,
@@ -608,7 +709,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn expire_foresights(&self, before: DateTime<Utc>) -> Result<usize> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let count = conn
             .execute(
                 "UPDATE foresight_signals SET status = 'Expired' WHERE status = 'Active' AND valid_until IS NOT NULL AND valid_until < ?1",
@@ -618,8 +722,14 @@ impl crate::store::GraphStore for SqliteGraphStore {
         Ok(count)
     }
 
-    async fn get_foresights_for_note(&self, note_id: &str) -> Result<Vec<crate::note::ForesightSignal>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn get_foresights_for_note(
+        &self,
+        note_id: &str,
+    ) -> Result<Vec<crate::note::ForesightSignal>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT id, content, valid_from, valid_until, source_note_id, confidence, status FROM foresight_signals WHERE source_note_id = ?1")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -640,7 +750,9 @@ impl crate::store::GraphStore for SqliteGraphStore {
                         .unwrap_or_default()
                         .with_timezone(&Utc),
                     valid_until: valid_until_str.and_then(|s| {
-                        DateTime::parse_from_rfc3339(&s).ok().map(|dt| dt.with_timezone(&Utc))
+                        DateTime::parse_from_rfc3339(&s)
+                            .ok()
+                            .map(|dt| dt.with_timezone(&Utc))
                     }),
                     source_note_id: row.get(4)?,
                     confidence: row.get(5)?,
@@ -657,7 +769,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Profiles ---
 
     async fn upsert_profile(&self, entity_id: &str, note_id: &str) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let now = Utc::now().to_rfc3339();
         conn.execute(
             "INSERT INTO profiles (entity_id, note_id, last_updated) VALUES (?1, ?2, ?3)
@@ -669,7 +784,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_profile_note_id(&self, entity_id: &str) -> Result<Option<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let result = conn.query_row(
             "SELECT note_id FROM profiles WHERE entity_id = ?1",
             rusqlite::params![entity_id],
@@ -683,7 +801,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_all_profiles(&self) -> Result<Vec<(String, String)>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT entity_id, note_id FROM profiles")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -698,7 +819,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Episodes ---
 
     async fn upsert_episode(&self, episode: &crate::note::Episode) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let tags_json = serde_json::to_string(&episode.topic_tags)?;
         conn.execute(
             "INSERT INTO episodes (id, narrative_note_id, start_time, end_time, session_id, topic_tags_json)
@@ -719,7 +843,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
 
     async fn get_episode(&self, id: &str) -> Result<Option<crate::note::Episode>> {
         let episode_result = {
-            let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
             conn.query_row(
                 "SELECT id, narrative_note_id, start_time, end_time, session_id, topic_tags_json FROM episodes WHERE id = ?1",
                 rusqlite::params![id],
@@ -753,9 +880,15 @@ impl crate::store::GraphStore for SqliteGraphStore {
         }
     }
 
-    async fn get_episodes_for_session(&self, session_id: &str) -> Result<Vec<crate::note::Episode>> {
+    async fn get_episodes_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<crate::note::Episode>> {
         let ids: Vec<String> = {
-            let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
             let mut stmt = conn
                 .prepare("SELECT id FROM episodes WHERE session_id = ?1 ORDER BY start_time ASC")
                 .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -775,7 +908,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn add_note_to_episode(&self, note_id: &str, episode_id: &str) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute(
             "INSERT OR IGNORE INTO note_episodes (note_id, episode_id) VALUES (?1, ?2)",
             rusqlite::params![note_id, episode_id],
@@ -785,7 +921,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_episode_for_note(&self, note_id: &str) -> Result<Option<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let result = conn.query_row(
             "SELECT episode_id FROM note_episodes WHERE note_id = ?1 LIMIT 1",
             rusqlite::params![note_id],
@@ -799,7 +938,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_notes_for_episode(&self, episode_id: &str) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT note_id FROM note_episodes WHERE episode_id = ?1")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -814,7 +956,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Efficient link count ---
 
     async fn get_link_count(&self, note_id: &str) -> Result<usize> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let count: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM links WHERE from_id = ?1",
@@ -828,9 +973,15 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Episode Digests (Phase Next) ---
 
     async fn upsert_episode_digest(&self, digest: &crate::note::EpisodeDigest) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let entities_json = serde_json::to_string(&digest.entities)?;
-        let date_range_json = digest.date_range.as_ref().map(|d| serde_json::to_string(d).unwrap_or_default());
+        let date_range_json = digest
+            .date_range
+            .as_ref()
+            .map(|d| serde_json::to_string(d).unwrap_or_default());
         let aggregations_json = serde_json::to_string(&digest.aggregations)?;
         let topic_sequence_json = serde_json::to_string(&digest.topic_sequence)?;
         let events_json = serde_json::to_string(&digest.events)?;
@@ -841,8 +992,14 @@ impl crate::store::GraphStore for SqliteGraphStore {
         Ok(())
     }
 
-    async fn get_episode_digest(&self, episode_id: &str) -> Result<Option<crate::note::EpisodeDigest>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn get_episode_digest(
+        &self,
+        episode_id: &str,
+    ) -> Result<Option<crate::note::EpisodeDigest>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT id, episode_id, entities_json, date_range_json, aggregations_json, topic_sequence_json, events_json, digest_text, digest_note_id, created_at FROM episode_digests WHERE episode_id = ?1"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -865,7 +1022,8 @@ impl crate::store::GraphStore for SqliteGraphStore {
                 digest_text: row.get(7)?,
                 digest_note_id: row.get(8)?,
                 created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
-                    .unwrap_or_default().with_timezone(&chrono::Utc),
+                    .unwrap_or_default()
+                    .with_timezone(&chrono::Utc),
             })
         });
 
@@ -877,49 +1035,65 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_all_episode_digests(&self) -> Result<Vec<crate::note::EpisodeDigest>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT id, episode_id, entities_json, date_range_json, aggregations_json, topic_sequence_json, events_json, digest_text, digest_note_id, created_at FROM episode_digests ORDER BY created_at"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        let digests = stmt.query_map([], |row| {
-            let entities_str: String = row.get(2)?;
-            let date_range_str: Option<String> = row.get(3)?;
-            let agg_str: String = row.get(4)?;
-            let topic_str: String = row.get(5)?;
-            let events_str: String = row.get(6)?;
-            let created_str: String = row.get(9)?;
-            Ok(crate::note::EpisodeDigest {
-                id: row.get(0)?,
-                episode_id: row.get(1)?,
-                entities: serde_json::from_str(&entities_str).unwrap_or_default(),
-                date_range: date_range_str.and_then(|s| serde_json::from_str(&s).ok()),
-                aggregations: serde_json::from_str(&agg_str).unwrap_or_default(),
-                topic_sequence: serde_json::from_str(&topic_str).unwrap_or_default(),
-                events: serde_json::from_str(&events_str).unwrap_or_default(),
-                digest_text: row.get(7)?,
-                digest_note_id: row.get(8)?,
-                created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
-                    .unwrap_or_default().with_timezone(&chrono::Utc),
+        let digests = stmt
+            .query_map([], |row| {
+                let entities_str: String = row.get(2)?;
+                let date_range_str: Option<String> = row.get(3)?;
+                let agg_str: String = row.get(4)?;
+                let topic_str: String = row.get(5)?;
+                let events_str: String = row.get(6)?;
+                let created_str: String = row.get(9)?;
+                Ok(crate::note::EpisodeDigest {
+                    id: row.get(0)?,
+                    episode_id: row.get(1)?,
+                    entities: serde_json::from_str(&entities_str).unwrap_or_default(),
+                    date_range: date_range_str.and_then(|s| serde_json::from_str(&s).ok()),
+                    aggregations: serde_json::from_str(&agg_str).unwrap_or_default(),
+                    topic_sequence: serde_json::from_str(&topic_str).unwrap_or_default(),
+                    events: serde_json::from_str(&events_str).unwrap_or_default(),
+                    digest_text: row.get(7)?,
+                    digest_note_id: row.get(8)?,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .unwrap_or_default()
+                        .with_timezone(&chrono::Utc),
+                })
             })
-        }).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         Ok(digests.filter_map(|r| r.ok()).collect())
     }
 
     async fn get_undigested_episode_ids(&self) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT e.id FROM episodes e LEFT JOIN episode_digests d ON e.id = d.episode_id WHERE d.id IS NULL"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        let ids = stmt.query_map([], |row| row.get(0))
+        let ids = stmt
+            .query_map([], |row| row.get(0))
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(ids.filter_map(|r| r.ok()).collect())
     }
 
-    async fn upsert_cross_episode_digest(&self, digest: &crate::note::CrossEpisodeDigest) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn upsert_cross_episode_digest(
+        &self,
+        digest: &crate::note::CrossEpisodeDigest,
+    ) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let entity_timeline_json = serde_json::to_string(&digest.entity_timeline)?;
         let cross_aggregations_json = serde_json::to_string(&digest.cross_aggregations)?;
         let events_json = serde_json::to_string(&digest.events)?;
@@ -932,37 +1106,52 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_all_cross_episode_digests(&self) -> Result<Vec<crate::note::CrossEpisodeDigest>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT id, scope_id, entity_timeline_json, cross_aggregations_json, events_json, topic_progression_json, digest_text, created_at FROM cross_episode_digests ORDER BY created_at"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        let digests = stmt.query_map([], |row| {
-            let timeline_str: String = row.get(2)?;
-            let agg_str: String = row.get(3)?;
-            let events_str: String = row.get(4)?;
-            let topic_str: String = row.get(5)?;
-            let created_str: String = row.get(7)?;
-            Ok(crate::note::CrossEpisodeDigest {
-                id: row.get(0)?,
-                scope_id: row.get(1)?,
-                entity_timeline: serde_json::from_str(&timeline_str).unwrap_or_default(),
-                cross_aggregations: serde_json::from_str(&agg_str).unwrap_or_default(),
-                events: serde_json::from_str(&events_str).unwrap_or_default(),
-                topic_progression: serde_json::from_str(&topic_str).unwrap_or_default(),
-                digest_text: row.get(6)?,
-                created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
-                    .unwrap_or_default().with_timezone(&chrono::Utc),
+        let digests = stmt
+            .query_map([], |row| {
+                let timeline_str: String = row.get(2)?;
+                let agg_str: String = row.get(3)?;
+                let events_str: String = row.get(4)?;
+                let topic_str: String = row.get(5)?;
+                let created_str: String = row.get(7)?;
+                Ok(crate::note::CrossEpisodeDigest {
+                    id: row.get(0)?,
+                    scope_id: row.get(1)?,
+                    entity_timeline: serde_json::from_str(&timeline_str).unwrap_or_default(),
+                    cross_aggregations: serde_json::from_str(&agg_str).unwrap_or_default(),
+                    events: serde_json::from_str(&events_str).unwrap_or_default(),
+                    topic_progression: serde_json::from_str(&topic_str).unwrap_or_default(),
+                    digest_text: row.get(6)?,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .unwrap_or_default()
+                        .with_timezone(&chrono::Utc),
+                })
             })
-        }).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         Ok(digests.filter_map(|r| r.ok()).collect())
     }
 
     // --- Atomic Fact Metadata (Phase Next) ---
 
-    async fn record_fact(&self, fact_id: &str, source_note_id: &str, ordinal: u32, subject: Option<&str>) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn record_fact(
+        &self,
+        fact_id: &str,
+        source_note_id: &str,
+        ordinal: u32,
+        subject: Option<&str>,
+    ) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute(
             "INSERT OR REPLACE INTO atomic_facts (id, source_note_id, ordinal, subject) VALUES (?1, ?2, ?3, ?4)",
             rusqlite::params![fact_id, source_note_id, ordinal, subject],
@@ -971,19 +1160,33 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_facts_by_subject(&self, subject: &str) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
-        let mut stmt = conn.prepare(
-            "SELECT id FROM atomic_facts WHERE subject = ?1 ORDER BY created_at"
-        ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
-        let ids = stmt.query_map(rusqlite::params![subject], |row| row.get(0))
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let mut stmt = conn
+            .prepare("SELECT id FROM atomic_facts WHERE subject = ?1 ORDER BY created_at")
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let ids = stmt
+            .query_map(rusqlite::params![subject], |row| row.get(0))
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(ids.filter_map(|r| r.ok()).collect())
     }
 
     // --- Episode Links (Phase Next) ---
 
-    async fn add_episode_link(&self, from_id: &str, to_id: &str, link_type: &str, entity: Option<&str>, reason: &str) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn add_episode_link(
+        &self,
+        from_id: &str,
+        to_id: &str,
+        link_type: &str,
+        entity: Option<&str>,
+        reason: &str,
+    ) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute(
             "INSERT OR IGNORE INTO episode_links (from_episode_id, to_episode_id, link_type, entity, reason) VALUES (?1, ?2, ?3, ?4, ?5)",
             rusqlite::params![from_id, to_id, link_type, entity, reason],
@@ -991,24 +1194,139 @@ impl crate::store::GraphStore for SqliteGraphStore {
         Ok(())
     }
 
-    async fn get_episode_links(&self, episode_id: &str) -> Result<Vec<(String, String, Option<String>)>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn get_episode_links(
+        &self,
+        episode_id: &str,
+    ) -> Result<Vec<(String, String, Option<String>)>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT to_episode_id, link_type, entity FROM episode_links WHERE from_episode_id = ?1 UNION SELECT from_episode_id, link_type, entity FROM episode_links WHERE to_episode_id = ?1"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
-        let links = stmt.query_map(rusqlite::params![episode_id], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-        }).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let links = stmt
+            .query_map(rusqlite::params![episode_id], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(links.filter_map(|r| r.ok()).collect())
     }
 
     async fn get_episodes_for_entity(&self, entity: &str) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT DISTINCT from_episode_id FROM episode_links WHERE entity = ?1 AND link_type = 'entity_continuity' UNION SELECT DISTINCT to_episode_id FROM episode_links WHERE entity = ?1 AND link_type = 'entity_continuity'"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
-        let ids = stmt.query_map(rusqlite::params![entity], |row| row.get(0))
+        let ids = stmt
+            .query_map(rusqlite::params![entity], |row| row.get(0))
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(ids.filter_map(|r| r.ok()).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cols_of(conn: &Connection, table: &str) -> Vec<String> {
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA table_info({})", table))
+            .unwrap();
+        stmt.query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect()
+    }
+
+    /// Running the migration twice must be a no-op on the second call and
+    /// preserve any rows already present.
+    #[test]
+    fn migrate_links_table_is_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        // New-schema table (what init() creates) — migration should be a no-op.
+        conn.execute_batch(
+            "CREATE TABLE links (
+                from_id TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                weight REAL NOT NULL DEFAULT 1.0,
+                link_type TEXT NOT NULL DEFAULT 'semantic',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (from_id, to_id, link_type)
+            );
+            INSERT INTO links (from_id, to_id, reason, weight, link_type, created_at)
+                VALUES ('a', 'b', 'r', 1.0, 'semantic', '2024-01-01T00:00:00Z');",
+        )
+        .unwrap();
+
+        SqliteGraphStore::migrate_links_table(&conn).expect("1st migrate");
+        SqliteGraphStore::migrate_links_table(&conn).expect("2nd migrate");
+
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM links", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 1, "row preserved across idempotent migrations");
+    }
+
+    /// Upgrading from the pre-ACTIVATE schema must add weight + link_type,
+    /// default existing rows to weight=1.0 / link_type='semantic', and
+    /// rebuild the PK to `(from_id, to_id, link_type)`.
+    #[test]
+    fn migrate_links_table_upgrades_legacy_schema() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Legacy schema: no weight / link_type, PK = (from_id, to_id).
+        conn.execute_batch(
+            "CREATE TABLE links (
+                from_id TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (from_id, to_id)
+            );
+            INSERT INTO links (from_id, to_id, reason, created_at)
+                VALUES ('a', 'b', 'legacy', '2024-01-01T00:00:00Z');",
+        )
+        .unwrap();
+
+        SqliteGraphStore::migrate_links_table(&conn).expect("migrate");
+
+        let cols = cols_of(&conn, "links");
+        assert!(cols.iter().any(|c| c == "weight"), "weight column added");
+        assert!(
+            cols.iter().any(|c| c == "link_type"),
+            "link_type column added"
+        );
+
+        let (weight, link_type): (f64, String) = conn
+            .query_row(
+                "SELECT weight, link_type FROM links WHERE from_id = 'a' AND to_id = 'b'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!((weight - 1.0).abs() < 1e-9, "default weight applied");
+        assert_eq!(link_type, "semantic", "default link_type applied");
+
+        // PK is (from_id, to_id, link_type): we should be able to insert a
+        // second row with a different link_type.
+        conn.execute(
+            "INSERT INTO links (from_id, to_id, reason, weight, link_type, created_at)
+                VALUES ('a', 'b', 'chain', 1.0, 'follows', '2024-01-02T00:00:00Z')",
+            [],
+        )
+        .expect("second row with different link_type should fit the new PK");
+
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM links WHERE from_id = 'a' AND to_id = 'b'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 2);
     }
 }

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
 use crate::error::Result;
-use crate::note::{AtomicFact, CrossEpisodeDigest, Episode, EpisodeDigest, ForesightSignal, MemoryNote};
+use crate::note::{
+    AtomicFact, CrossEpisodeDigest, Episode, EpisodeDigest, ForesightSignal, MemoryNote,
+};
 
 /// Stores note embeddings and metadata. Provides ANN similarity search.
 #[async_trait]
@@ -36,7 +38,9 @@ pub trait VectorStore: Send + Sync {
     // --- Atomic Facts (Phase Next) ---
 
     /// Insert or update an atomic fact with its embedding.
-    async fn upsert_fact(&self, _fact: &AtomicFact) -> Result<()> { Ok(()) }
+    async fn upsert_fact(&self, _fact: &AtomicFact) -> Result<()> {
+        Ok(())
+    }
 
     /// Find the top-K most similar atomic facts by embedding.
     async fn find_similar_facts(
@@ -44,17 +48,29 @@ pub trait VectorStore: Send + Sync {
         _embedding: &[f32],
         _top_k: usize,
         _exclude_source_note_ids: &[&str],
-    ) -> Result<Vec<(AtomicFact, f32)>> { Ok(Vec::new()) }
+    ) -> Result<Vec<(AtomicFact, f32)>> {
+        Ok(Vec::new())
+    }
 
     /// Get all facts for a given source note.
-    async fn get_facts_for_note(&self, _note_id: &str) -> Result<Vec<AtomicFact>> { Ok(Vec::new()) }
+    async fn get_facts_for_note(&self, _note_id: &str) -> Result<Vec<AtomicFact>> {
+        Ok(Vec::new())
+    }
 
     // --- ACTIVATE: access bookkeeping (Phase 7 — Trace) ---
 
     /// Record a single access: bump `access_count`, append `at` to
     /// `access_history` (capped at ACCESS_HISTORY_CAP), update `last_accessed_at`.
-    /// Default impl does a read-modify-write via `get` + `upsert`; stores with
-    /// native atomic update support may override for throughput.
+    ///
+    /// WARNING: The default implementation does a non-atomic
+    /// read-modify-write via `get` + `upsert`. Concurrent bumps can lose
+    /// increments, and because the entire note is re-upserted it can also
+    /// clobber concurrent content/context updates from other writers.
+    /// Production stores should override this with a native atomic update
+    /// (CAS / partial-row merge). Only safe for single-writer workloads or
+    /// when callers serialize access to each note id themselves. The
+    /// ACTIVATE phase_trace sample rate (`trace_sample_rate`) is the main
+    /// knob for bounding the write pressure this path generates.
     async fn bump_access(&self, id: &str, at: DateTime<Utc>) -> Result<()> {
         if let Some(mut note) = self.get(id).await? {
             note.record_access(at);
@@ -70,6 +86,22 @@ pub trait VectorStore: Send + Sync {
             self.bump_access(id, at).await?;
         }
         Ok(())
+    }
+
+    /// Find the most recent note in a given session (by turn_index, then
+    /// created_at). Used by the write path to re-hydrate the session-tail
+    /// cache after a restart.
+    ///
+    /// Default impl scans every note via `get_all()` and filters in-memory
+    /// (O(N) per session cold-start). Stores with indexed scan support
+    /// should override to push the filter down and use an ORDER BY.
+    async fn find_latest_by_session(&self, session_id: &str) -> Result<Option<MemoryNote>> {
+        // TODO: O(N) scan — Lance override pushes this to a filtered query.
+        let all = self.get_all().await?;
+        Ok(all
+            .into_iter()
+            .filter(|n| n.session_id.as_deref() == Some(session_id))
+            .max_by_key(|n| (n.turn_index.unwrap_or(0), n.created_at)))
     }
 }
 
@@ -148,6 +180,22 @@ pub trait GraphStore: Send + Sync {
         Ok(())
     }
 
+    /// Batched Hebbian bump for multiple co-activated pairs. Default impl
+    /// loops the single-pair method so stores that don't override keep
+    /// working. Stores with transaction support should override to commit
+    /// the whole batch atomically (see `SqliteGraphStore`).
+    async fn bump_link_weights_batch(
+        &self,
+        pairs: &[(&str, &str)],
+        delta: f32,
+        max: f32,
+    ) -> Result<()> {
+        for (a, b) in pairs {
+            let _ = self.bump_link_weight(a, b, delta, max).await;
+        }
+        Ok(())
+    }
+
     /// Apply multiplicative decay to every semantic edge: `weight = max(1.0, weight * factor)`.
     /// Called from `ForgetConfig` sweep. Default is a no-op.
     async fn decay_link_weights(&self, _factor: f32) -> Result<usize> {
@@ -165,7 +213,10 @@ pub trait GraphStore: Send + Sync {
     ) -> Result<()>;
 
     /// Get evolution history for a note.
-    async fn get_evolution_history(&self, note_id: &str) -> Result<Vec<crate::note::EvolutionRecord>>;
+    async fn get_evolution_history(
+        &self,
+        note_id: &str,
+    ) -> Result<Vec<crate::note::EvolutionRecord>>;
 
     // --- Dream state ---
 
@@ -180,51 +231,115 @@ pub trait GraphStore: Send + Sync {
 
     // --- Foresight signals (Phase 2B.2) ---
 
-    async fn upsert_foresight(&self, _signal: &ForesightSignal) -> Result<()> { Ok(()) }
-    async fn get_active_foresights(&self) -> Result<Vec<ForesightSignal>> { Ok(Vec::new()) }
-    async fn expire_foresights(&self, _before: chrono::DateTime<chrono::Utc>) -> Result<usize> { Ok(0) }
-    async fn get_foresights_for_note(&self, _note_id: &str) -> Result<Vec<ForesightSignal>> { Ok(Vec::new()) }
+    async fn upsert_foresight(&self, _signal: &ForesightSignal) -> Result<()> {
+        Ok(())
+    }
+    async fn get_active_foresights(&self) -> Result<Vec<ForesightSignal>> {
+        Ok(Vec::new())
+    }
+    async fn expire_foresights(&self, _before: chrono::DateTime<chrono::Utc>) -> Result<usize> {
+        Ok(0)
+    }
+    async fn get_foresights_for_note(&self, _note_id: &str) -> Result<Vec<ForesightSignal>> {
+        Ok(Vec::new())
+    }
 
     // --- Episodes (Phase 2B.1) ---
 
-    async fn upsert_episode(&self, _episode: &Episode) -> Result<()> { Ok(()) }
-    async fn get_episode(&self, _id: &str) -> Result<Option<Episode>> { Ok(None) }
-    async fn get_episodes_for_session(&self, _session_id: &str) -> Result<Vec<Episode>> { Ok(Vec::new()) }
-    async fn add_note_to_episode(&self, _note_id: &str, _episode_id: &str) -> Result<()> { Ok(()) }
-    async fn get_episode_for_note(&self, _note_id: &str) -> Result<Option<String>> { Ok(None) }
-    async fn get_notes_for_episode(&self, _episode_id: &str) -> Result<Vec<String>> { Ok(Vec::new()) }
+    async fn upsert_episode(&self, _episode: &Episode) -> Result<()> {
+        Ok(())
+    }
+    async fn get_episode(&self, _id: &str) -> Result<Option<Episode>> {
+        Ok(None)
+    }
+    async fn get_episodes_for_session(&self, _session_id: &str) -> Result<Vec<Episode>> {
+        Ok(Vec::new())
+    }
+    async fn add_note_to_episode(&self, _note_id: &str, _episode_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn get_episode_for_note(&self, _note_id: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+    async fn get_notes_for_episode(&self, _episode_id: &str) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 
     // --- Profiles (Phase 2B.3) ---
 
-    async fn upsert_profile(&self, _entity_id: &str, _note_id: &str) -> Result<()> { Ok(()) }
-    async fn get_profile_note_id(&self, _entity_id: &str) -> Result<Option<String>> { Ok(None) }
-    async fn get_all_profiles(&self) -> Result<Vec<(String, String)>> { Ok(Vec::new()) }
+    async fn upsert_profile(&self, _entity_id: &str, _note_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn get_profile_note_id(&self, _entity_id: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+    async fn get_all_profiles(&self) -> Result<Vec<(String, String)>> {
+        Ok(Vec::new())
+    }
 
     // --- Episode Digests (Phase Next) ---
 
-    async fn upsert_episode_digest(&self, _digest: &EpisodeDigest) -> Result<()> { Ok(()) }
-    async fn get_episode_digest(&self, _episode_id: &str) -> Result<Option<EpisodeDigest>> { Ok(None) }
-    async fn get_all_episode_digests(&self) -> Result<Vec<EpisodeDigest>> { Ok(Vec::new()) }
+    async fn upsert_episode_digest(&self, _digest: &EpisodeDigest) -> Result<()> {
+        Ok(())
+    }
+    async fn get_episode_digest(&self, _episode_id: &str) -> Result<Option<EpisodeDigest>> {
+        Ok(None)
+    }
+    async fn get_all_episode_digests(&self) -> Result<Vec<EpisodeDigest>> {
+        Ok(Vec::new())
+    }
     /// Get episode IDs that have no digest yet (for incremental dream processing).
-    async fn get_undigested_episode_ids(&self) -> Result<Vec<String>> { Ok(Vec::new()) }
+    async fn get_undigested_episode_ids(&self) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 
     // --- Cross-Episode Digests ---
 
-    async fn upsert_cross_episode_digest(&self, _digest: &CrossEpisodeDigest) -> Result<()> { Ok(()) }
-    async fn get_all_cross_episode_digests(&self) -> Result<Vec<CrossEpisodeDigest>> { Ok(Vec::new()) }
+    async fn upsert_cross_episode_digest(&self, _digest: &CrossEpisodeDigest) -> Result<()> {
+        Ok(())
+    }
+    async fn get_all_cross_episode_digests(&self) -> Result<Vec<CrossEpisodeDigest>> {
+        Ok(Vec::new())
+    }
 
     // --- Atomic Fact Metadata (Phase Next) ---
 
-    async fn record_fact(&self, _fact_id: &str, _source_note_id: &str, _ordinal: u32, _subject: Option<&str>) -> Result<()> { Ok(()) }
-    async fn get_facts_by_subject(&self, _subject: &str) -> Result<Vec<String>> { Ok(Vec::new()) }
+    async fn record_fact(
+        &self,
+        _fact_id: &str,
+        _source_note_id: &str,
+        _ordinal: u32,
+        _subject: Option<&str>,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn get_facts_by_subject(&self, _subject: &str) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 
     // --- Episode Links (Phase Next) ---
 
-    async fn add_episode_link(&self, _from_id: &str, _to_id: &str, _link_type: &str, _entity: Option<&str>, _reason: &str) -> Result<()> { Ok(()) }
+    async fn add_episode_link(
+        &self,
+        _from_id: &str,
+        _to_id: &str,
+        _link_type: &str,
+        _entity: Option<&str>,
+        _reason: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
     /// Returns (linked_episode_id, link_type, entity).
-    async fn get_episode_links(&self, _episode_id: &str) -> Result<Vec<(String, String, Option<String>)>> { Ok(Vec::new()) }
+    async fn get_episode_links(
+        &self,
+        _episode_id: &str,
+    ) -> Result<Vec<(String, String, Option<String>)>> {
+        Ok(Vec::new())
+    }
     /// Get all episode IDs linked to a given entity via entity_continuity.
-    async fn get_episodes_for_entity(&self, _entity: &str) -> Result<Vec<String>> { Ok(Vec::new()) }
+    async fn get_episodes_for_entity(&self, _entity: &str) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 
     // --- Lifecycle ---
 

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 
 use crate::error::Result;
 use crate::note::{AtomicFact, CrossEpisodeDigest, Episode, EpisodeDigest, ForesightSignal, MemoryNote};
@@ -47,6 +48,29 @@ pub trait VectorStore: Send + Sync {
 
     /// Get all facts for a given source note.
     async fn get_facts_for_note(&self, _note_id: &str) -> Result<Vec<AtomicFact>> { Ok(Vec::new()) }
+
+    // --- ACTIVATE: access bookkeeping (Phase 7 — Trace) ---
+
+    /// Record a single access: bump `access_count`, append `at` to
+    /// `access_history` (capped at ACCESS_HISTORY_CAP), update `last_accessed_at`.
+    /// Default impl does a read-modify-write via `get` + `upsert`; stores with
+    /// native atomic update support may override for throughput.
+    async fn bump_access(&self, id: &str, at: DateTime<Utc>) -> Result<()> {
+        if let Some(mut note) = self.get(id).await? {
+            note.record_access(at);
+            self.upsert(&note).await?;
+        }
+        Ok(())
+    }
+
+    /// Batch variant of `bump_access`. Override for a single transaction in
+    /// stores that support it.
+    async fn bump_access_many(&self, ids: &[&str], at: DateTime<Utc>) -> Result<()> {
+        for id in ids {
+            self.bump_access(id, at).await?;
+        }
+        Ok(())
+    }
 }
 
 /// Stores graph edges (links), evolution history, dream state,
@@ -67,6 +91,67 @@ pub trait GraphStore: Send + Sync {
     /// Get the number of links for a note (for graph-aware scoring).
     async fn get_link_count(&self, note_id: &str) -> Result<usize> {
         Ok(self.get_links(note_id).await?.len())
+    }
+
+    // --- ACTIVATE: typed + weighted links (Phases 2, 5b, 7) ---
+
+    /// Add a typed, weighted link. `link_type` is typically "semantic" or
+    /// "follows" (sequential). Direction of "follows" is preserved: it is a
+    /// single-direction edge (prev -> next) whose reverse is derived from
+    /// `turn_delta`.
+    async fn add_link_typed(
+        &self,
+        from_id: &str,
+        to_id: &str,
+        link_type: &str,
+        reason: &str,
+        weight: f32,
+    ) -> Result<()> {
+        let _ = (link_type, weight);
+        self.add_link(from_id, to_id, reason).await
+    }
+
+    /// Return (neighbor_id, weight) for a note. Optionally filter by link_type.
+    async fn get_links_with_weights(
+        &self,
+        note_id: &str,
+        _link_type: Option<&str>,
+    ) -> Result<Vec<(String, f32)>> {
+        Ok(self
+            .get_links(note_id)
+            .await?
+            .into_iter()
+            .map(|id| (id, 1.0_f32))
+            .collect())
+    }
+
+    /// Follow the "follows" chain from `note_id` in both directions up to
+    /// `radius` turns. Returns (neighbor_id, turn_delta) where delta is the
+    /// signed offset (negative = earlier turn, positive = later turn).
+    async fn get_sequential_neighbors(
+        &self,
+        _note_id: &str,
+        _radius: usize,
+    ) -> Result<Vec<(String, i32)>> {
+        Ok(Vec::new())
+    }
+
+    /// Hebbian strengthening: `weight = min(max, weight + delta)` on the
+    /// semantic edge between `from` and `to`. No-op if no edge exists.
+    async fn bump_link_weight(
+        &self,
+        _from_id: &str,
+        _to_id: &str,
+        _delta: f32,
+        _max: f32,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Apply multiplicative decay to every semantic edge: `weight = max(1.0, weight * factor)`.
+    /// Called from `ForgetConfig` sweep. Default is a no-op.
+    async fn decay_link_weights(&self, _factor: f32) -> Result<usize> {
+        Ok(0)
     }
 
     // --- Evolution history ---

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
-use crate::error::Result;
+use crate::error::{KartaError, Result};
 use crate::note::{
     AtomicFact, CrossEpisodeDigest, Episode, EpisodeDigest, ForesightSignal, MemoryNote,
 };
@@ -79,13 +79,18 @@ pub trait VectorStore: Send + Sync {
         Ok(())
     }
 
-    /// Batch variant of `bump_access`. Override for a single transaction in
-    /// stores that support it.
-    async fn bump_access_many(&self, ids: &[&str], at: DateTime<Utc>) -> Result<()> {
-        for id in ids {
-            self.bump_access(id, at).await?;
-        }
-        Ok(())
+    /// Batch variant of `bump_access`. Stores must override this with a native
+    /// partial update / transaction before enabling ACTIVATE trace writes.
+    ///
+    /// The old default looped through `bump_access`, which can devolve into a
+    /// full-note read-modify-write via `get` + `upsert`. That is not silently
+    /// safe for batch trace updates because concurrent writers can lose access
+    /// increments or overwrite note content/context. Return an explicit
+    /// unsupported error instead of pretending the unsafe fallback is atomic.
+    async fn bump_access_many(&self, _ids: &[&str], _at: DateTime<Utc>) -> Result<()> {
+        Err(KartaError::VectorStore(
+            "bump_access_many requires a store-specific atomic implementation".into(),
+        ))
     }
 
     /// Find the most recent note in a given session (by turn_index, then
@@ -191,7 +196,7 @@ pub trait GraphStore: Send + Sync {
         max: f32,
     ) -> Result<()> {
         for (a, b) in pairs {
-            let _ = self.bump_link_weight(a, b, delta, max).await;
+            self.bump_link_weight(a, b, delta, max).await?;
         }
         Ok(())
     }

--- a/crates/karta-core/src/write.rs
+++ b/crates/karta-core/src/write.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::Utc;
+use tokio::sync::RwLock;
 use tracing::{debug, info};
 use uuid::Uuid;
 
@@ -17,6 +19,10 @@ pub struct WriteEngine {
     llm: Arc<dyn LlmProvider>,
     config: WriteConfig,
     episode_config: EpisodeConfig,
+    /// Per-session "last note id" map used to emit typed "follows" links
+    /// that stitch consecutive turns together. Needed by the ACTIVATE PAS
+    /// channel so it can walk the sequential chain in either direction.
+    session_last_note: RwLock<HashMap<String, String>>,
 }
 
 impl WriteEngine {
@@ -33,7 +39,59 @@ impl WriteEngine {
             llm,
             config,
             episode_config,
+            session_last_note: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Look up the previous note id for a session. Hydrates from the vector
+    /// store on first lookup so sequential chains survive process restart.
+    async fn resolve_session_tail(&self, session_id: &str) -> Option<String> {
+        {
+            let g = self.session_last_note.read().await;
+            if let Some(id) = g.get(session_id) {
+                return Some(id.clone());
+            }
+        }
+        // Cold cache: scan for the most recent note with this session_id.
+        let candidate = self
+            .vector_store
+            .get_all()
+            .await
+            .ok()
+            .and_then(|all| {
+                all.into_iter()
+                    .filter(|n| n.session_id.as_deref() == Some(session_id))
+                    .max_by_key(|n| (n.turn_index.unwrap_or(0), n.created_at))
+                    .map(|n| n.id)
+            });
+        if let Some(ref id) = candidate {
+            let mut g = self.session_last_note.write().await;
+            g.insert(session_id.to_string(), id.clone());
+        }
+        candidate
+    }
+
+    /// Stamp a note with its session id + emit a "follows" edge from the
+    /// previous session tail. Safe to call once after persistence.
+    async fn emit_sequential_link(&self, session_id: &str, note: &mut MemoryNote) -> Result<()> {
+        note.session_id = Some(session_id.to_string());
+
+        let prev = self.resolve_session_tail(session_id).await;
+        if let Some(prev_id) = prev {
+            if prev_id != note.id {
+                // Single-direction edge prev -> next. Reverse is derived
+                // from turn_delta in get_sequential_neighbors.
+                let _ = self
+                    .graph_store
+                    .add_link_typed(&prev_id, &note.id, "follows", "sequential", 1.0)
+                    .await;
+            }
+        }
+        {
+            let mut g = self.session_last_note.write().await;
+            g.insert(session_id.to_string(), note.id.clone());
+        }
+        Ok(())
     }
 
     pub async fn add_note(&self, content: &str) -> Result<MemoryNote> {
@@ -227,7 +285,12 @@ impl WriteEngine {
         session_id: &str,
     ) -> Result<MemoryNote> {
         // First, add the note normally
-        let note = self.add_note(content).await?;
+        let mut note = self.add_note(content).await?;
+
+        // Stamp session_id + emit the "follows" edge from the previous
+        // session tail so PAS can walk the sequential chain later.
+        self.emit_sequential_link(session_id, &mut note).await?;
+        self.vector_store.upsert(&note).await?;
 
         if !self.episode_config.enabled {
             return Ok(note);
@@ -433,6 +496,9 @@ impl WriteEngine {
             last_accessed_at: Utc::now(),
             turn_index: None,
             source_timestamp: None,
+            access_count: 0,
+            access_history: Vec::new(),
+            session_id: None,
         };
 
         self.vector_store.upsert(&note).await?;

--- a/crates/karta-core/src/write.rs
+++ b/crates/karta-core/src/write.rs
@@ -45,6 +45,8 @@ impl WriteEngine {
 
     /// Look up the previous note id for a session. Hydrates from the vector
     /// store on first lookup so sequential chains survive process restart.
+    /// Uses the store's `find_latest_by_session` which stores may override
+    /// with an indexed query (Lance default impl is still an O(N) scan).
     async fn resolve_session_tail(&self, session_id: &str) -> Option<String> {
         {
             let g = self.session_last_note.read().await;
@@ -52,18 +54,13 @@ impl WriteEngine {
                 return Some(id.clone());
             }
         }
-        // Cold cache: scan for the most recent note with this session_id.
         let candidate = self
             .vector_store
-            .get_all()
+            .find_latest_by_session(session_id)
             .await
             .ok()
-            .and_then(|all| {
-                all.into_iter()
-                    .filter(|n| n.session_id.as_deref() == Some(session_id))
-                    .max_by_key(|n| (n.turn_index.unwrap_or(0), n.created_at))
-                    .map(|n| n.id)
-            });
+            .flatten()
+            .map(|n| n.id);
         if let Some(ref id) = candidate {
             let mut g = self.session_last_note.write().await;
             g.insert(session_id.to_string(), id.clone());
@@ -73,23 +70,31 @@ impl WriteEngine {
 
     /// Stamp a note with its session id + emit a "follows" edge from the
     /// previous session tail. Safe to call once after persistence.
+    ///
+    /// The cached session tail is advanced only after the edge write
+    /// succeeds (or when there is no previous tail to link from); a failed
+    /// `add_link_typed` propagates so the caller can retry without
+    /// silently losing the sequential chain.
     async fn emit_sequential_link(&self, session_id: &str, note: &mut MemoryNote) -> Result<()> {
         note.session_id = Some(session_id.to_string());
 
         let prev = self.resolve_session_tail(session_id).await;
-        if let Some(prev_id) = prev {
-            if prev_id != note.id {
+        match prev {
+            Some(prev_id) if prev_id != note.id => {
                 // Single-direction edge prev -> next. Reverse is derived
                 // from turn_delta in get_sequential_neighbors.
-                let _ = self
-                    .graph_store
+                self.graph_store
                     .add_link_typed(&prev_id, &note.id, "follows", "sequential", 1.0)
-                    .await;
+                    .await?;
+                let mut g = self.session_last_note.write().await;
+                g.insert(session_id.to_string(), note.id.clone());
             }
-        }
-        {
-            let mut g = self.session_last_note.write().await;
-            g.insert(session_id.to_string(), note.id.clone());
+            _ => {
+                // No prior tail (or self-link) — safe to advance the
+                // cache; there's nothing to link from.
+                let mut g = self.session_last_note.write().await;
+                g.insert(session_id.to_string(), note.id.clone());
+            }
         }
         Ok(())
     }
@@ -98,20 +103,17 @@ impl WriteEngine {
         let preview_end = {
             let max = 60;
             let mut end = content.len().min(max);
-            while end > 0 && !content.is_char_boundary(end) { end -= 1; }
+            while end > 0 && !content.is_char_boundary(end) {
+                end -= 1;
+            }
             end
         };
         info!("Adding note: \"{}...\"", &content[..preview_end]);
 
         // 1. Generate attributes + embed raw content in parallel
         let content_owned = content.to_string();
-        let embed_fut = async {
-            self.llm.embed(&[&content_owned]).await
-        };
-        let (attrs, raw_embeddings) = tokio::join!(
-            self.generate_attributes(content),
-            embed_fut
-        );
+        let embed_fut = async { self.llm.embed(&[&content_owned]).await };
+        let (attrs, raw_embeddings) = tokio::join!(self.generate_attributes(content), embed_fut);
         let attrs = attrs?;
         let raw_embedding = raw_embeddings?.into_iter().next().unwrap_or_default();
         debug!(context = %attrs.context, "Generated attributes");
@@ -129,12 +131,7 @@ impl WriteEngine {
             .await?;
 
         // 4. Compute enriched embedding for storage (content + context + keywords)
-        let embedding_text = format!(
-            "{} {} {}",
-            content,
-            note.context,
-            note.keywords.join(" ")
-        );
+        let embedding_text = format!("{} {} {}", content, note.context, note.keywords.join(" "));
         let enriched_embeddings = self.llm.embed(&[&embedding_text]).await?;
         note.embedding = enriched_embeddings.into_iter().next().unwrap_or_default();
 
@@ -147,7 +144,8 @@ impl WriteEngine {
 
         // 5. LLM decides which candidates to link
         let link_decisions = if !candidates.is_empty() {
-            self.decide_links(content, &note.context, &candidates).await?
+            self.decide_links(content, &note.context, &candidates)
+                .await?
         } else {
             Vec::new()
         };
@@ -159,10 +157,8 @@ impl WriteEngine {
             for decision in &link_decisions {
                 if let Some(existing) = self.vector_store.get(&decision.note_id).await? {
                     // Check evolution count — skip if over threshold (needs consolidation instead)
-                    let evolution_history = self
-                        .graph_store
-                        .get_evolution_history(&existing.id)
-                        .await?;
+                    let evolution_history =
+                        self.graph_store.get_evolution_history(&existing.id).await?;
 
                     if evolution_history.len() >= self.config.max_evolutions_per_note {
                         debug!(
@@ -238,14 +234,18 @@ impl WriteEngine {
 
         // 10. Store atomic facts (each with its own embedding for fine-grained retrieval)
         if !attrs.atomic_facts.is_empty() {
-            let fact_texts: Vec<&str> = attrs.atomic_facts.iter()
+            let fact_texts: Vec<&str> = attrs
+                .atomic_facts
+                .iter()
                 .take(self.config.max_facts_per_note)
                 .map(|f| f.content.as_str())
                 .collect();
 
             match self.llm.embed(&fact_texts).await {
                 Ok(fact_embeddings) => {
-                    for (i, (extraction, embedding)) in attrs.atomic_facts.iter()
+                    for (i, (extraction, embedding)) in attrs
+                        .atomic_facts
+                        .iter()
                         .take(5)
                         .zip(fact_embeddings)
                         .enumerate()
@@ -260,9 +260,10 @@ impl WriteEngine {
                         fact.created_at = note.created_at;
 
                         let _ = self.vector_store.upsert_fact(&fact).await;
-                        let _ = self.graph_store.record_fact(
-                            &fact.id, &note.id, i as u32, fact.subject.as_deref()
-                        ).await;
+                        let _ = self
+                            .graph_store
+                            .record_fact(&fact.id, &note.id, i as u32, fact.subject.as_deref())
+                            .await;
                     }
                     debug!(count = fact_texts.len(), note_id = %note.id, "Stored atomic facts");
                 }
@@ -308,9 +309,7 @@ impl WriteEngine {
         let should_new_episode = match current_episode {
             None => true,
             Some(ep) => {
-                let time_gap = Utc::now()
-                    .signed_duration_since(ep.end_time)
-                    .num_seconds();
+                let time_gap = Utc::now().signed_duration_since(ep.end_time).num_seconds();
 
                 // Hard boundary: time gap exceeds threshold
                 if time_gap > self.episode_config.time_gap_threshold_secs {
@@ -330,12 +329,8 @@ impl WriteEngine {
                     if last_note_content.is_empty() {
                         false
                     } else {
-                        self.detect_episode_boundary(
-                            &last_note_content,
-                            content,
-                            time_gap,
-                        )
-                        .await?
+                        self.detect_episode_boundary(&last_note_content, content, time_gap)
+                            .await?
                     }
                 }
             }
@@ -353,9 +348,7 @@ impl WriteEngine {
             episode.topic_tags = tags;
 
             // Create narrative note
-            let narrative_note = self
-                .create_narrative_note(&narrative, &episode.id)
-                .await?;
+            let narrative_note = self.create_narrative_note(&narrative, &episode.id).await?;
             episode.narrative_note_id = Some(narrative_note.id.clone());
 
             self.graph_store.upsert_episode(&episode).await?;
@@ -371,10 +364,7 @@ impl WriteEngine {
                 .await?;
 
             // Re-synthesize narrative with all notes in the episode
-            let all_note_ids = self
-                .graph_store
-                .get_notes_for_episode(&ep.id)
-                .await?;
+            let all_note_ids = self.graph_store.get_notes_for_episode(&ep.id).await?;
             let all_refs: Vec<&str> = all_note_ids.iter().map(|s| s.as_str()).collect();
             let all_notes = self.vector_store.get_many(&all_refs).await?;
             let contents: Vec<&str> = all_notes.iter().map(|n| n.content.as_str()).collect();
@@ -427,8 +417,7 @@ impl WriteEngine {
         ];
 
         let response = self.llm.chat(&messages, &GenConfig::default()).await?;
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         // If sameEpisode is false, we need a new episode
         Ok(!parsed["sameEpisode"].as_bool().unwrap_or(true))
@@ -454,8 +443,7 @@ impl WriteEngine {
         ];
 
         let response = self.llm.chat(&messages, &GenConfig::default()).await?;
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         let narrative = parsed["narrative"]
             .as_str()
@@ -463,17 +451,17 @@ impl WriteEngine {
             .to_string();
         let tags = parsed["topicTags"]
             .as_array()
-            .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
             .unwrap_or_default();
 
         Ok((narrative, tags))
     }
 
-    async fn create_narrative_note(
-        &self,
-        narrative: &str,
-        episode_id: &str,
-    ) -> Result<MemoryNote> {
+    async fn create_narrative_note(&self, narrative: &str, episode_id: &str) -> Result<MemoryNote> {
         let embeddings = self.llm.embed(&[narrative]).await?;
         let embedding = embeddings.into_iter().next().unwrap_or_default();
 
@@ -526,21 +514,25 @@ impl WriteEngine {
 
         let response = self.llm.chat(&messages, &config).await?;
 
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         Ok(NoteAttributes {
-            context: parsed["context"]
-                .as_str()
-                .unwrap_or(content)
-                .to_string(),
+            context: parsed["context"].as_str().unwrap_or(content).to_string(),
             keywords: parsed["keywords"]
                 .as_array()
-                .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
                 .unwrap_or_default(),
             tags: parsed["tags"]
                 .as_array()
-                .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
                 .unwrap_or_default(),
             foresight_signals: parsed["foresight_signals"]
                 .as_array()
@@ -557,9 +549,7 @@ impl WriteEngine {
                             } else {
                                 Some(crate::note::ForesightExtraction {
                                     content: v["content"].as_str()?.to_string(),
-                                    valid_until: v["valid_until"]
-                                        .as_str()
-                                        .map(String::from),
+                                    valid_until: v["valid_until"].as_str().map(String::from),
                                 })
                             }
                         })
@@ -617,8 +607,7 @@ impl WriteEngine {
 
         let response = self.llm.chat(&messages, &GenConfig::default()).await?;
 
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         let links = parsed["links"]
             .as_array()
@@ -662,8 +651,7 @@ impl WriteEngine {
 
         let response = self.llm.chat(&messages, &GenConfig::default()).await?;
 
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         Ok(parsed["updatedContext"]
             .as_str()

--- a/crates/karta-core/tests/activate_retrieval_invariants.rs
+++ b/crates/karta-core/tests/activate_retrieval_invariants.rs
@@ -1,0 +1,237 @@
+//! Retrieval-invariant tests for the ACTIVATE pipeline, Existence mode in
+//! particular.
+//!
+//! Targets the Hebbian-suppression regression diagnosed in BEAM Conv 1 Q4
+//! (see commits `229818c` and `f5f4e81`): in the unfixed state, the
+//! Existence-mode channel weights let Hebbian co-activation pull a cluster
+//! of "consistent" notes to the top and shove a single contradicting
+//! outlier out of the returned pool. The fix is to drop `hebbian` to 0.0
+//! and raise `facts`/`integration` for Existence mode.
+//!
+//! These tests are deterministic (no OpenAI calls, no LLM judging, no
+//! randomness) via `MockLlmProvider`, whose embedding function is a
+//! word-hash projection so texts that share words have higher cosine
+//! similarity.
+//!
+//! ## Discrimination caveat
+//!
+//! Test 1 asserts two things that *do* discriminate under MockLlmProvider:
+//! (1) an Existence-style query classifies into `QueryMode::Existence` (so
+//! the Existence channel-weight row is selected at all — catches prototype
+//! and keyword-fallback regressions), and (2) end-to-end retrieval still
+//! surfaces the contradicting outlier in top-K at a modest flood-cluster
+//! size.
+//!
+//! It does *not* reliably discriminate the `hebbian` weight value on its
+//! own — MockLlmProvider's linking produces a sparse Hebbian graph and
+//! extracts zero atomic facts, so the `hebbian`/`facts`/`integration`
+//! channels contribute little RRF mass under this fixture. A
+//! full-scale discrimination test requires real embeddings + real LLM
+//! linking, which is what BEAM Conv 1 Q4 provides. See the report that
+//! accompanied this commit for the empirical numbers.
+//!
+//! Run: `cargo test -p karta-core --test activate_retrieval_invariants`
+
+use std::sync::Arc;
+
+use karta_core::Karta;
+use karta_core::config::KartaConfig;
+use karta_core::llm::{LlmProvider, MockLlmProvider};
+use karta_core::store::lance::LanceVectorStore;
+use karta_core::store::sqlite::SqliteGraphStore;
+use karta_core::store::{GraphStore, VectorStore};
+
+/// Build a Karta instance backed by real LanceDB + SQLite, wired to
+/// `MockLlmProvider`. Each invocation gets its own scratch directory under
+/// `/tmp` so tests are isolated and can run in parallel.
+///
+/// Mirrors the fixture patterns in `tests/eval.rs` and `tests/bench_beam.rs`.
+async fn make_karta(enable_activate: bool, label: &str) -> Karta {
+    // Unique suffix per call so parallel tests (and repeated runs) don't
+    // collide on the same LanceDB / SQLite files.
+    let suffix = uuid::Uuid::new_v4().to_string();
+    let data_dir = format!("/tmp/karta-invariant-{}-{}", label, &suffix[..8]);
+    let _ = std::fs::remove_dir_all(&data_dir);
+
+    let vector_store =
+        Arc::new(LanceVectorStore::new(&data_dir).await.unwrap()) as Arc<dyn VectorStore>;
+    let graph_store = Arc::new(SqliteGraphStore::new(&data_dir).unwrap()) as Arc<dyn GraphStore>;
+    let llm = Arc::new(MockLlmProvider::new()) as Arc<dyn LlmProvider>;
+
+    let mut config = KartaConfig::default();
+    config.read.activate.enabled = enable_activate;
+
+    Karta::new(vector_store, graph_store, llm, config)
+        .await
+        .unwrap()
+}
+
+/// **Core invariant.** An Existence-classified query that asks whether the
+/// user has *ever* said something must surface a contradicting outlier note
+/// even when the ANN pool is dominated by a large consistent cluster.
+///
+/// If the Existence channel weights regress (e.g. `hebbian` goes back above
+/// 0.0), the flood cluster's Hebbian co-activation boosts push the
+/// contradicting note out of the top-K.
+#[tokio::test]
+async fn existence_mode_surfaces_contradicting_note() {
+    let karta = make_karta(true, "existence-contradicting").await;
+
+    // 1 contradicting outlier note. Phrased to share multiple meaningful
+    // words with the query ("have", "never", "integrated", "flask-login") so
+    // the ANN channel can place it within the anchor pool.
+    karta
+        .add_note(
+            "I have never integrated Flask-Login in this project — \
+             rolled my own session system instead.",
+        )
+        .await
+        .unwrap();
+
+    // 10 consistent notes that claim the opposite. We vary the wording per
+    // note so ANN sees distinct embeddings while the shared "Flask-Login
+    // integration" token still forms a Hebbian cluster (MockLlmProvider's
+    // linking threshold is 2+ shared words >4 chars, which this wording
+    // satisfies). Empirically under MockLlmProvider this size keeps the
+    // contradicting outlier reliably in top-10 when the pipeline is
+    // healthy; much larger pools saturate the RRF fusion and the outlier
+    // drops out regardless of channel weights (see module-level
+    // discrimination caveat).
+    let variations = [
+        "configured login_manager and user loader",
+        "wired up session cookies with remember_me",
+        "added UserMixin to the User model",
+        "debugging login_required decorator behavior",
+        "extended UserMixin with role flags",
+        "serialized user ids through flask_login",
+    ];
+    for i in 0..10 {
+        let variation = variations[i % variations.len()];
+        let note = format!(
+            "Day {}: working on Flask-Login integration today — {}.",
+            i, variation
+        );
+        karta.add_note(&note).await.unwrap();
+    }
+
+    // Existence-style question. Wording chosen to overlap with the
+    // Existence prototype set ("Have I been inconsistent about my
+    // preferences?", "Is it true that I contradicted myself about the
+    // tool?") and the keyword-fallback trigger ("contradict"), so the
+    // classifier routes it into Existence mode whether it is running on
+    // the embedding centroid path or the keyword fallback.
+    let query = "Have I contradicted myself about Flask-Login integration? \
+                 Did I ever say I have never integrated it?";
+
+    // --- Sub-assertion A: the query classifies as Existence mode. ---
+    // ask() exposes the classified mode in its result, which is the only
+    // externally-observable channel selector. Catches regressions in the
+    // prototype set (like 229818c → f5f4e81) or the keyword-fallback list.
+    let ask_result = karta.ask(query, 10).await.unwrap();
+    assert_eq!(
+        ask_result.query_mode, "Existence",
+        "An Existence-style query must classify into `QueryMode::Existence` so \
+         the Existence channel-weight row is applied. If this fails, the \
+         prototype set or keyword-fallback list regressed. Got: {:?}",
+        ask_result.query_mode
+    );
+
+    // --- Sub-assertion B: end-to-end retrieval surfaces the contradicting note. ---
+    let results = karta.search(query, 10).await.unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "Existence-mode retrieval returned zero results — fixture broken."
+    );
+
+    let contents: Vec<&str> = results.iter().map(|r| r.note.content.as_str()).collect();
+
+    assert!(
+        contents.iter().any(|c| c.contains("never integrated")),
+        "Existence-mode retrieval must surface the contradicting outlier \
+         note when the ANN pool is dominated by a consistent cluster. \
+         If this fails, the retrieval pipeline (or the Existence channel \
+         weights — hebbian=0.0, facts=1.3, integration=1.0 per \
+         `default_activate_channel_weights` in `config.rs`) may have \
+         regressed. Top-{} contents: {:#?}",
+        contents.len(),
+        contents
+    );
+}
+
+/// **Baseline control.** With ACTIVATE disabled, the legacy scalar scorer
+/// still returns *some* results for the same data. Guards against a broken
+/// test fixture: if this fails, the failure in Test 1 would not be
+/// attributable to the Existence channel-weights invariant.
+#[tokio::test]
+async fn baseline_standard_mode_without_activate_returns_results() {
+    let karta = make_karta(false, "baseline").await;
+
+    karta
+        .add_note("I have never integrated Flask-Login in this project.")
+        .await
+        .unwrap();
+    for i in 0..5 {
+        let note = format!("Day {}: working on Flask-Login integration today.", i);
+        karta.add_note(&note).await.unwrap();
+    }
+
+    let results = karta.search("Flask-Login integration", 5).await.unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "Baseline (ACTIVATE off) retrieval returned zero results — \
+         fixture infrastructure is broken, not the ACTIVATE invariant."
+    );
+}
+
+/// **Embedding-discrimination control.** MockLlmProvider's word-hash
+/// embedding must produce enough shared-word similarity for the Flask-Login
+/// note to rank above unrelated content. If this test fails, Test 1 cannot
+/// be trusted — its premise depends on embedding similarity tracking
+/// lexical overlap.
+#[tokio::test]
+async fn ann_retrieval_finds_keyword_matches() {
+    let karta = make_karta(false, "ann-control").await;
+
+    karta
+        .add_note("Recipe for homemade pasta carbonara with pancetta and eggs.")
+        .await
+        .unwrap();
+    karta
+        .add_note("Observations of Jupiter's moons through my backyard telescope.")
+        .await
+        .unwrap();
+    karta
+        .add_note("Gardening tips for tomato plants in clay-heavy soil.")
+        .await
+        .unwrap();
+    karta
+        .add_note("Python snakes require precise humidity and temperature control.")
+        .await
+        .unwrap();
+    karta
+        .add_note("Bicycle repair: adjusting derailleur and cable tension.")
+        .await
+        .unwrap();
+    karta
+        .add_note("Wired up Flask-Login session handling for the auth module.")
+        .await
+        .unwrap();
+
+    let results = karta.search("Flask-Login session", 3).await.unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "ANN control returned zero results — fixture broken."
+    );
+
+    let top_three: Vec<&str> = results.iter().map(|r| r.note.content.as_str()).collect();
+
+    assert!(
+        top_three.iter().any(|c| c.contains("Flask-Login")),
+        "MockLlmProvider's word-hash embedding must rank a Flask-Login \
+         note above unrelated topics. Top-3 contents: {:#?}",
+        top_three
+    );
+}


### PR DESCRIPTION
Introduces a 6-phase retrieval pipeline grounded in cognitive-science primitives and IR rank-fusion, behind the ReadConfig.activate.enabled flag (also toggled via KARTA_ACTIVATE_ENABLED env var). The existing search_wide() scalar scorer remains the production path and is used as fallback when the flag is off, so the 61.6% BEAM baseline is preserved.

Schema additions:
- MemoryNote: access_count, access_history (ring buffer, cap 8), session_id
- LanceDB notes table: 3 new nullable columns + fail-fast add_columns migration (propagates error so writer/reader schemas can't diverge); batch_to_notes uses column_by_name for legacy-row read tolerance
- SQLite links table: weight REAL + link_type TEXT with composite PK (from_id, to_id, link_type); one-shot rebuild migration on init using unchecked_transaction (auto-rollback on failure)

Storage trait extensions (all default no-op or O(N) fallback):
- VectorStore: bump_access, bump_access_many, find_latest_by_session
- GraphStore: add_link_typed, get_links_with_weights, get_sequential_neighbors, bump_link_weight, bump_link_weights_batch, decay_link_weights

New crates/karta-core/src/activate.rs implements:
- phase_anchor: ANN + atomic-facts + profiles + foresight channels
- phase_coactivation: Hebbian, top-K weighted neighbors per anchor
- phase_actr: ACT-R base-level learning B = ln(Sum t_k^-d)
- phase_integration: multi-hop BFS from anchors over **semantic** edges only (follows edges are exclusive to PAS, so Integration and PAS don't double-count session-chain neighbors)
- phase_rerank: cross-encoder channel
- phase_pas: Temporal-only sequential walk over follows chain
- phase_aggregate: RRF with per-QueryMode channel weights
- phase_trace: bump_access_many + batched Hebbian edge strengthening, **invoked from read.rs after result truncation** (not inside activate()) so activation state only trains on results that actually reach the caller

ActivateConfig lifts previously-magic numbers into explicit knobs:
- anchor_top_k (default 10)
- facts_min_score (default 0.3)
- integration_bfs_cap (default 64)

Per-QueryMode channel weights merge user-provided TOML overrides over the built-in default matrix via a custom Deserialize, so partial overrides (e.g. tweaking only Temporal.pas) don't silently wipe the other five modes. QueryMode→key lookup uses QueryMode::as_str() instead of the Debug formatter so variant renames are caught at compile time rather than at runtime.

Write path emits "follows" links from the previous session tail, so the PAS channel can walk the sequential chain; the session-tail map is hydrated lazily on first write per session via find_latest_by_session (default O(N) scan — TODO: indexed override on LanceDB). Follows-edge write failures now propagate and the session-tail cache only advances on success, so a broken edge can't strand the chain.

ForgetConfig gains actr_decay_floor and link_weight_decay. The sweep caller is not yet wired to decay_link_weights -- explicit follow-up.

Verification: cargo test -p karta-core --lib passes 15/15 (ACT-R monotonicity + temporal decay, RRF rank merging, RRF weight scaling, zero-weight and missing-channel handling, sampling bounds, channel_weights partial-override merge semantics + full-default fallback, QueryMode::as_str() coverage of the default weight matrix, SQLite links-table migration idempotence + legacy-schema upgrade, phase_trace batch path). Full workspace builds clean on rustc 1.95.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ACTIVATE: multi‑phase fused retrieval yields more relevant, diversified search results (including temporal sequencing and optional reranking).
  * Notes now record access counts/history and session IDs to improve recency and session-aware ranking and linking.
  * Session sequencing automatically links consecutive notes to preserve conversation flow.

* **Chores**
  * Storage schema upgrades and link‑weighting support for better related‑item discovery.

* **Tests**
  * Deterministic integration tests validating retrieval modes and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->