### PR TITLE
feat: migration and operational hardening (#11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,16 +44,12 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
-      # rustfmt + clippy -D warnings are intentionally lenient today — the
-      # tree has pre-existing style drift that will be cleaned up in a
-      # dedicated PR. For now, these run as informational checks so we at
-      # least surface regressions without blocking on the historical debt.
-      - name: rustfmt (informational)
-        run: cargo fmt --all -- --check || echo "::warning::fmt drift detected; not blocking CI yet"
+      # rustfmt and clippy are strict CI gates; formatting or lint warnings fail the run.
+      - name: rustfmt
+        run: cargo fmt --all -- --check
 
-      - name: clippy (informational)
-        run: cargo clippy --workspace --all-targets 2>&1 | tee clippy.log
-        # No -D warnings yet; see above.
+      - name: clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: build
         run: cargo build --workspace --all-targets

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ system could find because they were never explicitly stored.
 - **Provenance tracking** — every note tagged as FACT or INFERRED with confidence scores
 - **Forgetting** — note lifecycle (Active → Deprecated → Superseded → Archived) with access-based decay
 - **Embedded by default** — LanceDB + SQLite, zero infrastructure. `cargo add karta` and go.
+- **Schema versioning & health checks** — idempotent migrations, `Karta::health_check()`, `schema_meta` table tracks applied migrations
+- **Schema versioning & health checks** — idempotent migrations, `Karta::health_check()`, `schema_meta` table tracks applied migrations
 
 ## Quick Start
 
@@ -55,6 +57,7 @@ async fn main() {
 Write Path:  content → LLM attributes → embed → ANN search → link → evolve → store
 Read Path:   query → embed → ANN → rerank → multi-hop traverse → synthesize
 Dream Path:  cluster notes → deduction/induction/abduction/consolidation/contradiction → persist
+Health:      health_check() → vector store + graph store + schema version + pending migrations
 ```
 
 ### Storage (trait-based, pluggable)
@@ -156,6 +159,9 @@ karta/
 ```bash
 # Run tests (mock LLM, no API keys needed)
 cargo test
+
+# Run synthetic memory evals (zero API keys, deterministic)
+cargo test -p karta-core --test synthetic_memory_eval
 
 # Run real eval (requires .env credentials)
 cargo test --test real_eval -- --ignored --nocapture

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ system could find because they were never explicitly stored.
 - **Cross-encoder reranking** — Jina AI reranker for precise relevance scoring and intelligent abstention
 - **Temporal awareness** — exponential decay scoring, foresight signals with validity windows
 - **Provenance tracking** — every note tagged as FACT or INFERRED with confidence scores
+- **Forgetting engine** — `Karta::run_forgetting()` archives stale low-activation notes, `Karta::preview_forgetting()` dry-runs without mutations, exponential decay scoring with protected notes (profiles, episodes)
 - **Forgetting** — note lifecycle (Active → Deprecated → Superseded → Archived) with access-based decay
 - **Procedural memory** — `RuleEngine` with safe `ProceduralRule` DSL (query/session/contradiction conditions → prompt/retrieval actions only), fire-count tracking, note-sourced rules protected from forgetting
 - **Evidence packets** — `AskResult` exposes an optional `EvidencePacket` slot for per-channel rank traces, fired rule IDs, contradiction IDs, and human-readable "why retrieved" explanations; current read paths return `evidence: None` until ACTIVATE populates it
 - **Deterministic extractors** — `Extractor` trait with Markdown (headings, links, code fences), JSON (recursive paths), YAML (key-value), and Cargo.toml (metadata, dependency edges) extractors that run before LLM extraction
+- **Embedded by default** — LanceDB + SQLite, zero infrastructure. `cargo add karta` and go.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -157,12 +157,17 @@ karta/
 # Run tests (mock LLM, no API keys needed)
 cargo test
 
+# Run synthetic memory evals (zero API keys, deterministic)
+cargo test -p karta-core --test synthetic_memory_eval
+
 # Run real eval (requires .env credentials)
 cargo test --test real_eval -- --ignored --nocapture
 
 # Run BEAM benchmark
 BEAM_DATASET_PATH=data/beam-100k.json cargo test --test beam_100k beam_100k_single -- --ignored --nocapture
 ```
+
+CI gates on every PR: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo nextest run --workspace --no-fail-fast`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ system could find because they were never explicitly stored.
 - **Temporal awareness** — exponential decay scoring, foresight signals with validity windows
 - **Provenance tracking** — every note tagged as FACT or INFERRED with confidence scores
 - **Forgetting** — note lifecycle (Active → Deprecated → Superseded → Archived) with access-based decay
-- **Embedded by default** — LanceDB + SQLite, zero infrastructure. `cargo add karta` and go.
+- **Deterministic extractors** — `Extractor` trait with Markdown (headings, links, code fences), JSON (recursive paths), YAML (key-value), and Cargo.toml (metadata, dependency edges) extractors that run before LLM extraction
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ system could find because they were never explicitly stored.
 - **Temporal awareness** — exponential decay scoring, foresight signals with validity windows
 - **Provenance tracking** — every note tagged as FACT or INFERRED with confidence scores
 - **Forgetting** — note lifecycle (Active → Deprecated → Superseded → Archived) with access-based decay
+- **Evidence packets** — `AskResult` exposes an optional `EvidencePacket` slot for per-channel rank traces, fired rule IDs, contradiction IDs, and human-readable "why retrieved" explanations; current read paths return `evidence: None` until ACTIVATE populates it
 - **Deterministic extractors** — `Extractor` trait with Markdown (headings, links, code fences), JSON (recursive paths), YAML (key-value), and Cargo.toml (metadata, dependency edges) extractors that run before LLM extraction
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ system could find because they were never explicitly stored.
 - **Temporal awareness** — exponential decay scoring, foresight signals with validity windows
 - **Provenance tracking** — every note tagged as FACT or INFERRED with confidence scores
 - **Forgetting** — note lifecycle (Active → Deprecated → Superseded → Archived) with access-based decay
+- **Procedural memory** — `RuleEngine` with safe `ProceduralRule` DSL (query/session/contradiction conditions → prompt/retrieval actions only), fire-count tracking, note-sourced rules protected from forgetting
 - **Evidence packets** — `AskResult` exposes an optional `EvidencePacket` slot for per-channel rank traces, fired rule IDs, contradiction IDs, and human-readable "why retrieved" explanations; current read paths return `evidence: None` until ACTIVATE populates it
 - **Deterministic extractors** — `Extractor` trait with Markdown (headings, links, code fences), JSON (recursive paths), YAML (key-value), and Cargo.toml (metadata, dependency edges) extractors that run before LLM extraction
 

--- a/crates/karta-core/src/config.rs
+++ b/crates/karta-core/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct KartaConfig {
     pub storage: StorageConfig,
     pub llm: LlmConfig,
@@ -11,21 +11,6 @@ pub struct KartaConfig {
     pub episode: EpisodeConfig,
     pub forget: ForgetConfig,
     pub reranker: crate::rerank::RerankerConfig,
-}
-
-impl Default for KartaConfig {
-    fn default() -> Self {
-        Self {
-            storage: StorageConfig::default(),
-            llm: LlmConfig::default(),
-            read: ReadConfig::default(),
-            write: WriteConfig::default(),
-            dream: DreamConfig::default(),
-            episode: EpisodeConfig::default(),
-            forget: ForgetConfig::default(),
-            reranker: Default::default(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/karta-core/src/dream/engine.rs
+++ b/crates/karta-core/src/dream/engine.rs
@@ -35,11 +35,7 @@ impl DreamEngine {
         }
     }
 
-    pub async fn run(
-        &self,
-        scope_type: &str,
-        scope_id: &str,
-    ) -> Result<DreamRun> {
+    pub async fn run(&self, scope_type: &str, scope_id: &str) -> Result<DreamRun> {
         let run_id = Uuid::new_v4().to_string();
         let started_at = Utc::now();
         let mut total_tokens: u64 = 0;
@@ -111,7 +107,7 @@ impl DreamEngine {
             .config
             .enabled_types
             .iter()
-            .filter_map(|s| DreamType::from_str(s))
+            .filter_map(|s| s.parse::<DreamType>().ok())
             .collect();
 
         // Per-cluster dreams (with dedup)
@@ -182,21 +178,49 @@ impl DreamEngine {
             debug!(count = undigested.len(), "Undigested episodes found");
 
             for episode_id in &undigested {
-                if let Ok(Some(episode)) = self.graph_store.get_episode(&episode_id).await {
-                    if !episode.note_ids.is_empty() {
-                        let note_refs: Vec<&str> = episode.note_ids.iter().map(|s| s.as_str()).collect();
-                        if let Ok(ep_notes) = self.vector_store.get_many(&note_refs).await {
-                            match self.dream_episode_digest(&episode, &ep_notes).await {
-                                Ok((dream, tokens)) => {
-                                    total_tokens += tokens;
-                                    if dream.would_write {
-                                        let _ = self.persist_dream(&dream).await;
+                match self.graph_store.get_episode(episode_id).await {
+                    Ok(Some(episode)) if episode.note_ids.is_empty() => {
+                        let digest = crate::note::EpisodeDigest {
+                            id: Uuid::new_v4().to_string(),
+                            episode_id: episode.id.clone(),
+                            entities: Vec::new(),
+                            date_range: None,
+                            aggregations: Vec::new(),
+                            topic_sequence: Vec::new(),
+                            digest_text: String::new(),
+                            digest_note_id: None,
+                            events: Vec::new(),
+                            created_at: Utc::now(),
+                        };
+                        self.graph_store.upsert_episode_digest(&digest).await?;
+                        debug!(episode_id = %episode_id, "Marked empty episode as digested");
+                    }
+                    Ok(Some(episode)) => {
+                        let note_refs: Vec<&str> =
+                            episode.note_ids.iter().map(|s| s.as_str()).collect();
+                        match self.vector_store.get_many(&note_refs).await {
+                            Ok(ep_notes) => {
+                                match self.dream_episode_digest(&episode, &ep_notes).await {
+                                    Ok((dream, tokens)) => {
+                                        total_tokens += tokens;
+                                        if dream.would_write {
+                                            let _ = self.persist_dream(&dream).await;
+                                        }
+                                        dreams.push(dream);
                                     }
-                                    dreams.push(dream);
+                                    Err(e) => {
+                                        debug!(episode_id = %episode_id, error = %e, "Episode digest failed")
+                                    }
                                 }
-                                Err(e) => debug!(episode_id = %episode_id, error = %e, "Episode digest failed"),
+                            }
+                            Err(e) => {
+                                debug!(episode_id = %episode_id, error = %e, "Failed to fetch notes for episode digest")
                             }
                         }
+                    }
+                    Ok(None) => debug!(episode_id = %episode_id, "Undigested episode id not found"),
+                    Err(e) => {
+                        debug!(episode_id = %episode_id, error = %e, "Failed to load episode for digest")
                     }
                 }
             }
@@ -207,11 +231,15 @@ impl DreamEngine {
             let all_digests = self.graph_store.get_all_episode_digests().await?;
             if all_digests.len() >= 3 {
                 for chunk in all_digests.chunks(10) {
-                    if chunk.len() < 3 { continue; }
+                    if chunk.len() < 3 {
+                        continue;
+                    }
                     match self.dream_cross_episode_digest(chunk).await {
                         Ok((dream, tokens)) => {
                             total_tokens += tokens;
-                            if dream.would_write && !self.is_duplicate_dream(&dream).await.unwrap_or(false) {
+                            if dream.would_write
+                                && !self.is_duplicate_dream(&dream).await.unwrap_or(false)
+                            {
                                 let _ = self.persist_dream(&dream).await;
                             }
                             dreams.push(dream);
@@ -301,10 +329,7 @@ impl DreamEngine {
         }
 
         // Only return clusters with 2+ notes
-        Ok(clusters
-            .into_values()
-            .filter(|c| c.len() >= 2)
-            .collect())
+        Ok(clusters.into_values().filter(|c| c.len() >= 2).collect())
     }
 
     // --- Dream types ---
@@ -326,10 +351,7 @@ impl DreamEngine {
             .join("\n\n")
     }
 
-    async fn run_dream_prompt(
-        &self,
-        prompt: &str,
-    ) -> Result<(serde_json::Value, u64)> {
+    async fn run_dream_prompt(&self, prompt: &str) -> Result<(serde_json::Value, u64)> {
         let messages = vec![ChatMessage {
             role: Role::User,
             content: prompt.to_string(),
@@ -341,8 +363,7 @@ impl DreamEngine {
         };
 
         let response = self.llm.chat(&messages, &config).await?;
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         Ok((parsed, response.tokens_used))
     }
@@ -420,15 +441,15 @@ impl DreamEngine {
         let dream_id = Uuid::new_v4().to_string();
 
         // Emit foresight signal from hypothesis if it's forward-looking
-        if let Some(ref h) = hypothesis {
-            if would_write {
-                let fs = crate::note::ForesightSignal::new(
-                    h.clone(),
-                    dream_id.clone(),
-                    Some(chrono::Utc::now() + chrono::Duration::days(90)),
-                );
-                let _ = self.graph_store.upsert_foresight(&fs).await;
-            }
+        if let Some(ref h) = hypothesis
+            && would_write
+        {
+            let fs = crate::note::ForesightSignal::new(
+                h.clone(),
+                dream_id.clone(),
+                Some(chrono::Utc::now() + chrono::Duration::days(90)),
+            );
+            let _ = self.graph_store.upsert_foresight(&fs).await;
         }
 
         Ok((
@@ -469,12 +490,11 @@ impl DreamEngine {
         let dream_id = Uuid::new_v4().to_string();
 
         // Create or update entity profile if we have an entity ID and a valid peer card
-        if would_write {
-            if let (Some(entity), Some(card)) = (&entity_id, &peer_card) {
-                if let Err(e) = self.upsert_profile(entity, card, &dream_id, &capped).await {
-                    debug!(error = %e, "Failed to upsert profile (non-fatal)");
-                }
-            }
+        if would_write
+            && let (Some(entity), Some(card)) = (&entity_id, &peer_card)
+            && let Err(e) = self.upsert_profile(entity, card, &dream_id, &capped).await
+        {
+            debug!(error = %e, "Failed to upsert profile (non-fatal)");
         }
 
         Ok((
@@ -614,25 +634,22 @@ impl DreamEngine {
             None => return Ok(false),
         };
 
-        let candidates = self
-            .vector_store
-            .find_similar(&embedding, 5, &[])
-            .await?;
+        let candidates = self.vector_store.find_similar(&embedding, 5, &[]).await?;
 
         for (note, score) in &candidates {
             // High similarity + same dream type = duplicate
-            if *score > 0.85 && note.is_dream() {
-                if let Provenance::Dream { dream_type, .. } = &note.provenance {
-                    if dream_type == dream.dream_type.as_str() {
-                        debug!(
-                            dream_type = dream.dream_type.as_str(),
-                            existing_id = %note.id,
-                            similarity = score,
-                            "Skipping duplicate dream"
-                        );
-                        return Ok(true);
-                    }
-                }
+            if *score > 0.85
+                && note.is_dream()
+                && let Provenance::Dream { dream_type, .. } = &note.provenance
+                && dream_type == dream.dream_type.as_str()
+            {
+                debug!(
+                    dream_type = dream.dream_type.as_str(),
+                    existing_id = %note.id,
+                    similarity = score,
+                    "Skipping duplicate dream"
+                );
+                return Ok(true);
             }
         }
 
@@ -656,9 +673,13 @@ impl DreamEngine {
                 {
                     let max = 200;
                     let s = &dream.reasoning;
-                    if s.len() <= max { s } else {
+                    if s.len() <= max {
+                        s
+                    } else {
                         let mut end = max;
-                        while end > 0 && !s.is_char_boundary(end) { end -= 1; }
+                        while end > 0 && !s.is_char_boundary(end) {
+                            end -= 1;
+                        }
                         &s[..end]
                     }
                 }
@@ -668,10 +689,7 @@ impl DreamEngine {
                 "dream".to_string(),
                 "inference".to_string(),
             ],
-            tags: vec![
-                "dream".to_string(),
-                dream.dream_type.as_str().to_string(),
-            ],
+            tags: vec!["dream".to_string(), dream.dream_type.as_str().to_string()],
             links: Vec::new(), // Links added below
             embedding,
             created_at: dream.created_at,
@@ -694,7 +712,11 @@ impl DreamEngine {
         // Link dream to source notes
         for source_id in &dream.source_note_ids {
             self.graph_store
-                .add_link(&dream.id, source_id, &format!("{} dream", dream.dream_type.as_str()))
+                .add_link(
+                    &dream.id,
+                    source_id,
+                    &format!("{} dream", dream.dream_type.as_str()),
+                )
                 .await?;
         }
 
@@ -720,7 +742,9 @@ impl DreamEngine {
             TimedEvent,
         };
 
-        let notes_text: String = notes.iter().enumerate()
+        let notes_text: String = notes
+            .iter()
+            .enumerate()
             .map(|(i, n)| format!("[{}] {}\n    Context: {}", i + 1, n.content, n.context))
             .collect::<Vec<_>>()
             .join("\n\n");
@@ -745,15 +769,20 @@ impl DreamEngine {
         let digest_text = parsed["digest_text"].as_str().unwrap_or("").to_string();
 
         // Parse structured fields
-        let entities: Vec<EntityMention> = parsed["entities"].as_array()
-            .map(|a| a.iter().filter_map(|v| {
-                Some(EntityMention {
-                    name: v["name"].as_str()?.to_string(),
-                    entity_type: v["type"].as_str().unwrap_or("other").to_string(),
-                    count: v["count"].as_u64().unwrap_or(1) as u32,
-                    latest_value: v["latest_value"].as_str().map(String::from),
-                })
-            }).collect())
+        let entities: Vec<EntityMention> = parsed["entities"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| {
+                        Some(EntityMention {
+                            name: v["name"].as_str()?.to_string(),
+                            entity_type: v["type"].as_str().unwrap_or("other").to_string(),
+                            count: v["count"].as_u64().unwrap_or(1) as u32,
+                            latest_value: v["latest_value"].as_str().map(String::from),
+                        })
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
         let date_range = parsed["date_range"].as_object().and_then(|obj| {
@@ -763,43 +792,73 @@ impl DreamEngine {
             })
         });
 
-        let aggregations: Vec<AggregationEntry> = parsed["aggregations"].as_array()
-            .map(|a| a.iter().filter_map(|v| {
-                Some(AggregationEntry {
-                    label: v["label"].as_str()?.to_string(),
-                    count: v["count"].as_u64().unwrap_or(0) as u32,
-                    items: v["items"].as_array()
-                        .map(|arr| arr.iter().filter_map(|i| i.as_str().map(String::from)).collect())
-                        .unwrap_or_default(),
-                })
-            }).collect())
+        let aggregations: Vec<AggregationEntry> = parsed["aggregations"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| {
+                        Some(AggregationEntry {
+                            label: v["label"].as_str()?.to_string(),
+                            count: v["count"].as_u64().unwrap_or(0) as u32,
+                            items: v["items"]
+                                .as_array()
+                                .map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|i| i.as_str().map(String::from))
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                        })
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
-        let topic_sequence: Vec<String> = parsed["topic_sequence"].as_array()
-            .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        let topic_sequence: Vec<String> = parsed["topic_sequence"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
             .unwrap_or_default();
 
-        let events: Vec<TimedEvent> = parsed["timed_events"].as_array()
-            .map(|a| a.iter().filter_map(|v| {
-                let description = v["description"].as_str()?.trim();
-                if description.is_empty() { return None; }
-                Some(TimedEvent {
-                    description: description.to_string(),
-                    date: v["date"].as_str().and_then(|s| {
-                        let s = s.trim();
-                        if s.is_empty() || s.eq_ignore_ascii_case("null") { None }
-                        else { Some(s.to_string()) }
-                    }),
-                    source_turn: v["source_turn"].as_u64().map(|n| n as u32),
-                })
-            }).collect())
+        let events: Vec<TimedEvent> = parsed["timed_events"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| {
+                        let description = v["description"].as_str()?.trim();
+                        if description.is_empty() {
+                            return None;
+                        }
+                        Some(TimedEvent {
+                            description: description.to_string(),
+                            date: v["date"].as_str().and_then(|s| {
+                                let s = s.trim();
+                                if s.is_empty() || s.eq_ignore_ascii_case("null") {
+                                    None
+                                } else {
+                                    Some(s.to_string())
+                                }
+                            }),
+                            source_turn: v["source_turn"].as_u64().map(|n| n as u32),
+                        })
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
         // Create digest note for ANN searchability
         let mut digest_note_id = None;
         if !digest_text.is_empty() {
-            let embedding = self.llm.embed(&[&digest_text]).await?
-                .into_iter().next().unwrap_or_default();
+            let embedding = self
+                .llm
+                .embed(&[&digest_text])
+                .await?
+                .into_iter()
+                .next()
+                .unwrap_or_default();
 
             let note = MemoryNote {
                 id: Uuid::new_v4().to_string(),
@@ -812,7 +871,9 @@ impl DreamEngine {
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
                 evolution_history: Vec::new(),
-                provenance: Provenance::Digest { episode_id: episode.id.clone() },
+                provenance: Provenance::Digest {
+                    episode_id: episode.id.clone(),
+                },
                 confidence,
                 status: NoteStatus::Active,
                 last_accessed_at: Utc::now(),
@@ -856,7 +917,11 @@ impl DreamEngine {
             id: Uuid::new_v4().to_string(),
             dream_type: DreamType::EpisodeDigest,
             source_note_ids: notes.iter().map(|n| n.id.clone()).collect(),
-            reasoning: format!("Digest for episode {} with {} notes", episode.id, notes.len()),
+            reasoning: format!(
+                "Digest for episode {} with {} notes",
+                episode.id,
+                notes.len()
+            ),
             dream_content: digest_text,
             confidence,
             would_write: digest_note_id.is_some(),
@@ -879,7 +944,8 @@ impl DreamEngine {
 
         // Build mapping from display labels to real episode UUIDs
         // The LLM may return "Episode 1" or the UUID — we need to resolve both
-        let mut label_to_uuid: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let mut label_to_uuid: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
         for (i, d) in digests.iter().enumerate() {
             label_to_uuid.insert(format!("Episode {}", i + 1), d.episode_id.clone());
             label_to_uuid.insert(d.episode_id.clone(), d.episode_id.clone()); // UUID maps to itself
@@ -887,15 +953,22 @@ impl DreamEngine {
 
         // Pass the per-episode events through so the LLM can dedupe/merge them
         // instead of re-inferring from digest text alone.
-        let digests_text: String = digests.iter().enumerate()
+        let digests_text: String = digests
+            .iter()
+            .enumerate()
             .map(|(i, d)| {
                 let events_line = if d.events.is_empty() {
                     String::new()
                 } else {
-                    let inline: Vec<String> = d.events.iter().take(20).map(|e| {
-                        let date = e.date.as_deref().unwrap_or("?");
-                        format!("{}: {}", date, e.description)
-                    }).collect();
+                    let inline: Vec<String> = d
+                        .events
+                        .iter()
+                        .take(20)
+                        .map(|e| {
+                            let date = e.date.as_deref().unwrap_or("?");
+                            format!("{}: {}", date, e.description)
+                        })
+                        .collect();
                     format!("\n  Events: {}", inline.join(" | "))
                 };
                 format!(
@@ -903,7 +976,11 @@ impl DreamEngine {
                     i + 1,
                     d.episode_id,
                     d.digest_text,
-                    d.entities.iter().map(|e| format!("{}({})", e.name, e.count)).collect::<Vec<_>>().join(", "),
+                    d.entities
+                        .iter()
+                        .map(|e| format!("{}({})", e.name, e.count))
+                        .collect::<Vec<_>>()
+                        .join(", "),
                     d.topic_sequence.join(" → "),
                     events_line,
                 )
@@ -931,75 +1008,133 @@ impl DreamEngine {
         let digest_text = parsed["digest_text"].as_str().unwrap_or("").to_string();
 
         // Parse structured fields for persistent storage
-        let entity_timeline: Vec<EntityTimelineEntry> = parsed["entity_timeline"].as_array()
-            .map(|a| a.iter().filter_map(|v| {
-                let name = v["name"].as_str()?.to_string();
-                let entity_type = v["type"].as_str().unwrap_or("other").to_string();
-                let changes: Vec<EntityTimelineChange> = v["changes"].as_array()
-                    .map(|arr| arr.iter().filter_map(|c| {
-                        let raw = c["episode_id"].as_str()?;
-                        let resolved = label_to_uuid.get(raw).cloned().unwrap_or_else(|| raw.to_string());
-                        Some(EntityTimelineChange {
-                            episode_id: resolved,
-                            value: c["value"].as_str().unwrap_or("").to_string(),
+        let entity_timeline: Vec<EntityTimelineEntry> = parsed["entity_timeline"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| {
+                        let name = v["name"].as_str()?.to_string();
+                        let entity_type = v["type"].as_str().unwrap_or("other").to_string();
+                        let changes: Vec<EntityTimelineChange> = v["changes"]
+                            .as_array()
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|c| {
+                                        let raw = c["episode_id"].as_str()?;
+                                        let resolved = label_to_uuid
+                                            .get(raw)
+                                            .cloned()
+                                            .unwrap_or_else(|| raw.to_string());
+                                        Some(EntityTimelineChange {
+                                            episode_id: resolved,
+                                            value: c["value"].as_str().unwrap_or("").to_string(),
+                                        })
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        Some(EntityTimelineEntry {
+                            name,
+                            entity_type,
+                            changes,
                         })
-                    }).collect())
-                    .unwrap_or_default();
-                Some(EntityTimelineEntry { name, entity_type, changes })
-            }).collect())
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
-        let cross_aggregations: Vec<AggregationEntry> = parsed["cross_aggregations"].as_array()
-            .map(|a| a.iter().filter_map(|v| {
-                Some(AggregationEntry {
-                    label: v["label"].as_str()?.to_string(),
-                    count: v["count"].as_u64().unwrap_or(0) as u32,
-                    items: v["items"].as_array()
-                        .map(|arr| arr.iter().filter_map(|i| i.as_str().map(String::from)).collect())
-                        .unwrap_or_default(),
-                })
-            }).collect())
+        let cross_aggregations: Vec<AggregationEntry> = parsed["cross_aggregations"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| {
+                        Some(AggregationEntry {
+                            label: v["label"].as_str()?.to_string(),
+                            count: v["count"].as_u64().unwrap_or(0) as u32,
+                            items: v["items"]
+                                .as_array()
+                                .map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|i| i.as_str().map(String::from))
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                        })
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
-        let cross_events: Vec<TimedEvent> = parsed["timed_events"].as_array()
-            .map(|a| a.iter().filter_map(|v| {
-                let description = v["description"].as_str()?.trim();
-                if description.is_empty() { return None; }
-                Some(TimedEvent {
-                    description: description.to_string(),
-                    date: v["date"].as_str().and_then(|s| {
-                        let s = s.trim();
-                        if s.is_empty() || s.eq_ignore_ascii_case("null") { None }
-                        else { Some(s.to_string()) }
-                    }),
-                    source_turn: v["source_turn"].as_u64().map(|n| n as u32),
-                })
-            }).collect())
+        let cross_events: Vec<TimedEvent> = parsed["timed_events"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| {
+                        let description = v["description"].as_str()?.trim();
+                        if description.is_empty() {
+                            return None;
+                        }
+                        Some(TimedEvent {
+                            description: description.to_string(),
+                            date: v["date"].as_str().and_then(|s| {
+                                let s = s.trim();
+                                if s.is_empty() || s.eq_ignore_ascii_case("null") {
+                                    None
+                                } else {
+                                    Some(s.to_string())
+                                }
+                            }),
+                            source_turn: v["source_turn"].as_u64().map(|n| n as u32),
+                        })
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
-        let topic_progression: Vec<String> = parsed["topic_progression"].as_array()
-            .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        let topic_progression: Vec<String> = parsed["topic_progression"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
             .unwrap_or_default();
 
         // Create episode links from entity timelines
         for timeline in &entity_timeline {
-            let episode_ids: Vec<String> = timeline.changes.iter()
+            let episode_ids: Vec<String> = timeline
+                .changes
+                .iter()
                 .map(|c| c.episode_id.clone())
                 .collect();
 
             for window in episode_ids.windows(2) {
                 if window.len() == 2 {
-                    let has_value_change = timeline.changes.iter()
+                    let has_value_change = timeline
+                        .changes
+                        .iter()
                         .filter(|c| c.episode_id == window[0] || c.episode_id == window[1])
                         .map(|c| c.value.as_str())
                         .collect::<std::collections::HashSet<_>>()
-                        .len() > 1;
+                        .len()
+                        > 1;
 
-                    let link_type = if has_value_change { "value_update" } else { "entity_continuity" };
+                    let link_type = if has_value_change {
+                        "value_update"
+                    } else {
+                        "entity_continuity"
+                    };
                     let reason = format!("{} appears in both episodes", timeline.name);
-                    let _ = self.graph_store.add_episode_link(
-                        &window[0], &window[1], link_type, Some(&timeline.name), &reason
-                    ).await;
+                    let _ = self
+                        .graph_store
+                        .add_episode_link(
+                            &window[0],
+                            &window[1],
+                            link_type,
+                            Some(&timeline.name),
+                            &reason,
+                        )
+                        .await;
                 }
             }
         }
@@ -1016,7 +1151,11 @@ impl DreamEngine {
                 digest_text: digest_text.clone(),
                 created_at: Utc::now(),
             };
-            if let Err(e) = self.graph_store.upsert_cross_episode_digest(&cross_digest).await {
+            if let Err(e) = self
+                .graph_store
+                .upsert_cross_episode_digest(&cross_digest)
+                .await
+            {
                 debug!(error = %e, "Failed to persist cross-episode digest");
             } else {
                 debug!(
@@ -1028,7 +1167,8 @@ impl DreamEngine {
             }
         }
 
-        let source_ids: Vec<String> = digests.iter()
+        let source_ids: Vec<String> = digests
+            .iter()
             .filter_map(|d| d.digest_note_id.clone())
             .collect();
 
@@ -1036,8 +1176,11 @@ impl DreamEngine {
             id: Uuid::new_v4().to_string(),
             dream_type: DreamType::CrossEpisodeDigest,
             source_note_ids: source_ids,
-            reasoning: format!("Cross-episode digest across {} episodes ({} merged events)",
-                digests.len(), cross_events.len()),
+            reasoning: format!(
+                "Cross-episode digest across {} episodes ({} merged events)",
+                digests.len(),
+                cross_events.len()
+            ),
             dream_content: digest_text,
             confidence,
             would_write: confidence >= self.config.write_threshold,

--- a/crates/karta-core/src/dream/types.rs
+++ b/crates/karta-core/src/dream/types.rs
@@ -1,5 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -26,7 +28,7 @@ impl DreamType {
         }
     }
 
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn parse_kind(s: &str) -> Option<Self> {
         match s {
             "deduction" => Some(Self::Deduction),
             "induction" => Some(Self::Induction),
@@ -37,6 +39,25 @@ impl DreamType {
             "cross_episode_digest" => Some(Self::CrossEpisodeDigest),
             _ => None,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseDreamTypeError;
+
+impl fmt::Display for ParseDreamTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid dream type")
+    }
+}
+
+impl std::error::Error for ParseDreamTypeError {}
+
+impl FromStr for DreamType {
+    type Err = ParseDreamTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse_kind(s).ok_or(ParseDreamTypeError)
     }
 }
 

--- a/crates/karta-core/src/extract.rs
+++ b/crates/karta-core/src/extract.rs
@@ -1,0 +1,300 @@
+use serde::{Deserialize, Serialize};
+
+/// Result of running an extractor on content.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExtractionResult {
+    pub facts: Vec<ExtractedFact>,
+    pub edges: Vec<ExtractedEdge>,
+    pub metadata: Vec<(String, String)>,
+}
+
+/// A fact extracted deterministically from structured content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedFact {
+    pub key: String,
+    pub value: String,
+    pub confidence: f32,
+}
+
+/// An edge extracted from structured content (e.g., dependency relationships).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedEdge {
+    pub from: String,
+    pub to: String,
+    pub edge_type: String,
+}
+
+/// Trait for deterministic extractors that run before LLM extraction.
+pub trait Extractor: Send + Sync {
+    /// Returns the name of this extractor (e.g., "markdown", "json", "cargo_toml").
+    fn name(&self) -> &str;
+
+    /// Returns true if this extractor can handle the given content type.
+    fn can_extract(&self, content_type: &str, content: &str) -> bool;
+
+    /// Extract facts, edges, and metadata from content.
+    fn extract(&self, content_type: &str, content: &str) -> ExtractionResult;
+}
+
+/// Registry of deterministic extractors.
+pub struct ExtractorRegistry {
+    extractors: Vec<Box<dyn Extractor>>,
+}
+
+impl ExtractorRegistry {
+    pub fn new() -> Self {
+        let mut registry = Self {
+            extractors: Vec::new(),
+        };
+        registry.register_default_extractors();
+        registry
+    }
+
+    pub fn register(&mut self, extractor: Box<dyn Extractor>) {
+        self.extractors.push(extractor);
+    }
+
+    pub fn run(&self, content_type: &str, content: &str) -> ExtractionResult {
+        let mut combined = ExtractionResult::default();
+        for extractor in &self.extractors {
+            if extractor.can_extract(content_type, content) {
+                let result = extractor.extract(content_type, content);
+                combined.facts.extend(result.facts);
+                combined.edges.extend(result.edges);
+                combined.metadata.extend(result.metadata);
+            }
+        }
+        combined
+    }
+
+    fn register_default_extractors(&mut self) {
+        self.register(Box::new(MarkdownExtractor));
+        self.register(Box::new(JsonExtractor));
+        self.register(Box::new(YamlExtractor));
+        self.register(Box::new(CargoTomlExtractor));
+    }
+}
+
+impl Default for ExtractorRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extractor for Markdown content.
+pub struct MarkdownExtractor;
+
+impl Extractor for MarkdownExtractor {
+    fn name(&self) -> &str {
+        "markdown"
+    }
+
+    fn can_extract(&self, content_type: &str, _content: &str) -> bool {
+        content_type == "markdown" || content_type == "md"
+    }
+
+    fn extract(&self, _content_type: &str, content: &str) -> ExtractionResult {
+        let mut result = ExtractionResult::default();
+
+        for line in content.lines() {
+            if line.starts_with('#') {
+                let level = line.chars().take_while(|c| *c == '#').count();
+                let text = line
+                    .chars()
+                    .skip(level)
+                    .skip_while(|c| c.is_whitespace())
+                    .collect::<String>();
+                result.facts.push(ExtractedFact {
+                    key: format!("heading_level_{}", level),
+                    value: text,
+                    confidence: 1.0,
+                });
+            }
+
+            if line.starts_with("```") {
+                let lang = line.strip_prefix("```").unwrap_or("").trim();
+                if !lang.is_empty() {
+                    result
+                        .metadata
+                        .push(("code_fence_language".into(), lang.into()));
+                }
+            }
+
+            if let (true, Some(link_text)) = (
+                line.starts_with('[') && line.contains("]("),
+                line.split_once("]("),
+            ) {
+                result.facts.push(ExtractedFact {
+                    key: "link".into(),
+                    value: format!(
+                        "{} -> {}",
+                        link_text.0.trim_start_matches('[').trim_end_matches(']'),
+                        link_text.1.trim_end_matches(')')
+                    ),
+                    confidence: 1.0,
+                });
+            }
+        }
+
+        result
+    }
+}
+
+/// Extractor for JSON content.
+pub struct JsonExtractor;
+
+impl Extractor for JsonExtractor {
+    fn name(&self) -> &str {
+        "json"
+    }
+
+    fn can_extract(&self, content_type: &str, content: &str) -> bool {
+        (content_type == "json") && content.trim_start().starts_with('{')
+    }
+
+    fn extract(&self, _content_type: &str, content: &str) -> ExtractionResult {
+        let mut result = ExtractionResult::default();
+
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
+            extract_json_paths(&value, "", &mut result.facts);
+        }
+
+        result
+    }
+}
+
+fn extract_json_paths(value: &serde_json::Value, path: &str, facts: &mut Vec<ExtractedFact>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map {
+                let new_path = if path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{}.{}", path, key)
+                };
+                extract_json_paths(val, &new_path, facts);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for (i, val) in arr.iter().enumerate() {
+                let new_path = format!("{}[{}]", path, i);
+                extract_json_paths(val, &new_path, facts);
+            }
+        }
+        serde_json::Value::String(s) => {
+            facts.push(ExtractedFact {
+                key: path.to_string(),
+                value: s.clone(),
+                confidence: 1.0,
+            });
+        }
+        serde_json::Value::Number(n) => {
+            facts.push(ExtractedFact {
+                key: path.to_string(),
+                value: n.to_string(),
+                confidence: 1.0,
+            });
+        }
+        serde_json::Value::Bool(b) => {
+            facts.push(ExtractedFact {
+                key: path.to_string(),
+                value: b.to_string(),
+                confidence: 1.0,
+            });
+        }
+        _ => {}
+    }
+}
+
+/// Extractor for YAML content.
+pub struct YamlExtractor;
+
+impl Extractor for YamlExtractor {
+    fn name(&self) -> &str {
+        "yaml"
+    }
+
+    fn can_extract(&self, content_type: &str, content: &str) -> bool {
+        (content_type == "yaml" || content_type == "yml") && content.contains(':')
+    }
+
+    fn extract(&self, _content_type: &str, content: &str) -> ExtractionResult {
+        let mut result = ExtractionResult::default();
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            if let Some((key, value)) = trimmed.split_once(':') {
+                let value = value.trim().trim_matches('"').trim_matches('\'');
+                if !value.is_empty() {
+                    result.facts.push(ExtractedFact {
+                        key: key.trim().to_string(),
+                        value: value.to_string(),
+                        confidence: 0.9,
+                    });
+                }
+            }
+        }
+
+        result
+    }
+}
+
+/// Extractor for Cargo.toml files.
+pub struct CargoTomlExtractor;
+
+impl Extractor for CargoTomlExtractor {
+    fn name(&self) -> &str {
+        "cargo_toml"
+    }
+
+    fn can_extract(&self, content_type: &str, content: &str) -> bool {
+        (content_type == "toml" || content_type == "cargo_toml")
+            && (content.contains("[package]") || content.contains("[workspace]"))
+    }
+
+    fn extract(&self, _content_type: &str, content: &str) -> ExtractionResult {
+        let mut result = ExtractionResult::default();
+        let mut current_section = String::new();
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+
+            if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                current_section = trimmed.trim_matches('[').trim_matches(']').to_string();
+                continue;
+            }
+
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+
+            if let Some((key, value)) = trimmed.split_once('=') {
+                let key = key.trim();
+                let value = value.trim().trim_matches('"');
+
+                if current_section == "package" {
+                    result.facts.push(ExtractedFact {
+                        key: format!("package.{}", key),
+                        value: value.to_string(),
+                        confidence: 1.0,
+                    });
+                } else if current_section.starts_with("dependencies") {
+                    result.edges.push(ExtractedEdge {
+                        from: "this_crate".into(),
+                        to: key.to_string(),
+                        edge_type: "depends_on".into(),
+                    });
+                } else if current_section == "workspace" && key == "members" {
+                    result
+                        .metadata
+                        .push(("workspace_members".into(), value.to_string()));
+                }
+            }
+        }
+
+        result
+    }
+}

--- a/crates/karta-core/src/forget.rs
+++ b/crates/karta-core/src/forget.rs
@@ -1,0 +1,291 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::config::ForgetConfig;
+use crate::error::Result;
+use crate::note::{MemoryNote, NoteStatus, Provenance};
+use crate::store::{GraphStore, VectorStore};
+
+/// Result of a forgetting run.
+#[derive(Debug, Clone, Serialize)]
+pub struct ForgetRun {
+    pub run_id: String,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: DateTime<Utc>,
+    pub notes_inspected: usize,
+    pub notes_archived: usize,
+    pub notes_deprecated: usize,
+    pub notes_protected: usize,
+    pub archived_ids: Vec<String>,
+    pub deprecated_ids: Vec<String>,
+    pub protected_ids: Vec<String>,
+    pub links_decayed: Option<usize>,
+    pub warnings: Vec<String>,
+}
+
+/// A candidate for forgetting (used in preview and actual runs).
+#[derive(Debug, Clone, Serialize)]
+pub struct ForgetCandidate {
+    pub note_id: String,
+    pub decay_score: f64,
+    pub last_accessed_at: DateTime<Utc>,
+    pub current_status: NoteStatus,
+    pub is_protected: bool,
+    pub protection_reason: Option<String>,
+    pub action: ForgetAction,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub enum ForgetAction {
+    Archive,
+    Deprecate,
+    Skip,
+}
+
+/// Preview of what a forgetting run would do, without mutations.
+#[derive(Debug, Clone, Serialize)]
+pub struct ForgetPreview {
+    pub generated_at: DateTime<Utc>,
+    pub candidates: Vec<ForgetCandidate>,
+    pub total_archived: usize,
+    pub total_deprecated: usize,
+    pub total_protected: usize,
+    pub links_decayed: Option<usize>,
+    pub warnings: Vec<String>,
+}
+
+/// Engine that performs access-based forgetting over notes and link decay.
+pub struct ForgetEngine {
+    vector_store: Arc<dyn VectorStore>,
+    graph_store: Arc<dyn GraphStore>,
+    config: ForgetConfig,
+}
+
+impl ForgetEngine {
+    pub fn new(
+        vector_store: Arc<dyn VectorStore>,
+        graph_store: Arc<dyn GraphStore>,
+        config: ForgetConfig,
+    ) -> Self {
+        Self {
+            vector_store,
+            graph_store,
+            config,
+        }
+    }
+
+    /// Run forgetting: archive stale low-activation notes, decay link weights.
+    /// Idempotent — running twice produces the same result.
+    pub async fn run_forgetting(&self) -> Result<ForgetRun> {
+        if !self.config.enabled {
+            let now = Utc::now();
+            return Ok(ForgetRun {
+                run_id: uuid::Uuid::new_v4().to_string(),
+                started_at: now,
+                completed_at: now,
+                notes_inspected: 0,
+                notes_archived: 0,
+                notes_deprecated: 0,
+                notes_protected: 0,
+                archived_ids: vec![],
+                deprecated_ids: vec![],
+                protected_ids: vec![],
+                links_decayed: Some(0),
+                warnings: vec!["Forgetting engine is disabled".into()],
+            });
+        }
+
+        let started_at = Utc::now();
+        let notes = self.vector_store.get_all().await?;
+
+        let mut archived_ids = Vec::new();
+        let mut deprecated_ids = Vec::new();
+        let mut protected_ids = Vec::new();
+        let notes_inspected = notes.len();
+
+        for note in &notes {
+            if matches!(
+                note.status,
+                NoteStatus::Archived | NoteStatus::Superseded { .. }
+            ) {
+                continue;
+            }
+
+            if self.is_protected(note) {
+                protected_ids.push(note.id.clone());
+                continue;
+            }
+
+            let decay_score = self.compute_decay_score(note, &started_at);
+
+            if decay_score < self.config.archive_threshold as f64 {
+                let mut updated = note.clone();
+                updated.status = NoteStatus::Archived;
+                updated.updated_at = Utc::now();
+                self.vector_store.upsert(&updated).await?;
+                archived_ids.push(note.id.clone());
+            } else if note.status == NoteStatus::Active
+                && decay_score < (self.config.archive_threshold as f64 * 2.0)
+            {
+                let mut updated = note.clone();
+                updated.status = NoteStatus::Deprecated {
+                    by: "forgetting_engine".into(),
+                };
+                updated.updated_at = Utc::now();
+                self.vector_store.upsert(&updated).await?;
+                deprecated_ids.push(note.id.clone());
+            }
+        }
+
+        let links_decayed = self.decay_semantic_links(&started_at).await?;
+        let mut warnings = Vec::new();
+        if links_decayed.is_none() {
+            warnings.push(
+                "Semantic link decay is not implemented for this graph store/schema yet".into(),
+            );
+        }
+
+        Ok(ForgetRun {
+            run_id: uuid::Uuid::new_v4().to_string(),
+            started_at,
+            completed_at: Utc::now(),
+            notes_inspected,
+            notes_archived: archived_ids.len(),
+            notes_deprecated: deprecated_ids.len(),
+            notes_protected: protected_ids.len(),
+            archived_ids,
+            deprecated_ids,
+            protected_ids,
+            links_decayed,
+            warnings,
+        })
+    }
+
+    /// Dry-run preview: returns the same candidates as an actual run without mutations.
+    pub async fn preview_forgetting(&self) -> Result<ForgetPreview> {
+        let notes = self.vector_store.get_all().await?;
+        let now = Utc::now();
+        let links_decayed = if self.config.enabled {
+            self.decay_semantic_links(&now).await?
+        } else {
+            Some(0)
+        };
+        let mut warnings = Vec::new();
+        if !self.config.enabled {
+            warnings.push("Forgetting engine is disabled".into());
+        } else if links_decayed.is_none() {
+            warnings.push(
+                "Semantic link decay is not implemented for this graph store/schema yet".into(),
+            );
+        }
+
+        let mut candidates = Vec::new();
+        let mut total_archived = 0;
+        let mut total_deprecated = 0;
+        let mut total_protected = 0;
+
+        for note in &notes {
+            if !self.config.enabled
+                || matches!(
+                    note.status,
+                    NoteStatus::Archived | NoteStatus::Superseded { .. }
+                )
+            {
+                continue;
+            }
+
+            let is_protected = self.is_protected(note);
+            let protection_reason = if is_protected {
+                Some(self.protection_reason(note))
+            } else {
+                None
+            };
+
+            let decay_score = self.compute_decay_score(note, &now);
+
+            let action = if is_protected {
+                total_protected += 1;
+                ForgetAction::Skip
+            } else if decay_score < self.config.archive_threshold as f64 {
+                total_archived += 1;
+                ForgetAction::Archive
+            } else if note.status == NoteStatus::Active
+                && decay_score < (self.config.archive_threshold as f64 * 2.0)
+            {
+                total_deprecated += 1;
+                ForgetAction::Deprecate
+            } else {
+                continue;
+            };
+
+            candidates.push(ForgetCandidate {
+                note_id: note.id.clone(),
+                decay_score,
+                last_accessed_at: note.last_accessed_at,
+                current_status: note.status.clone(),
+                is_protected,
+                protection_reason,
+                action,
+            });
+        }
+
+        Ok(ForgetPreview {
+            generated_at: now,
+            candidates,
+            total_archived,
+            total_deprecated,
+            total_protected,
+            links_decayed,
+            warnings,
+        })
+    }
+
+    /// Compute an exponential decay score based on time since last access.
+    /// Score of 1.0 = just accessed, approaches 0.0 over time.
+    fn compute_decay_score(&self, note: &MemoryNote, now: &DateTime<Utc>) -> f64 {
+        let elapsed_days = (now
+            .signed_duration_since(note.last_accessed_at)
+            .num_milliseconds() as f64
+            / 86_400_000.0)
+            .max(0.0);
+        let half_life = self.config.decay_half_life_days;
+        if half_life <= 0.0 {
+            return 1.0;
+        }
+        // Exponential decay: score = 0.5^(elapsed / half_life)
+        0.5_f64.powf(elapsed_days / half_life).clamp(0.0, 1.0)
+    }
+
+    /// Check if a note should be protected from forgetting.
+    /// Observed notes (user input), profiles, and episodes are protected by default.
+    fn is_protected(&self, note: &MemoryNote) -> bool {
+        matches!(note.provenance, Provenance::Observed) || note.is_profile() || note.is_episode()
+    }
+
+    /// Human-readable reason why a note is protected.
+    fn protection_reason(&self, note: &MemoryNote) -> String {
+        debug_assert!(self.is_protected(note));
+        if matches!(note.provenance, Provenance::Observed) {
+            "observed_note".into()
+        } else if note.is_profile() {
+            "profile_note".into()
+        } else {
+            "episode_note".into()
+        }
+    }
+
+    /// Decay semantic link weights.
+    ///
+    /// Returns `Some(count)` when link decay is supported and ran, and `None`
+    /// when the current graph store/schema cannot represent weighted link decay yet.
+    async fn decay_semantic_links(&self, _now: &DateTime<Utc>) -> Result<Option<usize>> {
+        // TODO(forgetting-engine): Link decay requires typed/weighted link support from PR #3 (ACTIVATE).
+        // When that PR merges, this will call graph_store.decay_link_weights().
+        // For now, return None so consumers can distinguish "not implemented"
+        // from "implemented and matched zero links".
+        let _ = &self.graph_store;
+        Ok(None)
+    }
+}

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -251,7 +251,8 @@ impl Karta {
     // --- Health ---
 
     pub async fn health_check(&self) -> Result<KartaHealth> {
-        let vector_ok = self.vector_store.count().await.is_ok();
+        let vector_count = self.vector_store.count().await;
+        let vector_ok = vector_count.is_ok();
         let graph_meta = self.graph_store.get_schema_meta().await;
         let graph_ok = graph_meta.is_ok();
 
@@ -271,8 +272,15 @@ impl Karta {
         };
 
         let mut warnings = warnings;
-        if !vector_ok {
-            warnings.push("Vector store health check failed".into());
+        if let Err(e) = vector_count {
+            warnings.push(format!("Vector store health check failed: {e}"));
+        }
+        if schema_version != crate::migrate::CURRENT_SCHEMA_VERSION {
+            warnings.push(format!(
+                "Schema version mismatch: found {}, expected {}",
+                schema_version,
+                crate::migrate::CURRENT_SCHEMA_VERSION
+            ));
         }
         if !pending.is_empty() {
             warnings.push(format!(
@@ -285,7 +293,7 @@ impl Karta {
         Ok(KartaHealth {
             vector_store_ok: vector_ok,
             graph_store_ok: graph_ok,
-            schema_version: schema_version.to_string(),
+            schema_version,
             pending_migrations: pending,
             warnings,
         })
@@ -297,7 +305,7 @@ impl Karta {
 pub struct KartaHealth {
     pub vector_store_ok: bool,
     pub graph_store_ok: bool,
-    pub schema_version: String,
+    pub schema_version: u32,
     pub pending_migrations: Vec<String>,
     pub warnings: Vec<String>,
 }

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 use crate::config::KartaConfig;
 use crate::dream::{DreamEngine, DreamRun};
 use crate::error::Result;
+use crate::forget::{ForgetEngine, ForgetPreview, ForgetRun};
 use crate::llm::LlmProvider;
 use crate::note::{MemoryNote, SearchResult};
 use crate::read::ReadEngine;
@@ -215,6 +216,26 @@ impl Karta {
             self.config.dream.clone(),
         );
         engine.run(scope_type, scope_id).await
+    }
+
+    // --- Forgetting ---
+
+    pub async fn run_forgetting(&self) -> Result<ForgetRun> {
+        let engine = ForgetEngine::new(
+            Arc::clone(&self.vector_store),
+            Arc::clone(&self.graph_store),
+            self.config.forget.clone(),
+        );
+        engine.run_forgetting().await
+    }
+
+    pub async fn preview_forgetting(&self) -> Result<ForgetPreview> {
+        let engine = ForgetEngine::new(
+            Arc::clone(&self.vector_store),
+            Arc::clone(&self.graph_store),
+            self.config.forget.clone(),
+        );
+        engine.preview_forgetting().await
     }
 
     // --- Inspection ---

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -247,4 +247,57 @@ impl Karta {
     ) -> Result<crate::llm::ChatResponse> {
         self.llm.chat(messages, config).await
     }
+
+    // --- Health ---
+
+    pub async fn health_check(&self) -> Result<KartaHealth> {
+        let vector_ok = self.vector_store.count().await.is_ok();
+        let graph_meta = self.graph_store.get_schema_meta().await;
+        let graph_ok = graph_meta.is_ok();
+
+        let (schema_version, _applied, pending, warnings) = match graph_meta {
+            Ok(meta) => (
+                meta.schema_version,
+                meta.applied_migrations,
+                meta.pending_migrations,
+                meta.warnings,
+            ),
+            Err(ref e) => (
+                0,
+                vec![],
+                vec![],
+                vec![format!("Graph store schema meta unavailable: {e}")],
+            ),
+        };
+
+        let mut warnings = warnings;
+        if !vector_ok {
+            warnings.push("Vector store health check failed".into());
+        }
+        if !pending.is_empty() {
+            warnings.push(format!(
+                "{} pending migration(s): {}",
+                pending.len(),
+                pending.join(", ")
+            ));
+        }
+
+        Ok(KartaHealth {
+            vector_store_ok: vector_ok,
+            graph_store_ok: graph_ok,
+            schema_version: schema_version.to_string(),
+            pending_migrations: pending,
+            warnings,
+        })
+    }
+}
+
+/// Health status of a Karta instance.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct KartaHealth {
+    pub vector_store_ok: bool,
+    pub graph_store_ok: bool,
+    pub schema_version: String,
+    pub pending_migrations: Vec<String>,
+    pub warnings: Vec<String>,
 }

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -269,24 +269,32 @@ impl Karta {
     // --- Health ---
 
     pub async fn health_check(&self) -> Result<KartaHealth> {
-        let vector_ok = self.vector_store.count().await.is_ok();
+        let vector_count = self.vector_store.count().await;
+        let vector_ok = vector_count.is_ok();
         let graph_meta = self.graph_store.get_schema_meta().await;
         let graph_ok = graph_meta.is_ok();
 
         let (schema_version, pending, mut warnings) = match graph_meta {
-            Ok(meta) => (
-                Some(meta.schema_version.to_string()),
-                meta.pending_migrations,
-                meta.warnings,
-            ),
+            Ok(meta) => {
+                let schema_version = Some(meta.schema_version.to_string());
+                let mut warnings = meta.warnings;
+                if meta.schema_version != crate::migrate::CURRENT_SCHEMA_VERSION {
+                    warnings.push(format!(
+                        "Schema version mismatch: found {}, expected {}",
+                        meta.schema_version,
+                        crate::migrate::CURRENT_SCHEMA_VERSION
+                    ));
+                }
+                (schema_version, meta.pending_migrations, warnings)
+            }
             Err(ref e) => (
                 None,
                 vec![],
                 vec![format!("Graph store schema meta unavailable: {e}")],
             ),
         };
-        if !vector_ok {
-            warnings.push("Vector store health check failed".into());
+        if let Err(e) = vector_count {
+            warnings.push(format!("Vector store health check failed: {e}"));
         }
         if !pending.is_empty() {
             warnings.push(format!(

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 
 use crate::config::KartaConfig;
 use crate::dream::{DreamEngine, DreamRun};
-use crate::error::{KartaError, Result};
+use crate::error::Result;
 use crate::llm::LlmProvider;
 use crate::note::{MemoryNote, SearchResult};
 use crate::read::ReadEngine;
@@ -91,6 +91,7 @@ impl Karta {
     /// per-operation via `config.llm.overrides`.
     #[cfg(all(feature = "lance", feature = "sqlite", feature = "openai"))]
     pub async fn with_defaults(config: KartaConfig) -> Result<Self> {
+        use crate::error::KartaError;
         use crate::llm::OpenAiProvider;
         use crate::store::lance::LanceVectorStore;
         use crate::store::sqlite::SqliteGraphStore;
@@ -98,24 +99,24 @@ impl Karta {
         // Load .env if present (silently ignore if missing)
         let _ = dotenvy::dotenv();
 
-        let lance_uri = config.storage.lance_uri.clone()
+        let lance_uri = config
+            .storage
+            .lance_uri
+            .clone()
             .unwrap_or_else(|| format!("{}/lance", config.storage.data_dir));
-        let vector_store = Arc::new(
-            LanceVectorStore::new(&lance_uri).await?,
-        ) as Arc<dyn VectorStore>;
+        let vector_store =
+            Arc::new(LanceVectorStore::new(&lance_uri).await?) as Arc<dyn VectorStore>;
 
-        let graph_store = Arc::new(
-            SqliteGraphStore::new(&config.storage.data_dir)?,
-        ) as Arc<dyn GraphStore>;
+        let graph_store =
+            Arc::new(SqliteGraphStore::new(&config.storage.data_dir)?) as Arc<dyn GraphStore>;
 
         let model_ref = &config.llm.default;
 
         // Determine embedding model from config or env
-        let embedding_model = std::env::var("KARTA_EMBEDDING_MODEL")
-            .unwrap_or_else(|_| {
-                std::env::var("AZURE_OPENAI_EMBEDDING_MODEL")
-                    .unwrap_or_else(|_| "text-embedding-3-small".to_string())
-            });
+        let embedding_model = std::env::var("KARTA_EMBEDDING_MODEL").unwrap_or_else(|_| {
+            std::env::var("AZURE_OPENAI_EMBEDDING_MODEL")
+                .unwrap_or_else(|_| "text-embedding-3-small".to_string())
+        });
 
         // Build LLM provider based on what credentials are available
         let llm: Arc<dyn LlmProvider> = if let Some(ref base_url) = model_ref.base_url {
@@ -127,10 +128,11 @@ impl Karta {
             ))
         } else if let Ok(azure_key) = std::env::var("AZURE_OPENAI_API_KEY") {
             // Azure OpenAI — uses native AzureConfig for correct URL construction
-            let endpoint = std::env::var("AZURE_OPENAI_ENDPOINT")
-                .map_err(|_| KartaError::Config(
+            let endpoint = std::env::var("AZURE_OPENAI_ENDPOINT").map_err(|_| {
+                KartaError::Config(
                     "AZURE_OPENAI_API_KEY is set but AZURE_OPENAI_ENDPOINT is missing".into(),
-                ))?;
+                )
+            })?;
             let chat_model = std::env::var("AZURE_OPENAI_CHAT_MODEL")
                 .unwrap_or_else(|_| model_ref.model.clone());
             let api_version = std::env::var("AZURE_OPENAI_API_VERSION")
@@ -145,10 +147,7 @@ impl Karta {
             ))
         } else {
             // Standard OpenAI (reads OPENAI_API_KEY from env automatically)
-            Arc::new(OpenAiProvider::new(
-                &model_ref.model,
-                &embedding_model,
-            ))
+            Arc::new(OpenAiProvider::new(&model_ref.model, &embedding_model))
         };
 
         Self::new(vector_store, graph_store, llm, config).await
@@ -206,11 +205,7 @@ impl Karta {
 
     // --- Dream ---
 
-    pub async fn run_dreaming(
-        &self,
-        scope_type: &str,
-        scope_id: &str,
-    ) -> Result<DreamRun> {
+    pub async fn run_dreaming(&self, scope_type: &str, scope_id: &str) -> Result<DreamRun> {
         let engine = DreamEngine::new(
             Arc::clone(&self.vector_store),
             Arc::clone(&self.graph_store),
@@ -247,4 +242,53 @@ impl Karta {
     ) -> Result<crate::llm::ChatResponse> {
         self.llm.chat(messages, config).await
     }
+
+    // --- Health ---
+
+    pub async fn health_check(&self) -> Result<KartaHealth> {
+        let vector_ok = self.vector_store.count().await.is_ok();
+        let graph_meta = self.graph_store.get_schema_meta().await;
+        let graph_ok = graph_meta.is_ok();
+
+        let (schema_version, pending, mut warnings) = match graph_meta {
+            Ok(meta) => (
+                Some(meta.schema_version.to_string()),
+                meta.pending_migrations,
+                meta.warnings,
+            ),
+            Err(ref e) => (
+                None,
+                vec![],
+                vec![format!("Graph store schema meta unavailable: {e}")],
+            ),
+        };
+        if !vector_ok {
+            warnings.push("Vector store health check failed".into());
+        }
+        if !pending.is_empty() {
+            warnings.push(format!(
+                "{} pending migration(s): {}",
+                pending.len(),
+                pending.join(", ")
+            ));
+        }
+
+        Ok(KartaHealth {
+            vector_store_ok: vector_ok,
+            graph_store_ok: graph_ok,
+            schema_version,
+            pending_migrations: pending,
+            warnings,
+        })
+    }
+}
+
+/// Health status of a Karta instance.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct KartaHealth {
+    pub vector_store_ok: bool,
+    pub graph_store_ok: bool,
+    pub schema_version: Option<String>,
+    pub pending_migrations: Vec<String>,
+    pub warnings: Vec<String>,
 }

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -9,6 +9,8 @@ use crate::llm::LlmProvider;
 use crate::note::{MemoryNote, SearchResult};
 use crate::read::ReadEngine;
 use crate::rerank::{JinaReranker, LlmReranker, NoopReranker, Reranker};
+use crate::rules::{ProceduralRule, RuleContext, RuleEvaluation};
+use crate::rules_engine::RuleEngine;
 use crate::store::{GraphStore, VectorStore};
 use crate::write::WriteEngine;
 
@@ -280,6 +282,28 @@ impl Karta {
             pending_migrations: pending,
             warnings,
         })
+    }
+
+    // --- Rules ---
+
+    pub async fn evaluate_rules(&self, ctx: &RuleContext) -> Result<RuleEvaluation> {
+        let engine = RuleEngine::new(Arc::clone(&self.graph_store));
+        engine.evaluate(ctx).await
+    }
+
+    pub async fn add_rule(&self, rule: ProceduralRule) -> Result<()> {
+        let engine = RuleEngine::new(Arc::clone(&self.graph_store));
+        engine.add_rule(rule).await
+    }
+
+    pub async fn disable_rule(&self, rule_id: &str) -> Result<()> {
+        let engine = RuleEngine::new(Arc::clone(&self.graph_store));
+        engine.disable_rule(rule_id).await
+    }
+
+    pub async fn list_rules(&self) -> Result<Vec<ProceduralRule>> {
+        let engine = RuleEngine::new(Arc::clone(&self.graph_store));
+        engine.list_rules().await
     }
 }
 

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod dream;
 pub mod error;
+pub mod extract;
 pub mod llm;
 pub mod migrate;
 pub mod note;

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod dream;
 pub mod error;
 pub mod extract;
+pub mod forget;
 pub mod llm;
 pub mod migrate;
 pub mod note;

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod dream;
 pub mod error;
 pub mod llm;
+pub mod migrate;
 pub mod note;
 pub mod read;
 pub mod rerank;

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -7,6 +7,8 @@ pub mod migrate;
 pub mod note;
 pub mod read;
 pub mod rerank;
+pub mod rules;
+pub mod rules_engine;
 pub mod store;
 pub mod write;
 

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod dream;
 pub mod error;
 pub mod llm;
+pub mod migrate;
 pub mod note;
 pub mod read;
 pub mod rerank;
@@ -9,4 +10,4 @@ pub mod store;
 pub mod write;
 
 mod karta;
-pub use karta::Karta;
+pub use karta::{Karta, KartaHealth};

--- a/crates/karta-core/src/llm/mock.rs
+++ b/crates/karta-core/src/llm/mock.rs
@@ -19,6 +19,12 @@ pub struct MockLlmProvider {
     call_count: AtomicU64,
 }
 
+impl Default for MockLlmProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MockLlmProvider {
     pub fn new() -> Self {
         Self {
@@ -28,7 +34,10 @@ impl MockLlmProvider {
 
     fn extract_words(text: &str) -> Vec<String> {
         text.split_whitespace()
-            .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
+            .map(|w| {
+                w.trim_matches(|c: char| !c.is_alphanumeric())
+                    .to_lowercase()
+            })
             .filter(|w| w.len() > 3)
             .collect()
     }
@@ -136,22 +145,16 @@ impl MockLlmProvider {
         for block in candidates_text.split("[").skip(1) {
             // Extract the ID
             if let Some(id_line) = block.lines().find(|l| l.contains("ID:")) {
-                let id = id_line
-                    .split("ID:")
-                    .nth(1)
-                    .unwrap_or("")
-                    .trim()
-                    .to_string();
+                let id = id_line.split("ID:").nth(1).unwrap_or("").trim().to_string();
 
                 if id.is_empty() {
                     continue;
                 }
 
-                let candidate_words: std::collections::HashSet<String> =
-                    Self::extract_words(block)
-                        .into_iter()
-                        .filter(|w| w.len() > 4)
-                        .collect();
+                let candidate_words: std::collections::HashSet<String> = Self::extract_words(block)
+                    .into_iter()
+                    .filter(|w| w.len() > 4)
+                    .collect();
 
                 let shared: Vec<&String> = new_words.intersection(&candidate_words).collect();
                 if shared.len() >= 2 {
@@ -237,7 +240,8 @@ impl MockLlmProvider {
                     "reasoning": "Insufficient linked notes for deduction",
                     "conclusion": null,
                     "confidence": 0.0
-                }).to_string();
+                })
+                .to_string();
             };
             serde_json::json!({
                 "reasoning": "Analyzing the linked notes reveals logically connected constraints that entail a combined conclusion.",
@@ -334,13 +338,19 @@ impl LlmProvider for MockLlmProvider {
             self.handle_linking(user_msg)
         } else if system_msg.contains("Update the existing memory") {
             self.handle_evolution(user_msg)
-        } else if system_msg.to_lowercase().contains("answer questions using only") {
+        } else if system_msg
+            .to_lowercase()
+            .contains("answer questions using only")
+        {
             self.handle_synthesis(user_msg)
         } else if full_prompt.contains("updating an entity profile")
             || user_msg.contains("updating an entity profile")
         {
             // Profile merge
-            let new_info = user_msg.split("New information:").nth(1).unwrap_or(user_msg);
+            let new_info = user_msg
+                .split("New information:")
+                .nth(1)
+                .unwrap_or(user_msg);
             serde_json::json!({
                 "updatedProfile": format!("Updated profile incorporating new information. {}", new_info.trim().chars().take(200).collect::<String>())
             })
@@ -369,7 +379,11 @@ impl LlmProvider for MockLlmProvider {
             || full_prompt.contains("CONSPICUOUSLY ABSENT")
             || full_prompt.contains("CONTRADICT")
         {
-            self.handle_dream(if full_prompt.is_empty() { user_msg } else { full_prompt })
+            self.handle_dream(if full_prompt.is_empty() {
+                user_msg
+            } else {
+                full_prompt
+            })
         } else {
             // Fallback
             serde_json::json!({

--- a/crates/karta-core/src/llm/openai.rs
+++ b/crates/karta-core/src/llm/openai.rs
@@ -109,18 +109,16 @@ fn build_messages(messages: &[ChatMessage]) -> Vec<ChatCompletionRequestMessage>
     messages
         .iter()
         .map(|m| match m.role {
-            Role::System => ChatCompletionRequestMessage::System(
-                ChatCompletionRequestSystemMessage {
+            Role::System => {
+                ChatCompletionRequestMessage::System(ChatCompletionRequestSystemMessage {
                     content: m.content.clone().into(),
                     name: None,
-                },
-            ),
-            Role::User => ChatCompletionRequestMessage::User(
-                ChatCompletionRequestUserMessage {
-                    content: m.content.clone().into(),
-                    name: None,
-                },
-            ),
+                })
+            }
+            Role::User => ChatCompletionRequestMessage::User(ChatCompletionRequestUserMessage {
+                content: m.content.clone().into(),
+                name: None,
+            }),
             Role::Assistant => ChatCompletionRequestMessage::Assistant(
                 async_openai::types::ChatCompletionRequestAssistantMessage {
                     content: Some(m.content.clone().into()),
@@ -136,9 +134,7 @@ fn build_chat_request(
     messages: Vec<ChatCompletionRequestMessage>,
     config: &GenConfig,
 ) -> std::result::Result<async_openai::types::CreateChatCompletionRequest, KartaError> {
-    use async_openai::types::{
-        ResponseFormat, ResponseFormatJsonSchema,
-    };
+    use async_openai::types::{ResponseFormat, ResponseFormatJsonSchema};
 
     let mut builder = CreateChatCompletionRequestArgs::default();
     builder
@@ -257,10 +253,7 @@ impl LlmProvider for OpenAiProvider {
                 .and_then(|c| c.message.content.clone())
                 .unwrap_or_default();
 
-            let tokens_used = response
-                .usage
-                .map(|u| u.total_tokens as u64)
-                .unwrap_or(0);
+            let tokens_used = response.usage.map(|u| u.total_tokens as u64).unwrap_or(0);
 
             Ok(ChatResponse {
                 content,

--- a/crates/karta-core/src/migrate.rs
+++ b/crates/karta-core/src/migrate.rs
@@ -36,11 +36,16 @@ impl SchemaMeta {
 }
 
 /// A single migration step.
+///
+/// Migrations are applied forward with `up_sql`. `down_sql` is recorded so future
+/// tooling has an explicit rollback hook, but runtime rollback of a committed
+/// migration is not currently automated.
 #[derive(Debug, Clone)]
 pub struct Migration {
     pub id: &'static str,
     pub description: &'static str,
     pub up_sql: &'static str,
+    pub down_sql: Option<&'static str>,
 }
 
 /// Returns all migrations in order. Add new migrations here.
@@ -51,6 +56,15 @@ pub fn all_migrations() -> Vec<Migration> {
 /// Load the current schema meta from the database.
 #[cfg(feature = "sqlite")]
 pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
+    let migrations = all_migrations();
+    load_schema_meta_with_migrations(conn, &migrations)
+}
+
+#[cfg(feature = "sqlite")]
+fn load_schema_meta_with_migrations(
+    conn: &Connection,
+    migrations: &[Migration],
+) -> Result<SchemaMeta> {
     let result = conn.query_row(
         "SELECT schema_version, applied_migrations_json FROM schema_meta WHERE id = 1",
         [],
@@ -69,7 +83,7 @@ pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
                     format!("Invalid applied_migrations_json in schema_meta: {e}"),
                 )))
             })?;
-            let all_ids: Vec<&str> = all_migrations().iter().map(|m| m.id).collect();
+            let all_ids: Vec<&str> = migrations.iter().map(|m| m.id).collect();
             let pending: Vec<String> = all_ids
                 .iter()
                 .filter(|id| !applied.iter().any(|a| a == *id))
@@ -77,7 +91,10 @@ pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
                 .collect();
             Ok(SchemaMeta::new(version, applied, pending, vec![]))
         }
-        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(SchemaMeta::new(0, vec![], vec![], vec![])),
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            let pending = migrations.iter().map(|m| m.id.to_string()).collect();
+            Ok(SchemaMeta::new(0, vec![], pending, vec![]))
+        }
         Err(e) => Err(KartaError::GraphStore(e.to_string())),
     }
 }
@@ -90,26 +107,38 @@ pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
 }
 
 #[cfg(feature = "sqlite")]
-fn apply_migrations_with(conn: &Connection, migrations: &[Migration]) -> Result<SchemaMeta> {
-    let meta = load_schema_meta(conn)?;
-    let pending_migrations: Vec<String> = migrations
-        .iter()
-        .filter(|m| !meta.applied_migrations.iter().any(|id| id == m.id))
-        .map(|m| m.id.to_string())
-        .collect();
+fn persist_schema_meta(conn: &Connection, schema_version: u32, applied: &[String]) -> Result<()> {
+    let applied_json = serde_json::to_string(applied).map_err(KartaError::Serialization)?;
+    let now = Utc::now().to_rfc3339();
 
-    if pending_migrations.is_empty() {
-        return Ok(SchemaMeta::new(
-            meta.schema_version,
-            meta.applied_migrations,
-            Vec::new(),
-            meta.warnings,
-        ));
+    conn.execute(
+        "INSERT INTO schema_meta (id, schema_version, applied_migrations_json, last_migration_at)
+         VALUES (1, ?1, ?2, ?3)
+         ON CONFLICT(id) DO UPDATE SET
+             schema_version = ?1,
+             applied_migrations_json = ?2,
+             last_migration_at = ?3",
+        rusqlite::params![schema_version, applied_json, now],
+    )
+    .map(|_| ())
+    .map_err(|e| KartaError::GraphStore(e.to_string()))
+}
+
+#[cfg(feature = "sqlite")]
+fn apply_migrations_with(conn: &Connection, migrations: &[Migration]) -> Result<SchemaMeta> {
+    let meta = load_schema_meta_with_migrations(conn, migrations)?;
+
+    if meta.pending_migrations.is_empty() {
+        if meta.schema_version < CURRENT_SCHEMA_VERSION {
+            persist_schema_meta(conn, CURRENT_SCHEMA_VERSION, &meta.applied_migrations)?;
+            return load_schema_meta_with_migrations(conn, migrations);
+        }
+        return Ok(meta);
     }
 
     let mut applied = meta.applied_migrations.clone();
 
-    for pending_id in &pending_migrations {
+    for pending_id in &meta.pending_migrations {
         let migration = migrations.iter().find(|m| m.id == pending_id.as_str());
         let migration = match migration {
             Some(m) => m,
@@ -133,7 +162,6 @@ fn apply_migrations_with(conn: &Connection, migrations: &[Migration]) -> Result<
             )));
         }
 
-        // Update schema_meta to record this migration only after its SQL succeeded.
         applied.push(migration.id.to_string());
         let applied_json = serde_json::to_string(&applied).map_err(KartaError::Serialization)?;
         let now = Utc::now().to_rfc3339();
@@ -162,17 +190,7 @@ fn apply_migrations_with(conn: &Connection, migrations: &[Migration]) -> Result<
         }
     }
 
-    let pending_migrations: Vec<String> = migrations
-        .iter()
-        .filter(|m| !applied.iter().any(|id| id == m.id))
-        .map(|m| m.id.to_string())
-        .collect();
-    Ok(SchemaMeta::new(
-        CURRENT_SCHEMA_VERSION,
-        applied,
-        pending_migrations,
-        Vec::new(),
-    ))
+    load_schema_meta_with_migrations(conn, migrations)
 }
 
 /// Initialize the schema_meta table if it doesn't exist, then apply pending migrations.
@@ -234,11 +252,13 @@ mod tests {
                 id: "001_test",
                 description: "first synthetic migration",
                 up_sql: "CREATE TABLE synthetic_one (id INTEGER PRIMARY KEY);",
+                down_sql: Some("DROP TABLE synthetic_one;"),
             },
             Migration {
                 id: "002_test",
                 description: "second synthetic migration",
                 up_sql: "CREATE TABLE synthetic_two (id INTEGER PRIMARY KEY);",
+                down_sql: Some("DROP TABLE synthetic_two;"),
             },
         ];
 
@@ -260,5 +280,32 @@ mod tests {
         let rerun = apply_migrations_with(&conn, &migrations).unwrap();
         assert_eq!(rerun.applied_migrations, meta.applied_migrations);
         assert!(rerun.pending_migrations.is_empty());
+    }
+
+    #[test]
+    fn init_bootstraps_empty_migration_list_to_current_schema_version() {
+        let conn = Connection::open_in_memory().unwrap();
+
+        let meta = init_and_migrate(&conn).unwrap();
+
+        assert_eq!(meta.schema_version, CURRENT_SCHEMA_VERSION);
+        assert!(meta.applied_migrations.is_empty());
+        assert!(meta.pending_migrations.is_empty());
+    }
+
+    #[test]
+    fn malformed_applied_migrations_json_returns_error() {
+        let conn = setup_conn();
+        conn.execute(
+            "INSERT INTO schema_meta (id, schema_version, applied_migrations_json) VALUES (1, 1, 'not-json')",
+            [],
+        )
+        .unwrap();
+
+        let err = load_schema_meta(&conn).expect_err("malformed JSON should fail");
+        match err {
+            KartaError::Serialization(_) => {}
+            other => panic!("expected serialization error, got {other:?}"),
+        }
     }
 }

--- a/crates/karta-core/src/migrate.rs
+++ b/crates/karta-core/src/migrate.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
 use chrono::Utc;
 use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
 
 use crate::error::{KartaError, Result};
 
@@ -17,7 +17,12 @@ pub struct SchemaMeta {
 }
 
 impl SchemaMeta {
-    pub fn new(version: u32, applied: Vec<String>, pending: Vec<String>, warnings: Vec<String>) -> Self {
+    pub fn new(
+        version: u32,
+        applied: Vec<String>,
+        pending: Vec<String>,
+        warnings: Vec<String>,
+    ) -> Self {
         Self {
             schema_version: version,
             applied_migrations: applied,
@@ -28,10 +33,15 @@ impl SchemaMeta {
 }
 
 /// A single migration step.
+///
+/// Migrations are applied forward with `up_sql`. `down_sql` is recorded so future
+/// tooling has an explicit rollback hook, but runtime rollback of a committed
+/// migration is not currently automated.
 pub struct Migration {
     pub id: &'static str,
     pub description: &'static str,
     pub up_sql: &'static str,
+    pub down_sql: Option<&'static str>,
 }
 
 /// Returns all migrations in order. Add new migrations here.
@@ -41,6 +51,14 @@ pub fn all_migrations() -> Vec<Migration> {
 
 /// Load the current schema meta from the database.
 pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
+    let migrations = all_migrations();
+    load_schema_meta_with_migrations(conn, &migrations)
+}
+
+fn load_schema_meta_with_migrations(
+    conn: &Connection,
+    migrations: &[Migration],
+) -> Result<SchemaMeta> {
     let result = conn.query_row(
         "SELECT schema_version, applied_migrations_json FROM schema_meta WHERE id = 1",
         [],
@@ -53,8 +71,13 @@ pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
 
     match result {
         Ok((version, applied_json)) => {
-            let applied: Vec<String> = serde_json::from_str(&applied_json).unwrap_or_default();
-            let all_ids: Vec<&str> = all_migrations().iter().map(|m| m.id).collect();
+            let applied: Vec<String> = serde_json::from_str(&applied_json).map_err(|e| {
+                KartaError::GraphStore(format!(
+                    "Invalid applied_migrations_json in schema_meta: {}",
+                    e
+                ))
+            })?;
+            let all_ids: Vec<&str> = migrations.iter().map(|m| m.id).collect();
             let pending: Vec<String> = all_ids
                 .iter()
                 .filter(|id| !applied.iter().any(|a| a == *id))
@@ -63,7 +86,8 @@ pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
             Ok(SchemaMeta::new(version, applied, pending, vec![]))
         }
         Err(rusqlite::Error::QueryReturnedNoRows) => {
-            Ok(SchemaMeta::new(0, vec![], vec![], vec![]))
+            let pending = migrations.iter().map(|m| m.id.to_string()).collect();
+            Ok(SchemaMeta::new(0, vec![], pending, vec![]))
         }
         Err(e) => Err(KartaError::GraphStore(e.to_string())),
     }
@@ -71,13 +95,42 @@ pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
 
 /// Apply pending migrations. Returns the updated SchemaMeta.
 pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
-    let meta = load_schema_meta(conn)?;
+    let migrations = all_migrations();
+    apply_migrations_with_migrations(conn, &migrations)
+}
+
+fn persist_schema_meta(conn: &Connection, schema_version: u32, applied: &[String]) -> Result<()> {
+    let applied_json = serde_json::to_string(applied).map_err(|e| KartaError::Serialization(e))?;
+    let now = Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO schema_meta (id, schema_version, applied_migrations_json, last_migration_at)
+         VALUES (1, ?1, ?2, ?3)
+         ON CONFLICT(id) DO UPDATE SET
+             schema_version = ?1,
+             applied_migrations_json = ?2,
+             last_migration_at = ?3",
+        rusqlite::params![schema_version, applied_json, now],
+    )
+    .map(|_| ())
+    .map_err(|e| KartaError::GraphStore(e.to_string()))
+}
+
+fn apply_migrations_with_migrations(
+    conn: &Connection,
+    migrations: &[Migration],
+) -> Result<SchemaMeta> {
+    let meta = load_schema_meta_with_migrations(conn, migrations)?;
 
     if meta.pending_migrations.is_empty() {
+        if meta.schema_version < CURRENT_SCHEMA_VERSION {
+            persist_schema_meta(conn, CURRENT_SCHEMA_VERSION, &meta.applied_migrations)?;
+            return load_schema_meta_with_migrations(conn, migrations);
+        }
         return Ok(meta);
     }
 
-    let migrations = all_migrations();
+    let mut applied = meta.applied_migrations.clone();
 
     for pending_id in &meta.pending_migrations {
         let migration = migrations.iter().find(|m| m.id == pending_id.as_str());
@@ -91,7 +144,8 @@ pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
             }
         };
 
-        let tx = conn.unchecked_transaction()
+        let tx = conn
+            .unchecked_transaction()
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         if let Err(e) = tx.execute_batch(migration.up_sql) {
@@ -103,10 +157,9 @@ pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
         }
 
         // Update schema_meta to record this migration
-        let mut applied = meta.applied_migrations.clone();
         applied.push(migration.id.to_string());
-        let applied_json = serde_json::to_string(&applied)
-            .map_err(|e| KartaError::Serialization(e))?;
+        let applied_json =
+            serde_json::to_string(&applied).map_err(|e| KartaError::Serialization(e))?;
         let now = Utc::now().to_rfc3339();
 
         if let Err(e) = tx.execute(
@@ -116,7 +169,7 @@ pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
                  schema_version = ?1,
                  applied_migrations_json = ?2,
                  last_migration_at = ?3",
-            rusqlite::params![applied.len(), applied_json, now],
+            rusqlite::params![CURRENT_SCHEMA_VERSION, applied_json, now],
         ) {
             let _ = tx.rollback();
             return Err(KartaError::GraphStore(format!(
@@ -133,7 +186,7 @@ pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
         }
     }
 
-    load_schema_meta(conn)
+    load_schema_meta_with_migrations(conn, migrations)
 }
 
 /// Initialize the schema_meta table if it doesn't exist, then apply pending migrations.
@@ -147,7 +200,87 @@ pub fn init_and_migrate(conn: &Connection) -> Result<SchemaMeta> {
             last_migration_at TEXT
         )",
         [],
-    ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    )
+    .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
     apply_migrations(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn in_memory_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory sqlite database");
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS schema_meta (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                schema_version INTEGER NOT NULL DEFAULT 0,
+                applied_migrations_json TEXT NOT NULL DEFAULT '[]',
+                last_migration_at TEXT
+            )",
+            [],
+        )
+        .expect("create schema_meta");
+        conn
+    }
+
+    #[test]
+    fn init_bootstraps_empty_migration_list_to_current_schema_version() {
+        let conn = Connection::open_in_memory().expect("open in-memory sqlite database");
+
+        let meta = init_and_migrate(&conn).expect("initialize schema metadata");
+
+        assert_eq!(meta.schema_version, CURRENT_SCHEMA_VERSION);
+        assert!(meta.applied_migrations.is_empty());
+        assert!(meta.pending_migrations.is_empty());
+    }
+
+    #[test]
+    fn malformed_applied_migrations_json_returns_graph_store_error() {
+        let conn = in_memory_conn();
+        conn.execute(
+            "INSERT INTO schema_meta (id, schema_version, applied_migrations_json)
+             VALUES (1, 1, 'not-json')",
+            [],
+        )
+        .expect("insert malformed schema metadata");
+
+        let err = load_schema_meta(&conn).expect_err("malformed JSON should fail");
+
+        match err {
+            KartaError::GraphStore(message) => {
+                assert!(message.contains("Invalid applied_migrations_json"));
+            }
+            other => panic!("expected GraphStore error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn migration_loop_accumulates_applied_ids_and_persists_current_schema_version() {
+        let conn = in_memory_conn();
+        let migrations = vec![
+            Migration {
+                id: "001_create_foo",
+                description: "create foo",
+                up_sql: "CREATE TABLE foo (id INTEGER PRIMARY KEY);",
+                down_sql: Some("DROP TABLE foo;"),
+            },
+            Migration {
+                id: "002_create_bar",
+                description: "create bar",
+                up_sql: "CREATE TABLE bar (id INTEGER PRIMARY KEY);",
+                down_sql: Some("DROP TABLE bar;"),
+            },
+        ];
+
+        let meta = apply_migrations_with_migrations(&conn, &migrations).expect("apply migrations");
+
+        assert_eq!(meta.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(
+            meta.applied_migrations,
+            vec!["001_create_foo".to_string(), "002_create_bar".to_string()]
+        );
+        assert!(meta.pending_migrations.is_empty());
+    }
 }

--- a/crates/karta-core/src/migrate.rs
+++ b/crates/karta-core/src/migrate.rs
@@ -1,0 +1,153 @@
+use serde::{Deserialize, Serialize};
+use chrono::Utc;
+use rusqlite::Connection;
+
+use crate::error::{KartaError, Result};
+
+/// Current schema version. Increment this when adding new migrations.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Tracks the current schema state of a Karta data directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaMeta {
+    pub schema_version: u32,
+    pub applied_migrations: Vec<String>,
+    pub pending_migrations: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl SchemaMeta {
+    pub fn new(version: u32, applied: Vec<String>, pending: Vec<String>, warnings: Vec<String>) -> Self {
+        Self {
+            schema_version: version,
+            applied_migrations: applied,
+            pending_migrations: pending,
+            warnings,
+        }
+    }
+}
+
+/// A single migration step.
+pub struct Migration {
+    pub id: &'static str,
+    pub description: &'static str,
+    pub up_sql: &'static str,
+}
+
+/// Returns all migrations in order. Add new migrations here.
+pub fn all_migrations() -> Vec<Migration> {
+    vec![]
+}
+
+/// Load the current schema meta from the database.
+pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
+    let result = conn.query_row(
+        "SELECT schema_version, applied_migrations_json FROM schema_meta WHERE id = 1",
+        [],
+        |row| {
+            let version: u32 = row.get(0)?;
+            let applied_json: String = row.get(1)?;
+            Ok((version, applied_json))
+        },
+    );
+
+    match result {
+        Ok((version, applied_json)) => {
+            let applied: Vec<String> = serde_json::from_str(&applied_json).unwrap_or_default();
+            let all_ids: Vec<&str> = all_migrations().iter().map(|m| m.id).collect();
+            let pending: Vec<String> = all_ids
+                .iter()
+                .filter(|id| !applied.iter().any(|a| a == *id))
+                .map(|s| s.to_string())
+                .collect();
+            Ok(SchemaMeta::new(version, applied, pending, vec![]))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            Ok(SchemaMeta::new(0, vec![], vec![], vec![]))
+        }
+        Err(e) => Err(KartaError::GraphStore(e.to_string())),
+    }
+}
+
+/// Apply pending migrations. Returns the updated SchemaMeta.
+pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
+    let meta = load_schema_meta(conn)?;
+
+    if meta.pending_migrations.is_empty() {
+        return Ok(meta);
+    }
+
+    let migrations = all_migrations();
+
+    for pending_id in &meta.pending_migrations {
+        let migration = migrations.iter().find(|m| m.id == pending_id.as_str());
+        let migration = match migration {
+            Some(m) => m,
+            None => {
+                return Err(KartaError::Config(format!(
+                    "Migration {} not found in migration list",
+                    pending_id
+                )));
+            }
+        };
+
+        let tx = conn.unchecked_transaction()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        if let Err(e) = tx.execute_batch(migration.up_sql) {
+            let _ = tx.rollback();
+            return Err(KartaError::GraphStore(format!(
+                "Migration {} failed: {}",
+                migration.id, e
+            )));
+        }
+
+        // Update schema_meta to record this migration
+        let mut applied = meta.applied_migrations.clone();
+        applied.push(migration.id.to_string());
+        let applied_json = serde_json::to_string(&applied)
+            .map_err(|e| KartaError::Serialization(e))?;
+        let now = Utc::now().to_rfc3339();
+
+        if let Err(e) = tx.execute(
+            "INSERT INTO schema_meta (id, schema_version, applied_migrations_json, last_migration_at)
+             VALUES (1, ?1, ?2, ?3)
+             ON CONFLICT(id) DO UPDATE SET
+                 schema_version = ?1,
+                 applied_migrations_json = ?2,
+                 last_migration_at = ?3",
+            rusqlite::params![applied.len(), applied_json, now],
+        ) {
+            let _ = tx.rollback();
+            return Err(KartaError::GraphStore(format!(
+                "Failed to update schema_meta after migration {}: {}",
+                migration.id, e
+            )));
+        }
+
+        if let Err(e) = tx.commit() {
+            return Err(KartaError::GraphStore(format!(
+                "Failed to commit migration {}: {}",
+                migration.id, e
+            )));
+        }
+    }
+
+    load_schema_meta(conn)
+}
+
+/// Initialize the schema_meta table if it doesn't exist, then apply pending migrations.
+pub fn init_and_migrate(conn: &Connection) -> Result<SchemaMeta> {
+    // Create schema_meta table first (bootstrap)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_meta (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            schema_version INTEGER NOT NULL DEFAULT 0,
+            applied_migrations_json TEXT NOT NULL DEFAULT '[]',
+            last_migration_at TEXT
+        )",
+        [],
+    ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+    apply_migrations(conn)
+}

--- a/crates/karta-core/src/migrate.rs
+++ b/crates/karta-core/src/migrate.rs
@@ -1,0 +1,264 @@
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "sqlite")]
+use crate::error::{KartaError, Result};
+#[cfg(feature = "sqlite")]
+use chrono::Utc;
+#[cfg(feature = "sqlite")]
+use rusqlite::Connection;
+
+/// Current schema version. Increment this when adding new migrations.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Tracks the current schema state of a Karta data directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaMeta {
+    pub schema_version: u32,
+    pub applied_migrations: Vec<String>,
+    pub pending_migrations: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl SchemaMeta {
+    pub fn new(
+        version: u32,
+        applied: Vec<String>,
+        pending: Vec<String>,
+        warnings: Vec<String>,
+    ) -> Self {
+        Self {
+            schema_version: version,
+            applied_migrations: applied,
+            pending_migrations: pending,
+            warnings,
+        }
+    }
+}
+
+/// A single migration step.
+#[derive(Debug, Clone)]
+pub struct Migration {
+    pub id: &'static str,
+    pub description: &'static str,
+    pub up_sql: &'static str,
+}
+
+/// Returns all migrations in order. Add new migrations here.
+pub fn all_migrations() -> Vec<Migration> {
+    vec![]
+}
+
+/// Load the current schema meta from the database.
+#[cfg(feature = "sqlite")]
+pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
+    let result = conn.query_row(
+        "SELECT schema_version, applied_migrations_json FROM schema_meta WHERE id = 1",
+        [],
+        |row| {
+            let version: u32 = row.get(0)?;
+            let applied_json: String = row.get(1)?;
+            Ok((version, applied_json))
+        },
+    );
+
+    match result {
+        Ok((version, applied_json)) => {
+            let applied: Vec<String> = serde_json::from_str(&applied_json).map_err(|e| {
+                KartaError::Serialization(serde_json::Error::io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Invalid applied_migrations_json in schema_meta: {e}"),
+                )))
+            })?;
+            let all_ids: Vec<&str> = all_migrations().iter().map(|m| m.id).collect();
+            let pending: Vec<String> = all_ids
+                .iter()
+                .filter(|id| !applied.iter().any(|a| a == *id))
+                .map(|s| s.to_string())
+                .collect();
+            Ok(SchemaMeta::new(version, applied, pending, vec![]))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(SchemaMeta::new(0, vec![], vec![], vec![])),
+        Err(e) => Err(KartaError::GraphStore(e.to_string())),
+    }
+}
+
+/// Apply pending migrations. Returns the updated SchemaMeta.
+#[cfg(feature = "sqlite")]
+pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
+    let migrations = all_migrations();
+    apply_migrations_with(conn, &migrations)
+}
+
+#[cfg(feature = "sqlite")]
+fn apply_migrations_with(conn: &Connection, migrations: &[Migration]) -> Result<SchemaMeta> {
+    let meta = load_schema_meta(conn)?;
+    let pending_migrations: Vec<String> = migrations
+        .iter()
+        .filter(|m| !meta.applied_migrations.iter().any(|id| id == m.id))
+        .map(|m| m.id.to_string())
+        .collect();
+
+    if pending_migrations.is_empty() {
+        return Ok(SchemaMeta::new(
+            meta.schema_version,
+            meta.applied_migrations,
+            Vec::new(),
+            meta.warnings,
+        ));
+    }
+
+    let mut applied = meta.applied_migrations.clone();
+
+    for pending_id in &pending_migrations {
+        let migration = migrations.iter().find(|m| m.id == pending_id.as_str());
+        let migration = match migration {
+            Some(m) => m,
+            None => {
+                return Err(KartaError::Config(format!(
+                    "Migration {} not found in migration list",
+                    pending_id
+                )));
+            }
+        };
+
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        if let Err(e) = tx.execute_batch(migration.up_sql) {
+            let _ = tx.rollback();
+            return Err(KartaError::GraphStore(format!(
+                "Migration {} failed: {}",
+                migration.id, e
+            )));
+        }
+
+        // Update schema_meta to record this migration only after its SQL succeeded.
+        applied.push(migration.id.to_string());
+        let applied_json = serde_json::to_string(&applied).map_err(KartaError::Serialization)?;
+        let now = Utc::now().to_rfc3339();
+
+        if let Err(e) = tx.execute(
+            "INSERT INTO schema_meta (id, schema_version, applied_migrations_json, last_migration_at)
+             VALUES (1, ?1, ?2, ?3)
+             ON CONFLICT(id) DO UPDATE SET
+                 schema_version = ?1,
+                 applied_migrations_json = ?2,
+                 last_migration_at = ?3",
+            rusqlite::params![CURRENT_SCHEMA_VERSION, applied_json, now],
+        ) {
+            let _ = tx.rollback();
+            return Err(KartaError::GraphStore(format!(
+                "Failed to update schema_meta after migration {}: {}",
+                migration.id, e
+            )));
+        }
+
+        if let Err(e) = tx.commit() {
+            return Err(KartaError::GraphStore(format!(
+                "Failed to commit migration {}: {}",
+                migration.id, e
+            )));
+        }
+    }
+
+    let pending_migrations: Vec<String> = migrations
+        .iter()
+        .filter(|m| !applied.iter().any(|id| id == m.id))
+        .map(|m| m.id.to_string())
+        .collect();
+    Ok(SchemaMeta::new(
+        CURRENT_SCHEMA_VERSION,
+        applied,
+        pending_migrations,
+        Vec::new(),
+    ))
+}
+
+/// Initialize the schema_meta table if it doesn't exist, then apply pending migrations.
+#[cfg(feature = "sqlite")]
+pub fn init_and_migrate(conn: &Connection) -> Result<SchemaMeta> {
+    // Create schema_meta table first (bootstrap)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_meta (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            schema_version INTEGER NOT NULL DEFAULT 0,
+            applied_migrations_json TEXT NOT NULL DEFAULT '[]',
+            last_migration_at TEXT
+        )",
+        [],
+    )
+    .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+    // Ensure the singleton metadata row exists even when there are no pending
+    // migrations. Without this bootstrap row, a freshly initialized database
+    // reports schema_version=0 indefinitely.
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_meta (
+            id,
+            schema_version,
+            applied_migrations_json,
+            last_migration_at
+        ) VALUES (1, ?1, '[]', ?2)",
+        rusqlite::params![CURRENT_SCHEMA_VERSION, Utc::now().to_rfc3339()],
+    )
+    .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+    apply_migrations(conn)
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE schema_meta (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                schema_version INTEGER NOT NULL DEFAULT 0,
+                applied_migrations_json TEXT NOT NULL DEFAULT '[]',
+                last_migration_at TEXT
+            )",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn apply_migrations_persists_all_ids_and_is_idempotent() {
+        let conn = setup_conn();
+        let migrations = vec![
+            Migration {
+                id: "001_test",
+                description: "first synthetic migration",
+                up_sql: "CREATE TABLE synthetic_one (id INTEGER PRIMARY KEY);",
+            },
+            Migration {
+                id: "002_test",
+                description: "second synthetic migration",
+                up_sql: "CREATE TABLE synthetic_two (id INTEGER PRIMARY KEY);",
+            },
+        ];
+
+        // Seed schema_meta empty; apply_migrations_with computes pending IDs from the supplied synthetic list.
+        conn.execute(
+            "INSERT INTO schema_meta (id, schema_version, applied_migrations_json) VALUES (1, 0, '[]')",
+            [],
+        )
+        .unwrap();
+
+        let meta = apply_migrations_with(&conn, &migrations).unwrap();
+        assert_eq!(meta.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(
+            meta.applied_migrations,
+            vec!["001_test".to_string(), "002_test".to_string()]
+        );
+        assert!(meta.pending_migrations.is_empty());
+
+        let rerun = apply_migrations_with(&conn, &migrations).unwrap();
+        assert_eq!(rerun.applied_migrations, meta.applied_migrations);
+        assert!(rerun.pending_migrations.is_empty());
+    }
+}

--- a/crates/karta-core/src/note.rs
+++ b/crates/karta-core/src/note.rs
@@ -103,21 +103,13 @@ pub enum Provenance {
         confidence: f32,
     },
     /// Entity profile built from consolidation dreams.
-    Profile {
-        entity_id: String,
-    },
+    Profile { entity_id: String },
     /// Episode narrative synthesis.
-    Episode {
-        episode_id: String,
-    },
+    Episode { episode_id: String },
     /// Atomic fact extracted from a note.
-    Fact {
-        source_note_id: String,
-    },
+    Fact { source_note_id: String },
     /// Episode digest produced by dream engine.
-    Digest {
-        episode_id: String,
-    },
+    Digest { episode_id: String },
 }
 
 /// Result of a similarity search.
@@ -206,7 +198,11 @@ pub enum ForesightStatus {
 }
 
 impl ForesightSignal {
-    pub fn new(content: String, source_note_id: String, valid_until: Option<DateTime<Utc>>) -> Self {
+    pub fn new(
+        content: String,
+        source_note_id: String,
+        valid_until: Option<DateTime<Utc>>,
+    ) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
             content,
@@ -404,16 +400,15 @@ pub struct AggregationEntry {
 
 // ─── Note Lifecycle (Phase 3.1) ─────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub enum NoteStatus {
+    #[default]
     Active,
-    Deprecated { by: String },
-    Superseded { by: String },
+    Deprecated {
+        by: String,
+    },
+    Superseded {
+        by: String,
+    },
     Archived,
-}
-
-impl Default for NoteStatus {
-    fn default() -> Self {
-        NoteStatus::Active
-    }
 }

--- a/crates/karta-core/src/note.rs
+++ b/crates/karta-core/src/note.rs
@@ -137,6 +137,37 @@ pub struct AskResult {
     pub has_contradiction: bool,
     /// Best reranker relevance score (None if reranker disabled).
     pub reranker_best_score: Option<f32>,
+    /// Evidence packets explaining why each note was retrieved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<EvidencePacket>,
+}
+
+/// Evidence packet explaining why notes were retrieved for an answer.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct EvidencePacket {
+    /// Per-channel retrieval traces (e.g., "ann", "facts", "profile").
+    pub channel_traces: Vec<ChannelTrace>,
+    /// IDs of fired procedural rules.
+    pub fired_rule_ids: Vec<String>,
+    /// IDs of unresolved contradictions affecting this answer.
+    pub contradiction_ids: Vec<String>,
+    /// Human-readable explanation of why these notes were retrieved.
+    pub why_retrieved: String,
+}
+
+/// Trace for a single retrieval channel.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChannelTrace {
+    pub channel: String,
+    /// Ranked hits for this channel, in retrieval order.
+    pub ranked: Vec<RankedHit>,
+    pub rrf_contribution: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RankedHit {
+    pub note_id: String,
+    pub score: f32,
 }
 
 /// A forward-looking statement extracted by the LLM during attribute generation.

--- a/crates/karta-core/src/read.rs
+++ b/crates/karta-core/src/read.rs
@@ -31,59 +31,77 @@ pub enum QueryMode {
 /// Prototype examples for embedding-based query classification.
 /// Each mode has representative queries that define its embedding centroid.
 const PROTOTYPES: &[(QueryMode, &[&str])] = &[
-    (QueryMode::Temporal, &[
-        "Can you list in order how I brought up different topics?",
-        "What was the sequence of events in my project?",
-        "In what order did I discuss these subjects?",
-        "What was the chronological progression of my work?",
-        "List the timeline of my activities",
-        "What happened first, second, third?",
-        "Walk me through the order of topics we covered",
-    ]),
-    (QueryMode::Recency, &[
-        "What is my current status on the project?",
-        "What's the latest update on my progress?",
-        "What am I working on right now?",
-        "What's the most recent version of my plan?",
-        "What did I last decide about the design?",
-        "What's my updated budget?",
-    ]),
-    (QueryMode::Breadth, &[
-        "Give me a comprehensive summary of my project",
-        "Can you summarize everything we've discussed?",
-        "Provide an overview of all my activities",
-        "Walk me through the full picture of what I've been doing",
-        "How has my approach evolved over time?",
-        "How did my project develop from start to finish?",
-    ]),
-    (QueryMode::Computation, &[
-        "How many days between the start and the deadline?",
-        "How many weeks did it take to finish?",
-        "How long did it take me to complete the task?",
-        "What's the total number of items I completed?",
-        "How many more problems did I solve compared to last time?",
-        "Calculate the time between event A and event B",
-        "How much progress did I make between March and April?",
-        "Which happened first, X or Y, and how far apart?",
-        "How many hours did I spend studying?",
-        "Days between my meeting and the deadline",
-    ]),
-    (QueryMode::Existence, &[
-        "Did I ever mention using Excel for tracking?",
-        "Is it true that I contradicted myself about the tool?",
-        "Have I been inconsistent about my preferences?",
-        "Does my earlier statement conflict with the later one?",
-        "Was there a contradiction in what I said?",
-    ]),
-    (QueryMode::Standard, &[
-        "What tools am I using for my project?",
-        "What did I say about the API integration?",
-        "What are my preferences for the UI design?",
-        "Tell me about my debugging approach",
-        "What feedback did I receive on my work?",
-        "What are the main features I'm building?",
-        "What constraints or requirements did I mention?",
-    ]),
+    (
+        QueryMode::Temporal,
+        &[
+            "Can you list in order how I brought up different topics?",
+            "What was the sequence of events in my project?",
+            "In what order did I discuss these subjects?",
+            "What was the chronological progression of my work?",
+            "List the timeline of my activities",
+            "What happened first, second, third?",
+            "Walk me through the order of topics we covered",
+        ],
+    ),
+    (
+        QueryMode::Recency,
+        &[
+            "What is my current status on the project?",
+            "What's the latest update on my progress?",
+            "What am I working on right now?",
+            "What's the most recent version of my plan?",
+            "What did I last decide about the design?",
+            "What's my updated budget?",
+        ],
+    ),
+    (
+        QueryMode::Breadth,
+        &[
+            "Give me a comprehensive summary of my project",
+            "Can you summarize everything we've discussed?",
+            "Provide an overview of all my activities",
+            "Walk me through the full picture of what I've been doing",
+            "How has my approach evolved over time?",
+            "How did my project develop from start to finish?",
+        ],
+    ),
+    (
+        QueryMode::Computation,
+        &[
+            "How many days between the start and the deadline?",
+            "How many weeks did it take to finish?",
+            "How long did it take me to complete the task?",
+            "What's the total number of items I completed?",
+            "How many more problems did I solve compared to last time?",
+            "Calculate the time between event A and event B",
+            "How much progress did I make between March and April?",
+            "Which happened first, X or Y, and how far apart?",
+            "How many hours did I spend studying?",
+            "Days between my meeting and the deadline",
+        ],
+    ),
+    (
+        QueryMode::Existence,
+        &[
+            "Did I ever mention using Excel for tracking?",
+            "Is it true that I contradicted myself about the tool?",
+            "Have I been inconsistent about my preferences?",
+            "Does my earlier statement conflict with the later one?",
+            "Was there a contradiction in what I said?",
+        ],
+    ),
+    (
+        QueryMode::Standard,
+        &[
+            "What tools am I using for my project?",
+            "What did I say about the API integration?",
+            "What are my preferences for the UI design?",
+            "Tell me about my debugging approach",
+            "What feedback did I receive on my work?",
+            "What are the main features I'm building?",
+            "What constraints or requirements did I mention?",
+        ],
+    ),
 ];
 
 /// Embedding-based query classifier. Classifies by cosine similarity to prototype centroids.
@@ -162,38 +180,56 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 fn classify_query_keywords(query: &str) -> QueryMode {
     let q = query.to_lowercase();
 
-    if q.contains("in what order") || q.contains("in order") || q.contains("sequence")
-        || q.contains("timeline") || q.contains("chronolog")
-        || q.contains("progression") || q.contains("history of")
-        || q.contains("changed over") || q.contains("steps ")
+    if q.contains("in what order")
+        || q.contains("in order")
+        || q.contains("sequence")
+        || q.contains("timeline")
+        || q.contains("chronolog")
+        || q.contains("progression")
+        || q.contains("history of")
+        || q.contains("changed over")
+        || q.contains("steps ")
         || (q.contains("list") && (q.contains("order") || q.contains("topic")))
     {
         return QueryMode::Temporal;
     }
 
-    if q.contains("current") || q.contains("latest") || q.contains("most recent")
-        || q.contains("right now") || q.contains("updated")
+    if q.contains("current")
+        || q.contains("latest")
+        || q.contains("most recent")
+        || q.contains("right now")
+        || q.contains("updated")
         || (q.contains("now") && !q.contains("know"))
     {
         return QueryMode::Recency;
     }
 
-    if q.contains("summary") || q.contains("summarize") || q.contains("comprehensive")
-        || q.contains("overview") || q.contains("walk me through")
-        || q.contains("how has") || q.contains("how did")
+    if q.contains("summary")
+        || q.contains("summarize")
+        || q.contains("comprehensive")
+        || q.contains("overview")
+        || q.contains("walk me through")
+        || q.contains("how has")
+        || q.contains("how did")
     {
         return QueryMode::Breadth;
     }
 
-    if q.contains("how many") || q.contains("how much") || q.contains("total")
-        || q.contains("calculate") || q.contains("difference between")
-        || q.contains("compare") || q.contains("days between")
+    if q.contains("how many")
+        || q.contains("how much")
+        || q.contains("total")
+        || q.contains("calculate")
+        || q.contains("difference between")
+        || q.contains("compare")
+        || q.contains("days between")
         || q.contains("months between")
     {
         return QueryMode::Computation;
     }
 
-    if q.contains("contradict") || q.contains("is it true") || q.contains("conflict")
+    if q.contains("contradict")
+        || q.contains("is it true")
+        || q.contains("conflict")
         || q.contains("inconsisten")
     {
         return QueryMode::Existence;
@@ -236,22 +272,31 @@ impl ReadEngine {
     /// Get or initialize the embedding-based query classifier.
     /// Falls back to empty classifier (keyword matching) on timeout or error.
     async fn get_classifier(&self) -> &QueryClassifier {
-        self.classifier.get_or_init(|| async {
-            eprintln!("[CLASSIFIER] Starting init (timeout: 60s)...");
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(60),
-                QueryClassifier::new(self.llm.as_ref()),
-            ).await {
-                Ok(c) => {
-                    eprintln!("[CLASSIFIER] Initialized with {} centroids", c.centroids.len());
-                    c
+        self.classifier
+            .get_or_init(|| async {
+                eprintln!("[CLASSIFIER] Starting init (timeout: 60s)...");
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(60),
+                    QueryClassifier::new(self.llm.as_ref()),
+                )
+                .await
+                {
+                    Ok(c) => {
+                        eprintln!(
+                            "[CLASSIFIER] Initialized with {} centroids",
+                            c.centroids.len()
+                        );
+                        c
+                    }
+                    Err(_) => {
+                        eprintln!("[CLASSIFIER] TIMEOUT — falling back to keyword matching");
+                        QueryClassifier {
+                            centroids: Vec::new(),
+                        }
+                    }
                 }
-                Err(_) => {
-                    eprintln!("[CLASSIFIER] TIMEOUT — falling back to keyword matching");
-                    QueryClassifier { centroids: Vec::new() }
-                }
-            }
-        }).await
+            })
+            .await
     }
 
     /// Compute a recency score for a note using exponential decay.
@@ -276,7 +321,12 @@ impl ReadEngine {
 
     /// Combine similarity score with recency to produce a final score.
     /// Accepts an explicit recency weight for mode-specific overrides.
-    fn blended_score_with_weight(&self, similarity: f32, note: &MemoryNote, recency_weight: f32) -> f32 {
+    fn blended_score_with_weight(
+        &self,
+        similarity: f32,
+        note: &MemoryNote,
+        recency_weight: f32,
+    ) -> f32 {
         let w = recency_weight.clamp(0.0, 1.0);
         let recency = self.recency_score(note);
         (1.0 - w) * similarity + w * recency
@@ -299,18 +349,16 @@ impl ReadEngine {
             .collect();
 
         // Chronological order: prefer turn_index > source_timestamp > created_at
-        notes.sort_by(|a, b| {
-            match (a.turn_index, b.turn_index) {
-                (Some(ai), Some(bi)) => ai.cmp(&bi),
+        notes.sort_by(|a, b| match (a.turn_index, b.turn_index) {
+            (Some(ai), Some(bi)) => ai.cmp(&bi),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => match (a.source_timestamp, b.source_timestamp) {
+                (Some(at), Some(bt)) => at.cmp(&bt),
                 (Some(_), None) => std::cmp::Ordering::Less,
                 (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => match (a.source_timestamp, b.source_timestamp) {
-                    (Some(at), Some(bt)) => at.cmp(&bt),
-                    (Some(_), None) => std::cmp::Ordering::Less,
-                    (None, Some(_)) => std::cmp::Ordering::Greater,
-                    (None, None) => a.created_at.cmp(&b.created_at),
-                },
-            }
+                (None, None) => a.created_at.cmp(&b.created_at),
+            },
         });
         notes.truncate(self.config.max_notes_per_episode);
         Ok(notes)
@@ -387,7 +435,11 @@ impl ReadEngine {
     /// Internal search: returns the full expanded candidate pool (not truncated)
     /// plus the classified query mode. Used by ask() so the reranker can see the
     /// full pool before truncation, and ask() can use the same mode for top_k sizing.
-    async fn search_wide(&self, query: &str, top_k: usize) -> Result<(Vec<SearchResult>, QueryMode)> {
+    async fn search_wide(
+        &self,
+        query: &str,
+        top_k: usize,
+    ) -> Result<(Vec<SearchResult>, QueryMode)> {
         info!("Searching: \"{}\"", query);
 
         let embeddings = self.llm.embed(&[query]).await?;
@@ -419,12 +471,17 @@ impl ReadEngine {
         let fact_k = fetch_k / 2;
         let (direct, fact_hits) = if self.config.fact_retrieval_enabled {
             let (direct_result, fact_hits_result) = tokio::join!(
-                self.vector_store.find_similar(&query_embedding, fetch_k, &[]),
-                self.vector_store.find_similar_facts(&query_embedding, fact_k, &[])
+                self.vector_store
+                    .find_similar(&query_embedding, fetch_k, &[]),
+                self.vector_store
+                    .find_similar_facts(&query_embedding, fact_k, &[])
             );
             (direct_result?, fact_hits_result.unwrap_or_default())
         } else {
-            let direct = self.vector_store.find_similar(&query_embedding, fetch_k, &[]).await?;
+            let direct = self
+                .vector_store
+                .find_similar(&query_embedding, fetch_k, &[])
+                .await?;
             (direct, Vec::new())
         };
 
@@ -449,22 +506,23 @@ impl ReadEngine {
                 .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
                 .filter(|t| t.len() >= 3)
                 .collect();
-            let matched = tokens.iter().any(|t| query_lower.contains(&t.to_lowercase()));
-            if matched {
-                if let Some(note) = self.vector_store.get(note_id).await? {
-                    if note.is_active() {
-                        let link_count = self.graph_store.get_link_count(note_id).await?;
-                        let graph_bonus = self.config.graph_weight * (1.0 + link_count as f32).ln();
-                        let score = 1.0 + graph_bonus;
-                        profile_note_ids.insert(note_id.clone());
-                        debug!(entity_id = %entity_id, score = score, "Profile auto-include");
-                        profile_results.push(SearchResult {
-                            note,
-                            score,
-                            linked_notes: Vec::new(),
-                        });
-                    }
-                }
+            let matched = tokens
+                .iter()
+                .any(|t| query_lower.contains(&t.to_lowercase()));
+            if matched
+                && let Some(note) = self.vector_store.get(note_id).await?
+                && note.is_active()
+            {
+                let link_count = self.graph_store.get_link_count(note_id).await?;
+                let graph_bonus = self.config.graph_weight * (1.0 + link_count as f32).ln();
+                let score = 1.0 + graph_bonus;
+                profile_note_ids.insert(note_id.clone());
+                debug!(entity_id = %entity_id, score = score, "Profile auto-include");
+                profile_results.push(SearchResult {
+                    note,
+                    score,
+                    linked_notes: Vec::new(),
+                });
             }
         }
 
@@ -485,11 +543,14 @@ impl ReadEngine {
             // Dreams are surfaced via contradiction force-retrieval.
             // Digests are surfaced via episode drilldown + episode link traversal.
             match &note.provenance {
-                Provenance::Dream { .. } | Provenance::Digest { .. } | Provenance::Fact { .. } => continue,
+                Provenance::Dream { .. } | Provenance::Digest { .. } | Provenance::Fact { .. } => {
+                    continue;
+                }
                 _ => {}
             }
 
-            let mut final_score = self.blended_score_with_weight(sim, &note, effective_recency_weight);
+            let mut final_score =
+                self.blended_score_with_weight(sim, &note, effective_recency_weight);
 
             // Graph-aware scoring: notes with more links score higher (PageRank-lite)
             let link_count = self.graph_store.get_link_count(&note.id).await?;
@@ -500,15 +561,14 @@ impl ReadEngine {
                 final_score += foresight_boost;
             }
 
-            if self.config.episode_retrieval_enabled {
-                if let Provenance::Episode { ref episode_id } = note.provenance {
-                    if final_score >= self.config.episode_drilldown_min_score {
-                        episode_hits.push((episode_id.clone(), final_score));
-                        continue; // Only skip flat if we're drilling down
-                    }
-                    // Below threshold: fall through to flat_hits — narrative may still be useful
-                }
+            if self.config.episode_retrieval_enabled
+                && let Provenance::Episode { ref episode_id } = note.provenance
+                && final_score >= self.config.episode_drilldown_min_score
+            {
+                episode_hits.push((episode_id.clone(), final_score));
+                continue; // Only skip flat if we're drilling down
             }
+            // Below threshold: fall through to flat_hits — narrative may still be useful
 
             flat_hits.push((note, final_score));
         }
@@ -561,9 +621,7 @@ impl ReadEngine {
             if episode_note_ids.contains(&note.id) {
                 continue; // Already included via episode drilldown
             }
-            let linked_notes = self
-                .multi_hop_traverse(&note.id, max_depth, decay)
-                .await?;
+            let linked_notes = self.multi_hop_traverse(&note.id, max_depth, decay).await?;
 
             flat_results.push(SearchResult {
                 note,
@@ -578,32 +636,40 @@ impl ReadEngine {
         let mut seen_note_ids: HashSet<String> = HashSet::new();
 
         // Collect already-included note IDs
-        for r in &profile_results { seen_note_ids.insert(r.note.id.clone()); }
-        for r in &episode_results { seen_note_ids.insert(r.note.id.clone()); }
-        for r in &flat_results { seen_note_ids.insert(r.note.id.clone()); }
-        for id in &episode_note_ids { seen_note_ids.insert(id.clone()); }
+        for r in &profile_results {
+            seen_note_ids.insert(r.note.id.clone());
+        }
+        for r in &episode_results {
+            seen_note_ids.insert(r.note.id.clone());
+        }
+        for r in &flat_results {
+            seen_note_ids.insert(r.note.id.clone());
+        }
+        for id in &episode_note_ids {
+            seen_note_ids.insert(id.clone());
+        }
 
         let fact_boost = self.config.fact_match_boost;
         for (fact, score) in &fact_hits {
-            if *score < 0.3 { continue; }
-            if seen_note_ids.insert(fact.source_note_id.clone()) {
-                if let Ok(Some(parent)) = self.vector_store.get(&fact.source_note_id).await {
-                    if parent.is_active() {
-                        // Clone the parent and prepend the matched fact text so the
-                        // synthesis LLM sees the exact value. The clone prevents
-                        // the access-tracking upsert from corrupting stored content.
-                        let mut annotated = parent.clone();
-                        annotated.content = format!(
-                            "[Matched fact: {}]\n\n{}",
-                            fact.content, annotated.content
-                        );
-                        fact_expanded.push(SearchResult {
-                            note: annotated,
-                            score: score + fact_boost,
-                            linked_notes: Vec::new(),
-                        });
-                    }
-                }
+            if *score < 0.3 {
+                continue;
+            }
+            // seen_note_ids.insert intentionally runs before self.vector_store.get and parent.is_active to preserve prior no-retry behavior.
+            if seen_note_ids.insert(fact.source_note_id.clone())
+                && let Ok(Some(parent)) = self.vector_store.get(&fact.source_note_id).await
+                && parent.is_active()
+            {
+                // Clone the parent and prepend the matched fact text so the
+                // synthesis LLM sees the exact value. The clone prevents
+                // the access-tracking upsert from corrupting stored content.
+                let mut annotated = parent.clone();
+                annotated.content =
+                    format!("[Matched fact: {}]\n\n{}", fact.content, annotated.content);
+                fact_expanded.push(SearchResult {
+                    note: annotated,
+                    score: score + fact_boost,
+                    linked_notes: Vec::new(),
+                });
             }
         }
 
@@ -617,27 +683,29 @@ impl ReadEngine {
         for (episode_id, _) in &episode_hits {
             if let Ok(links) = self.graph_store.get_episode_links(episode_id).await {
                 for (linked_ep_id, _link_type, _entity) in &links {
-                    if let Ok(Some(digest)) = self.graph_store.get_episode_digest(linked_ep_id).await {
-                        if let Some(ref note_id) = digest.digest_note_id {
-                            if seen_note_ids.insert(note_id.clone()) {
-                                if let Ok(Some(digest_note)) = self.vector_store.get(note_id).await {
-                                    if digest_note.is_active() {
-                                        linked_digest_results.push(SearchResult {
-                                            note: digest_note,
-                                            score: 0.5, // Moderate score for linked digests
-                                            linked_notes: Vec::new(),
-                                        });
-                                    }
-                                }
-                            }
-                        }
+                    if let Ok(Some(digest)) =
+                        self.graph_store.get_episode_digest(linked_ep_id).await
+                        && let Some(ref note_id) = digest.digest_note_id
+                        // seen_note_ids.insert intentionally runs before self.vector_store.get and digest_note.is_active to preserve prior no-retry behavior.
+                        && seen_note_ids.insert(note_id.clone())
+                        && let Ok(Some(digest_note)) = self.vector_store.get(note_id).await
+                        && digest_note.is_active()
+                    {
+                        linked_digest_results.push(SearchResult {
+                            note: digest_note,
+                            score: 0.5, // Moderate score for linked digests
+                            linked_notes: Vec::new(),
+                        });
                     }
                 }
             }
         }
 
         if !linked_digest_results.is_empty() {
-            debug!(count = linked_digest_results.len(), "Episode-linked digest notes");
+            debug!(
+                count = linked_digest_results.len(),
+                "Episode-linked digest notes"
+            );
         }
 
         // --- Structured digest query ---
@@ -645,7 +713,10 @@ impl ReadEngine {
         // Digests contain pre-computed aggregations, entity counts, and date ranges
         // that answer "how many X" and "what is the current Y" questions directly.
         let mut digest_matched_results: Vec<SearchResult> = Vec::new();
-        if matches!(mode, QueryMode::Computation | QueryMode::Breadth | QueryMode::Recency) {
+        if matches!(
+            mode,
+            QueryMode::Computation | QueryMode::Breadth | QueryMode::Recency
+        ) {
             let all_digests = self.graph_store.get_all_episode_digests().await?;
             let query_lower = query.to_lowercase();
 
@@ -656,9 +727,12 @@ impl ReadEngine {
                 // Search entities
                 for entity in &digest.entities {
                     if query_lower.contains(&entity.name.to_lowercase())
-                        || entity.name.to_lowercase().contains(&query_lower.split_whitespace()
-                            .filter(|w| w.len() > 3)
-                            .next().unwrap_or(""))
+                        || entity.name.to_lowercase().contains(
+                            query_lower
+                                .split_whitespace()
+                                .find(|w| w.len() > 3)
+                                .unwrap_or(""),
+                        )
                     {
                         matched = true;
                         break;
@@ -684,10 +758,12 @@ impl ReadEngine {
                 // Search digest text for query keywords
                 if !matched && !digest.digest_text.is_empty() {
                     let digest_lower = digest.digest_text.to_lowercase();
-                    let query_words: Vec<&str> = query_lower.split_whitespace()
+                    let query_words: Vec<&str> = query_lower
+                        .split_whitespace()
                         .filter(|w| w.len() > 3)
                         .collect();
-                    let match_count = query_words.iter()
+                    let match_count = query_words
+                        .iter()
                         .filter(|w| digest_lower.contains(*w))
                         .count();
                     if match_count >= 2 || (query_words.len() <= 3 && match_count >= 1) {
@@ -695,25 +771,26 @@ impl ReadEngine {
                     }
                 }
 
-                if matched {
-                    if let Some(ref note_id) = digest.digest_note_id {
-                        if seen_note_ids.insert(note_id.clone()) {
-                            if let Ok(Some(digest_note)) = self.vector_store.get(note_id).await {
-                                if digest_note.is_active() {
-                                    digest_matched_results.push(SearchResult {
-                                        note: digest_note,
-                                        score: 0.8, // High score: structured match is strong signal
-                                        linked_notes: Vec::new(),
-                                    });
-                                }
-                            }
-                        }
-                    }
+                if matched
+                    && let Some(ref note_id) = digest.digest_note_id
+                    // seen_note_ids.insert intentionally runs before self.vector_store.get and digest_note.is_active to preserve prior no-retry behavior.
+                    && seen_note_ids.insert(note_id.clone())
+                    && let Ok(Some(digest_note)) = self.vector_store.get(note_id).await
+                    && digest_note.is_active()
+                {
+                    digest_matched_results.push(SearchResult {
+                        note: digest_note,
+                        score: 0.8, // High score: structured match is strong signal
+                        linked_notes: Vec::new(),
+                    });
                 }
             }
 
             if !digest_matched_results.is_empty() {
-                debug!(count = digest_matched_results.len(), "Structurally matched episode digests");
+                debug!(
+                    count = digest_matched_results.len(),
+                    "Structurally matched episode digests"
+                );
             }
         }
 
@@ -760,7 +837,9 @@ impl ReadEngine {
 
         if results.is_empty() {
             return Ok(AskResult {
-                answer: "Based on the available memories, I don't have information about this topic.".to_string(),
+                answer:
+                    "Based on the available memories, I don't have information about this topic."
+                        .to_string(),
                 query_mode: mode_str,
                 notes_used: 0,
                 note_ids: Vec::new(),
@@ -780,7 +859,8 @@ impl ReadEngine {
 
             let reranked = self.reranker.rerank(query, notes_for_rerank).await?;
 
-            let best_relevance = reranked.iter()
+            let best_relevance = reranked
+                .iter()
                 .map(|r| r.relevance_score)
                 .fold(0.0f32, f32::max);
 
@@ -802,11 +882,13 @@ impl ReadEngine {
             // Computation needs factual completeness (both date notes), not topical precision.
             // Reranker pushes date-bearing notes down because they score low on topical relevance.
             if mode != QueryMode::Computation {
-                let reranked_ids: HashSet<String> = reranked.iter().map(|r| r.note.id.clone()).collect();
+                let reranked_ids: HashSet<String> =
+                    reranked.iter().map(|r| r.note.id.clone()).collect();
                 let mut reordered: Vec<SearchResult> = Vec::new();
 
                 for rr in &reranked {
-                    let linked = results.iter()
+                    let linked = results
+                        .iter()
                         .find(|r| r.note.id == rr.note.id)
                         .map(|r| r.linked_notes.clone())
                         .unwrap_or_default();
@@ -824,7 +906,10 @@ impl ReadEngine {
                 }
 
                 results = reordered;
-                debug!(reranked_count = reranked.len(), "Reranker: reordered results by relevance");
+                debug!(
+                    reranked_count = reranked.len(),
+                    "Reranker: reordered results by relevance"
+                );
             } else {
                 debug!("Reranker: skipping reorder for Computation mode (preserving ANN order)");
             }
@@ -870,18 +955,16 @@ impl ReadEngine {
 
         // Sort notes by conversation order (turn_index > source_timestamp > created_at).
         // LLMs perform better when notes arrive in chronological sequence, not relevance order.
-        all_notes.sort_by(|a, b| {
-            match (a.turn_index, b.turn_index) {
-                (Some(ai), Some(bi)) => ai.cmp(&bi),
+        all_notes.sort_by(|a, b| match (a.turn_index, b.turn_index) {
+            (Some(ai), Some(bi)) => ai.cmp(&bi),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => match (a.source_timestamp, b.source_timestamp) {
+                (Some(at), Some(bt)) => at.cmp(&bt),
                 (Some(_), None) => std::cmp::Ordering::Less,
                 (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => match (a.source_timestamp, b.source_timestamp) {
-                    (Some(at), Some(bt)) => at.cmp(&bt),
-                    (Some(_), None) => std::cmp::Ordering::Less,
-                    (None, Some(_)) => std::cmp::Ordering::Greater,
-                    (None, None) => a.created_at.cmp(&b.created_at),
-                },
-            }
+                (None, None) => a.created_at.cmp(&b.created_at),
+            },
         });
 
         // --- Contradiction force-retrieval ---
@@ -892,12 +975,16 @@ impl ReadEngine {
 
         // 1. Scan for contradiction dreams in retrieved notes
         for note in all_notes.iter() {
-            if let Provenance::Dream { dream_type, source_note_ids, .. } = &note.provenance {
-                if dream_type == "contradiction" {
-                    for sid in source_note_ids {
-                        if !seen_ids.contains(sid) {
-                            contradiction_inject_ids.insert(sid.clone());
-                        }
+            if let Provenance::Dream {
+                dream_type,
+                source_note_ids,
+                ..
+            } = &note.provenance
+                && dream_type == "contradiction"
+            {
+                for sid in source_note_ids {
+                    if !seen_ids.contains(sid) {
+                        contradiction_inject_ids.insert(sid.clone());
                     }
                 }
             }
@@ -907,31 +994,44 @@ impl ReadEngine {
         for note in all_notes.iter().take(10) {
             if let Ok(links) = self.graph_store.get_links_with_reasons(&note.id).await {
                 for (linked_id, reason) in &links {
-                    if reason.contains("contradiction dream") && !seen_ids.contains(linked_id) {
-                        if let Ok(Some(dream_note)) = self.vector_store.get(linked_id).await {
-                            if let Provenance::Dream { source_note_ids, .. } = &dream_note.provenance {
-                                for sid in source_note_ids {
-                                    if !seen_ids.contains(sid) {
-                                        contradiction_inject_ids.insert(sid.clone());
-                                    }
+                    if reason.contains("contradiction dream")
+                        && !seen_ids.contains(linked_id)
+                        && let Ok(Some(dream_note)) = self.vector_store.get(linked_id).await
+                    {
+                        if let Provenance::Dream {
+                            source_note_ids, ..
+                        } = &dream_note.provenance
+                        {
+                            for sid in source_note_ids {
+                                if !seen_ids.contains(sid) {
+                                    contradiction_inject_ids.insert(sid.clone());
                                 }
                             }
-                            contradiction_inject_ids.insert(linked_id.clone());
                         }
+                        contradiction_inject_ids.insert(linked_id.clone());
                     }
                 }
             }
         }
 
         // 3. Fetch injected notes (cap at 10 to bound LLM context growth)
-        let mut inject_ids_vec: Vec<&str> = contradiction_inject_ids.iter().map(|s| s.as_str()).collect();
+        let mut inject_ids_vec: Vec<&str> = contradiction_inject_ids
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
         inject_ids_vec.truncate(10);
         let inject_refs = inject_ids_vec;
         let contradiction_notes: Vec<MemoryNote> = if inject_refs.is_empty() {
             Vec::new()
         } else {
-            debug!(count = inject_refs.len(), "Injecting contradiction source notes");
-            self.vector_store.get_many(&inject_refs).await.unwrap_or_default()
+            debug!(
+                count = inject_refs.len(),
+                "Injecting contradiction source notes"
+            );
+            self.vector_store
+                .get_many(&inject_refs)
+                .await
+                .unwrap_or_default()
         };
 
         // Build notes text with provenance markers so the LLM knows
@@ -940,7 +1040,11 @@ impl ReadEngine {
         let format_note = |i: usize, note: &MemoryNote, is_contradiction_source: bool| {
             let provenance_marker = match &note.provenance {
                 Provenance::Observed => "FACT".to_string(),
-                Provenance::Dream { dream_type, confidence, .. } => {
+                Provenance::Dream {
+                    dream_type,
+                    confidence,
+                    ..
+                } => {
                     format!("INFERRED:{} conf={:.0}%", dream_type, confidence * 100.0)
                 }
                 Provenance::Profile { entity_id } => {
@@ -950,7 +1054,10 @@ impl ReadEngine {
                     format!("EPISODE:{}", episode_id)
                 }
                 Provenance::Fact { source_note_id } => {
-                    format!("FACT:from-{}", &source_note_id[..8.min(source_note_id.len())])
+                    format!(
+                        "FACT:from-{}",
+                        &source_note_id[..8.min(source_note_id.len())]
+                    )
                 }
                 Provenance::Digest { episode_id } => {
                     format!("DIGEST:{}", &episode_id[..8.min(episode_id.len())])
@@ -958,9 +1065,7 @@ impl ReadEngine {
             };
             // Use source_timestamp (real conversation date) if available, fall back to created_at
             let display_time = note.source_timestamp.unwrap_or(note.created_at);
-            let age = Utc::now()
-                .signed_duration_since(display_time)
-                .num_days();
+            let age = Utc::now().signed_duration_since(display_time).num_days();
             let recency = if age == 0 {
                 "today".to_string()
             } else if age == 1 {
@@ -970,7 +1075,11 @@ impl ReadEngine {
             };
 
             let date_str = display_time.format("%Y-%m-%d");
-            let prefix = if is_contradiction_source { "[CONTRADICTION SOURCE] " } else { "" };
+            let prefix = if is_contradiction_source {
+                "[CONTRADICTION SOURCE] "
+            } else {
+                ""
+            };
             format!(
                 "[{}] {}({}, {}, {}) {}\n    Context: {}",
                 i + 1,
@@ -1028,8 +1137,7 @@ impl ReadEngine {
         let response = self.llm.chat(&messages, &config).await?;
 
         // Parse structured response
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         let has_contradiction = parsed["has_contradiction"].as_bool().unwrap_or(false);
 
@@ -1100,21 +1208,21 @@ impl ReadEngine {
                 }
 
                 // Sort chronologically
-                retry_notes.sort_by(|a, b| {
-                    match (a.turn_index, b.turn_index) {
-                        (Some(ai), Some(bi)) => ai.cmp(&bi),
+                retry_notes.sort_by(|a, b| match (a.turn_index, b.turn_index) {
+                    (Some(ai), Some(bi)) => ai.cmp(&bi),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => match (a.source_timestamp, b.source_timestamp) {
+                        (Some(at), Some(bt)) => at.cmp(&bt),
                         (Some(_), None) => std::cmp::Ordering::Less,
                         (None, Some(_)) => std::cmp::Ordering::Greater,
-                        (None, None) => match (a.source_timestamp, b.source_timestamp) {
-                            (Some(at), Some(bt)) => at.cmp(&bt),
-                            (Some(_), None) => std::cmp::Ordering::Less,
-                            (None, Some(_)) => std::cmp::Ordering::Greater,
-                            (None, None) => a.created_at.cmp(&b.created_at),
-                        },
-                    }
+                        (None, None) => a.created_at.cmp(&b.created_at),
+                    },
                 });
 
-                let joined_retry: String = retry_notes.iter().enumerate()
+                let joined_retry: String = retry_notes
+                    .iter()
+                    .enumerate()
                     .map(|(i, note)| format_note(i, note, false))
                     .collect::<Vec<_>>()
                     .join("\n\n");
@@ -1145,30 +1253,33 @@ impl ReadEngine {
                 if let Ok(retry_response) = self.llm.chat(&retry_messages, &config).await {
                     let retry_parsed: serde_json::Value =
                         serde_json::from_str(&retry_response.content).unwrap_or_default();
-                    if let Some(retry_answer) = retry_parsed["answer"].as_str() {
-                        if !retry_answer.is_empty() && !Self::answer_admits_insufficient_info(retry_answer) {
-                            let retry_note_ids: Vec<String> = retry_notes.iter().map(|n| n.id.clone()).collect();
-                            let retry_has_contradiction = retry_parsed["has_contradiction"].as_bool().unwrap_or(false);
+                    if let Some(retry_answer) = retry_parsed["answer"].as_str()
+                        && !retry_answer.is_empty()
+                        && !Self::answer_admits_insufficient_info(retry_answer)
+                    {
+                        let retry_note_ids: Vec<String> =
+                            retry_notes.iter().map(|n| n.id.clone()).collect();
+                        let retry_has_contradiction =
+                            retry_parsed["has_contradiction"].as_bool().unwrap_or(false);
 
-                            let mut final_answer = retry_answer.to_string();
-                            if retry_has_contradiction {
-                                final_answer = format!(
-                                    "**Note: The memories contain contradictory information on this topic.**\n\n{}",
-                                    final_answer
-                                );
-                            }
-
-                            info!("Retry produced confident answer, using it");
-                            return Ok(AskResult {
-                                answer: final_answer,
-                                query_mode: mode_str,
-                                notes_used: retry_notes.len(),
-                                note_ids: retry_note_ids,
-                                contradiction_injected: 0,
-                                has_contradiction: retry_has_contradiction,
-                                reranker_best_score: reranker_best,
-                            });
+                        let mut final_answer = retry_answer.to_string();
+                        if retry_has_contradiction {
+                            final_answer = format!(
+                                "**Note: The memories contain contradictory information on this topic.**\n\n{}",
+                                final_answer
+                            );
                         }
+
+                        info!("Retry produced confident answer, using it");
+                        return Ok(AskResult {
+                            answer: final_answer,
+                            query_mode: mode_str,
+                            notes_used: retry_notes.len(),
+                            note_ids: retry_note_ids,
+                            contradiction_injected: 0,
+                            has_contradiction: retry_has_contradiction,
+                            reranker_best_score: reranker_best,
+                        });
                     }
                 }
                 info!("Retry also insufficient or failed, keeping original answer");
@@ -1202,8 +1313,16 @@ impl ReadEngine {
             return String::new();
         }
 
-        let per_episode = self.graph_store.get_all_episode_digests().await.unwrap_or_default();
-        let cross_level = self.graph_store.get_all_cross_episode_digests().await.unwrap_or_default();
+        let per_episode = self
+            .graph_store
+            .get_all_episode_digests()
+            .await
+            .unwrap_or_default();
+        let cross_level = self
+            .graph_store
+            .get_all_cross_episode_digests()
+            .await
+            .unwrap_or_default();
 
         if per_episode.is_empty() && cross_level.is_empty() {
             return String::new();
@@ -1247,7 +1366,10 @@ impl ReadEngine {
             (Some(ad), Some(bd)) => ad.cmp(bd),
             (Some(_), None) => std::cmp::Ordering::Less,
             (None, Some(_)) => std::cmp::Ordering::Greater,
-            (None, None) => a.source_turn.unwrap_or(u32::MAX).cmp(&b.source_turn.unwrap_or(u32::MAX)),
+            (None, None) => a
+                .source_turn
+                .unwrap_or(u32::MAX)
+                .cmp(&b.source_turn.unwrap_or(u32::MAX)),
         });
 
         // Cap to keep the context tight. 400 events ≈ 6-8k tokens; smoke

--- a/crates/karta-core/src/read.rs
+++ b/crates/karta-core/src/read.rs
@@ -846,6 +846,7 @@ impl ReadEngine {
                 contradiction_injected: 0,
                 has_contradiction: false,
                 reranker_best_score: None,
+                evidence: None,
             });
         }
 
@@ -950,6 +951,7 @@ impl ReadEngine {
                 contradiction_injected: 0,
                 has_contradiction: false,
                 reranker_best_score: reranker_best,
+                evidence: None,
             });
         }
 
@@ -1162,6 +1164,7 @@ impl ReadEngine {
                         contradiction_injected: contradiction_count,
                         has_contradiction,
                         reranker_best_score: reranker_best,
+                        evidence: None,
                     });
                 }
                 response.content.clone()
@@ -1279,6 +1282,7 @@ impl ReadEngine {
                             contradiction_injected: 0,
                             has_contradiction: retry_has_contradiction,
                             reranker_best_score: reranker_best,
+                            evidence: None,
                         });
                     }
                 }
@@ -1294,6 +1298,7 @@ impl ReadEngine {
             contradiction_injected: contradiction_count,
             has_contradiction,
             reranker_best_score: reranker_best,
+            evidence: None,
         })
     }
 

--- a/crates/karta-core/src/rerank.rs
+++ b/crates/karta-core/src/rerank.rs
@@ -11,7 +11,7 @@
 
 use async_trait::async_trait;
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::error::Result;
 use crate::llm::{ChatMessage, GenConfig, LlmProvider, Role};
@@ -110,7 +110,16 @@ impl Reranker for LlmReranker {
             .enumerate()
             .map(|(i, (note, _))| {
                 let content = if note.content.len() > 200 {
-                    format!("{}...", &note.content[..note.content.char_indices().take(200).last().map(|(i,_)|i).unwrap_or(200)])
+                    format!(
+                        "{}...",
+                        &note.content[..note
+                            .content
+                            .char_indices()
+                            .take(200)
+                            .last()
+                            .map(|(i, ch)| i + ch.len_utf8())
+                            .unwrap_or(note.content.len())]
+                    )
                 } else {
                     note.content.clone()
                 };
@@ -142,8 +151,13 @@ impl Reranker for LlmReranker {
         };
 
         let response = self.llm.chat(&messages, &config).await?;
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = match serde_json::from_str(&response.content) {
+            Ok(value) => value,
+            Err(e) => {
+                warn!(error = %e, raw_response = %response.content, "LLM reranker returned invalid JSON; using neutral fallback");
+                serde_json::Value::Null
+            }
+        };
 
         let scores: Vec<f32> = parsed["scores"]
             .as_array()
@@ -226,7 +240,15 @@ impl Reranker for JinaReranker {
             .map(|(note, _)| {
                 let content = &note.content;
                 if content.len() > 500 {
-                    format!("{}...", &content[..content.char_indices().take(500).last().map(|(i,_)|i).unwrap_or(500)])
+                    format!(
+                        "{}...",
+                        &content[..content
+                            .char_indices()
+                            .take(500)
+                            .last()
+                            .map(|(i, ch)| i + ch.len_utf8())
+                            .unwrap_or(content.len())]
+                    )
                 } else {
                     content.clone()
                 }
@@ -257,14 +279,16 @@ impl Reranker for JinaReranker {
             .map_err(|e| crate::error::KartaError::Llm(format!("Jina parse error: {}", e)))?;
 
         // Parse Jina response: results[].index + results[].relevance_score
-        let jina_results = resp_body["results"]
-            .as_array()
-            .cloned()
-            .unwrap_or_default();
+        let jina_results = resp_body["results"].as_array().ok_or_else(|| {
+            crate::error::KartaError::Llm(format!(
+                "Jina rerank response missing array field 'results': {}",
+                resp_body
+            ))
+        })?;
 
         // Build index → score map
         let mut score_map: std::collections::HashMap<usize, f32> = std::collections::HashMap::new();
-        for r in &jina_results {
+        for r in jina_results {
             let idx = r["index"].as_u64().unwrap_or(0) as usize;
             let score = r["relevance_score"].as_f64().unwrap_or(0.0) as f32;
             score_map.insert(idx, score);

--- a/crates/karta-core/src/rules.rs
+++ b/crates/karta-core/src/rules.rs
@@ -1,0 +1,94 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A safe action that a rule can perform. Constrained to prompt/retrieval
+/// modifications only — rules cannot mutate storage or execute arbitrary code.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleAction {
+    AppendSystemPrompt { text: String },
+    RewriteQuery { prefix: String },
+    FilterByTags { tags: Vec<String> },
+    BoostKeywords { keywords: Vec<String>, boost: f32 },
+    LimitTopK { top_k: usize },
+    WarnContradiction { message: String },
+}
+
+/// Condition that triggers a rule.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleCondition {
+    QueryContains { keywords: Vec<String> },
+    SessionMatches { session_id: String },
+    ContradictionForEntity { entity: String },
+    RetrievedTagPresent { tag: String },
+    Always,
+}
+
+/// A procedural rule that modifies retrieval/answer behavior when its condition matches.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProceduralRule {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub condition: RuleCondition,
+    pub actions: Vec<RuleAction>,
+    pub enabled: bool,
+    pub protected: bool,
+    pub source_note_id: Option<String>,
+    pub fire_count: u64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl ProceduralRule {
+    pub fn new(
+        name: String,
+        description: String,
+        condition: RuleCondition,
+        actions: Vec<RuleAction>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            name,
+            description,
+            condition,
+            actions,
+            enabled: true,
+            protected: false,
+            source_note_id: None,
+            fire_count: 0,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn with_source(mut self, note_id: &str) -> Self {
+        self.source_note_id = Some(note_id.to_string());
+        self.protected = true;
+        self
+    }
+}
+
+/// Context passed to the rule engine for evaluation.
+#[derive(Debug, Clone, Default)]
+pub struct RuleContext {
+    pub query: String,
+    pub session_id: Option<String>,
+    pub retrieved_tags: Vec<String>,
+    pub contradiction_entities: Vec<String>,
+}
+
+/// Result of rule evaluation.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RuleEvaluation {
+    pub fired_rules: Vec<FiredRule>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FiredRule {
+    pub rule_id: String,
+    pub rule_name: String,
+    pub actions: Vec<RuleAction>,
+}

--- a/crates/karta-core/src/rules_engine.rs
+++ b/crates/karta-core/src/rules_engine.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::error::Result;
+use crate::rules::{FiredRule, ProceduralRule, RuleCondition, RuleContext, RuleEvaluation};
+use crate::store::GraphStore;
+
+/// Engine that evaluates procedural rules against retrieval context.
+pub struct RuleEngine {
+    graph_store: Arc<dyn GraphStore>,
+}
+
+impl RuleEngine {
+    pub fn new(graph_store: Arc<dyn GraphStore>) -> Self {
+        Self { graph_store }
+    }
+
+    /// Evaluate all enabled rules against the given context.
+    pub async fn evaluate(&self, ctx: &RuleContext) -> Result<RuleEvaluation> {
+        let rules = self.list_rules().await?;
+        let mut fired_rules = Vec::new();
+
+        for rule in &rules {
+            if !rule.enabled {
+                continue;
+            }
+
+            if Self::matches(&rule.condition, ctx) {
+                fired_rules.push(FiredRule {
+                    rule_id: rule.id.clone(),
+                    rule_name: rule.name.clone(),
+                    actions: rule.actions.clone(),
+                });
+                let _ = self.graph_store.increment_rule_fire_count(&rule.id).await;
+            }
+        }
+
+        Ok(RuleEvaluation { fired_rules })
+    }
+
+    pub async fn add_rule(&self, rule: ProceduralRule) -> Result<()> {
+        self.graph_store.upsert_procedural_rule(&rule).await
+    }
+
+    pub async fn disable_rule(&self, rule_id: &str) -> Result<()> {
+        self.graph_store.disable_procedural_rule(rule_id).await
+    }
+
+    pub async fn list_rules(&self) -> Result<Vec<ProceduralRule>> {
+        self.graph_store.list_procedural_rules().await
+    }
+
+    fn matches(condition: &RuleCondition, ctx: &RuleContext) -> bool {
+        match condition {
+            RuleCondition::QueryContains { keywords } => {
+                let query_lower = ctx.query.to_lowercase();
+                keywords
+                    .iter()
+                    .any(|k| query_lower.contains(&k.to_lowercase()))
+            }
+            RuleCondition::SessionMatches { session_id } => {
+                ctx.session_id.as_ref().is_some_and(|s| s == session_id)
+            }
+            RuleCondition::ContradictionForEntity { entity } => {
+                ctx.contradiction_entities.contains(entity)
+            }
+            RuleCondition::RetrievedTagPresent { tag } => ctx.retrieved_tags.contains(tag),
+            RuleCondition::Always => true,
+        }
+    }
+}
+
+/// Trace output showing which rules fired during a query.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RuleTrace {
+    pub fired_rules: Vec<FiredRuleTrace>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FiredRuleTrace {
+    pub rule_id: String,
+    pub rule_name: String,
+}

--- a/crates/karta-core/src/store/lance.rs
+++ b/crates/karta-core/src/store/lance.rs
@@ -1,17 +1,12 @@
 use std::sync::Arc;
 
-use arrow_array::{
-    Float32Array, RecordBatch, RecordBatchIterator, StringArray,
-    RecordBatchReader,
-};
+use arrow_array::{Float32Array, RecordBatch, RecordBatchIterator, RecordBatchReader, StringArray};
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use lancedb::{
-    Connection,
-    connect,
+    Connection, Table as LanceTable, connect,
     query::{ExecutableQuery, QueryBase},
-    Table as LanceTable,
 };
 use tokio::sync::RwLock;
 
@@ -32,8 +27,7 @@ impl LanceVectorStore {
     pub async fn new(uri: &str) -> Result<Self> {
         // Only create local directories for local paths
         if !uri.starts_with("gs://") && !uri.starts_with("s3://") && !uri.starts_with("az://") {
-            std::fs::create_dir_all(uri)
-                .map_err(|e| KartaError::VectorStore(e.to_string()))?;
+            std::fs::create_dir_all(uri).map_err(|e| KartaError::VectorStore(e.to_string()))?;
         }
         let conn = connect(uri)
             .execute()
@@ -147,17 +141,27 @@ impl LanceVectorStore {
             return Ok(());
         }
 
-        let names = self.conn.table_names().execute().await
+        let names = self
+            .conn
+            .table_names()
+            .execute()
+            .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
 
         let table = if names.contains(&FACTS_TABLE_NAME.to_string()) {
-            self.conn.open_table(FACTS_TABLE_NAME).execute().await
+            self.conn
+                .open_table(FACTS_TABLE_NAME)
+                .execute()
+                .await
                 .map_err(|e| KartaError::VectorStore(e.to_string()))?
         } else {
             let schema = Self::facts_schema();
             let empty_batch = RecordBatch::new_empty(schema.clone());
             let reader = Self::make_reader(vec![empty_batch], schema);
-            self.conn.create_table(FACTS_TABLE_NAME, reader).execute().await
+            self.conn
+                .create_table(FACTS_TABLE_NAME, reader)
+                .execute()
+                .await
                 .map_err(|e| KartaError::VectorStore(e.to_string()))?
         };
 
@@ -177,7 +181,8 @@ impl LanceVectorStore {
             EMBEDDING_DIM as i32,
             Arc::new(Float32Array::from(embedding)),
             None,
-        ).map_err(|e| KartaError::VectorStore(e.to_string()))?;
+        )
+        .map_err(|e| KartaError::VectorStore(e.to_string()))?;
 
         let created_at = fact.created_at.to_rfc3339();
         let ordinal_str = fact.ordinal.to_string();
@@ -194,23 +199,56 @@ impl LanceVectorStore {
                 Arc::new(StringArray::from(vec![created_at.as_str()])),
                 Arc::new(vector_array),
             ],
-        ).map_err(|e| KartaError::VectorStore(e.to_string()))
+        )
+        .map_err(|e| KartaError::VectorStore(e.to_string()))
     }
 
     fn batch_to_facts(batch: &RecordBatch) -> Result<Vec<crate::note::AtomicFact>> {
-        let ids = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-        let contents = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
-        let source_ids = batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
-        let ordinals = batch.column(3).as_any().downcast_ref::<StringArray>().unwrap();
-        let subjects = batch.column(4).as_any().downcast_ref::<StringArray>().unwrap();
-        let created_ats = batch.column(5).as_any().downcast_ref::<StringArray>().unwrap();
-        let vector_col = batch.column(6).as_any()
-            .downcast_ref::<arrow_array::FixedSizeListArray>().unwrap();
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let contents = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let source_ids = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let ordinals = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let subjects = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let created_ats = batch
+            .column(5)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let vector_col = batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<arrow_array::FixedSizeListArray>()
+            .unwrap();
 
         let mut facts = Vec::with_capacity(batch.num_rows());
         for i in 0..batch.num_rows() {
-            let embedding = vector_col.value(i).as_any()
-                .downcast_ref::<Float32Array>().unwrap().values().to_vec();
+            let embedding = vector_col
+                .value(i)
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .unwrap()
+                .values()
+                .to_vec();
             let subject_val = subjects.value(i);
 
             facts.push(crate::note::AtomicFact {
@@ -218,10 +256,15 @@ impl LanceVectorStore {
                 content: contents.value(i).to_string(),
                 source_note_id: source_ids.value(i).to_string(),
                 ordinal: ordinals.value(i).parse().unwrap_or(0),
-                subject: if subject_val.is_empty() { None } else { Some(subject_val.to_string()) },
+                subject: if subject_val.is_empty() {
+                    None
+                } else {
+                    Some(subject_val.to_string())
+                },
                 embedding,
                 created_at: chrono::DateTime::parse_from_rfc3339(created_ats.value(i))
-                    .unwrap_or_default().with_timezone(&chrono::Utc),
+                    .unwrap_or_default()
+                    .with_timezone(&chrono::Utc),
             });
         }
         Ok(facts)
@@ -257,7 +300,10 @@ impl LanceVectorStore {
         let updated_at = note.updated_at.to_rfc3339();
         let last_accessed_at = note.last_accessed_at.to_rfc3339();
         let turn_index_str = note.turn_index.map(|t| t.to_string()).unwrap_or_default();
-        let source_timestamp_str = note.source_timestamp.map(|t| t.to_rfc3339()).unwrap_or_default();
+        let source_timestamp_str = note
+            .source_timestamp
+            .map(|t| t.to_rfc3339())
+            .unwrap_or_default();
 
         let batch = RecordBatch::try_new(
             Self::schema(),
@@ -284,19 +330,71 @@ impl LanceVectorStore {
     }
 
     fn batch_to_notes(batch: &RecordBatch) -> Result<Vec<MemoryNote>> {
-        let ids = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-        let contents = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
-        let contexts = batch.column(2).as_any().downcast_ref::<StringArray>().unwrap();
-        let keywords_jsons = batch.column(3).as_any().downcast_ref::<StringArray>().unwrap();
-        let tags_jsons = batch.column(4).as_any().downcast_ref::<StringArray>().unwrap();
-        let provenance_jsons = batch.column(5).as_any().downcast_ref::<StringArray>().unwrap();
-        let confidences = batch.column(6).as_any().downcast_ref::<Float32Array>().unwrap();
-        let created_ats = batch.column(7).as_any().downcast_ref::<StringArray>().unwrap();
-        let updated_ats = batch.column(8).as_any().downcast_ref::<StringArray>().unwrap();
-        let status_jsons = batch.column(9).as_any().downcast_ref::<StringArray>().unwrap();
-        let last_accessed_ats = batch.column(10).as_any().downcast_ref::<StringArray>().unwrap();
-        let turn_index_strs = batch.column(11).as_any().downcast_ref::<StringArray>().unwrap();
-        let source_timestamp_strs = batch.column(12).as_any().downcast_ref::<StringArray>().unwrap();
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let contents = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let contexts = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let keywords_jsons = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let tags_jsons = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let provenance_jsons = batch
+            .column(5)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let confidences = batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap();
+        let created_ats = batch
+            .column(7)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let updated_ats = batch
+            .column(8)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let status_jsons = batch
+            .column(9)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let last_accessed_ats = batch
+            .column(10)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let turn_index_strs = batch
+            .column(11)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let source_timestamp_strs = batch
+            .column(12)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
 
         let vector_col = batch
             .column(13)
@@ -317,14 +415,11 @@ impl LanceVectorStore {
 
             let keywords: Vec<String> =
                 serde_json::from_str(keywords_jsons.value(i)).unwrap_or_default();
-            let tags: Vec<String> =
-                serde_json::from_str(tags_jsons.value(i)).unwrap_or_default();
+            let tags: Vec<String> = serde_json::from_str(tags_jsons.value(i)).unwrap_or_default();
             let provenance: Provenance =
-                serde_json::from_str(provenance_jsons.value(i))
-                    .unwrap_or(Provenance::Observed);
+                serde_json::from_str(provenance_jsons.value(i)).unwrap_or(Provenance::Observed);
             let status: NoteStatus =
-                serde_json::from_str(status_jsons.value(i))
-                    .unwrap_or_default();
+                serde_json::from_str(status_jsons.value(i)).unwrap_or_default();
 
             notes.push(MemoryNote {
                 id: ids.value(i).to_string(),
@@ -389,9 +484,7 @@ impl crate::store::VectorStore for LanceVectorStore {
         let table = self.get_table().await?;
 
         // Delete existing row if present (upsert semantics)
-        let _ = table
-            .delete(&format!("id = '{}'", note.id))
-            .await;
+        let _ = table.delete(&format!("id = '{}'", note.id)).await;
 
         let batch = Self::note_to_batch(note)?;
         let schema = Self::schema();
@@ -523,7 +616,10 @@ impl crate::store::VectorStore for LanceVectorStore {
         let batch = Self::fact_to_batch(fact)?;
         let schema = Self::facts_schema();
         let reader = Self::make_reader(vec![batch], schema);
-        table.add(reader).execute().await
+        table
+            .add(reader)
+            .execute()
+            .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
         Ok(())
     }
@@ -535,17 +631,21 @@ impl crate::store::VectorStore for LanceVectorStore {
         exclude_source_note_ids: &[&str],
     ) -> Result<Vec<(crate::note::AtomicFact, f32)>> {
         let table = self.get_facts_table().await?;
-        let query = table.vector_search(embedding)
+        let query = table
+            .vector_search(embedding)
             .map_err(|e| KartaError::VectorStore(e.to_string()))?
             .limit(top_k + exclude_source_note_ids.len() * 5);
-        let results = query.execute().await
+        let results = query
+            .execute()
+            .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
         let batches = Self::collect_batches(results).await?;
 
         let mut scored = Vec::new();
         for batch in &batches {
             let facts = Self::batch_to_facts(batch)?;
-            let distance_col = batch.column_by_name("_distance")
+            let distance_col = batch
+                .column_by_name("_distance")
                 .and_then(|c| c.as_any().downcast_ref::<Float32Array>());
             for (i, fact) in facts.into_iter().enumerate() {
                 if exclude_source_note_ids.contains(&fact.source_note_id.as_str()) {
@@ -562,9 +662,11 @@ impl crate::store::VectorStore for LanceVectorStore {
 
     async fn get_facts_for_note(&self, note_id: &str) -> Result<Vec<crate::note::AtomicFact>> {
         let table = self.get_facts_table().await?;
-        let results = table.query()
+        let results = table
+            .query()
             .only_if(format!("source_note_id = '{}'", note_id))
-            .execute().await
+            .execute()
+            .await
             .map_err(|e| KartaError::VectorStore(e.to_string()))?;
         let batches = Self::collect_batches(results).await?;
         let mut facts = Vec::new();

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -174,7 +174,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        // Initialize schema_meta table and apply pending migrations
+        // This CREATE TABLE IF NOT EXISTS batch is the immutable schema v1
+        // baseline. Future schema changes should be added as forward migrations
+        // in migrate.rs rather than changing this baseline in-place.
+        // Initialize schema_meta table and apply pending migrations.
         migrate::init_and_migrate(&conn)?;
 
         Ok(())

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 
 use crate::dream::DreamRun;
 use crate::error::{KartaError, Result};
+use crate::migrate;
 use crate::note::EvolutionRecord;
 
 pub struct SqliteGraphStore {
@@ -172,6 +173,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
             ",
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        // Initialize schema_meta table and apply pending migrations
+        migrate::init_and_migrate(&conn)?;
+
         Ok(())
     }
 
@@ -787,5 +792,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         let ids = stmt.query_map(rusqlite::params![entity], |row| row.get(0))
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(ids.filter_map(|r| r.ok()).collect())
+    }
+
+    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        migrate::load_schema_meta(&conn)
     }
 }

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -171,6 +171,22 @@ impl crate::store::GraphStore for SqliteGraphStore {
             CREATE INDEX IF NOT EXISTS idx_ep_links_from ON episode_links(from_episode_id);
             CREATE INDEX IF NOT EXISTS idx_ep_links_to ON episode_links(to_episode_id);
             CREATE INDEX IF NOT EXISTS idx_ep_links_entity ON episode_links(entity);
+
+            -- Procedural rules (Issue #6)
+            CREATE TABLE IF NOT EXISTS procedural_rules (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                condition_json TEXT NOT NULL,
+                actions_json TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                protected INTEGER NOT NULL DEFAULT 0,
+                source_note_id TEXT,
+                fire_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_rules_enabled ON procedural_rules(enabled);
             ",
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -947,5 +963,107 @@ impl crate::store::GraphStore for SqliteGraphStore {
             .lock()
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         migrate::load_schema_meta(&conn)
+    }
+
+    // --- Procedural Rules ---
+
+    async fn upsert_procedural_rule(&self, rule: &crate::rules::ProceduralRule) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let condition_json =
+            serde_json::to_string(&rule.condition).map_err(KartaError::Serialization)?;
+        let actions_json =
+            serde_json::to_string(&rule.actions).map_err(KartaError::Serialization)?;
+        conn.execute(
+            "INSERT INTO procedural_rules (id, name, description, condition_json, actions_json, enabled, protected, source_note_id, fire_count, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+             ON CONFLICT(id) DO UPDATE SET
+                 name=?2, description=?3, condition_json=?4, actions_json=?5,
+                 enabled=?6, protected=?7, source_note_id=?8, fire_count=?9, updated_at=?11",
+            rusqlite::params![
+                rule.id,
+                rule.name,
+                rule.description,
+                condition_json,
+                actions_json,
+                rule.enabled as i32,
+                rule.protected as i32,
+                rule.source_note_id,
+                rule.fire_count as i64,
+                rule.created_at.to_rfc3339(),
+                rule.updated_at.to_rfc3339(),
+            ],
+        )
+        .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn list_procedural_rules(&self) -> Result<Vec<crate::rules::ProceduralRule>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let mut stmt = conn.prepare(
+            "SELECT id, name, description, condition_json, actions_json, enabled, protected, source_note_id, fire_count, created_at, updated_at FROM procedural_rules ORDER BY name"
+        ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let rows = stmt
+            .query_map([], |row| {
+                let condition: crate::rules::RuleCondition =
+                    serde_json::from_str(&row.get::<_, String>(3)?)
+                        .unwrap_or(crate::rules::RuleCondition::Always);
+                let actions: Vec<crate::rules::RuleAction> =
+                    serde_json::from_str(&row.get::<_, String>(4)?).unwrap_or_default();
+                let created_at = DateTime::parse_from_rfc3339(&row.get::<_, String>(9)?)
+                    .unwrap_or_default()
+                    .with_timezone(&Utc);
+                let updated_at = DateTime::parse_from_rfc3339(&row.get::<_, String>(10)?)
+                    .unwrap_or_default()
+                    .with_timezone(&Utc);
+                Ok(crate::rules::ProceduralRule {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    description: row.get(2)?,
+                    condition,
+                    actions,
+                    enabled: row.get::<_, i32>(5)? != 0,
+                    protected: row.get::<_, i32>(6)? != 0,
+                    source_note_id: row.get(7)?,
+                    fire_count: row.get::<_, i64>(8)? as u64,
+                    created_at,
+                    updated_at,
+                })
+            })
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    async fn disable_procedural_rule(&self, rule_id: &str) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE procedural_rules SET enabled = 0, updated_at = ?2 WHERE id = ?1",
+            rusqlite::params![rule_id, now],
+        )
+        .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn increment_rule_fire_count(&self, rule_id: &str) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE procedural_rules SET fire_count = fire_count + 1, updated_at = ?2 WHERE id = ?1",
+            rusqlite::params![rule_id, now],
+        )
+        .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(())
     }
 }

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 
 use crate::dream::DreamRun;
 use crate::error::{KartaError, Result};
+use crate::migrate;
 use crate::note::EvolutionRecord;
 
 pub struct SqliteGraphStore {
@@ -14,11 +15,9 @@ pub struct SqliteGraphStore {
 impl SqliteGraphStore {
     pub fn new(data_dir: &str) -> Result<Self> {
         let path = format!("{}/karta.db", data_dir);
-        std::fs::create_dir_all(data_dir)
-            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        std::fs::create_dir_all(data_dir).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        let conn = Connection::open(&path)
-            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = Connection::open(&path).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         // Use DELETE journal mode for compatibility with network filesystems (e.g. GCS FUSE).
         // WAL requires shared memory / file locking that FUSE mounts don't support.
@@ -36,7 +35,10 @@ impl SqliteGraphStore {
 #[async_trait]
 impl crate::store::GraphStore for SqliteGraphStore {
     async fn init(&self) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute_batch(
             "
             CREATE TABLE IF NOT EXISTS links (
@@ -172,11 +174,18 @@ impl crate::store::GraphStore for SqliteGraphStore {
             ",
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        // Initialize schema_meta table and apply pending migrations
+        migrate::init_and_migrate(&conn)?;
+
         Ok(())
     }
 
     async fn add_link(&self, from_id: &str, to_id: &str, reason: &str) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let now = Utc::now().to_rfc3339();
 
         // Bidirectional: insert both directions
@@ -196,7 +205,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_links(&self, note_id: &str) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT to_id FROM links WHERE from_id = ?1")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -211,7 +223,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_links_with_reasons(&self, note_id: &str) -> Result<Vec<(String, String)>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT to_id, reason FROM links WHERE from_id = ?1")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -233,7 +248,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         triggered_by: &str,
         previous_context: &str,
     ) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let now = Utc::now().to_rfc3339();
 
         conn.execute(
@@ -246,7 +264,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_evolution_history(&self, note_id: &str) -> Result<Vec<EvolutionRecord>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare(
                 "SELECT triggered_by, previous_context, evolved_at FROM evolution_history WHERE note_id = ?1 ORDER BY id ASC",
@@ -273,7 +294,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn record_dream_run(&self, run: &DreamRun) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let dreams_json = serde_json::to_string(&run.dreams)?;
 
         conn.execute(
@@ -297,7 +321,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_dream_cursor(&self) -> Result<Option<DateTime<Utc>>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let result = conn.query_row(
             "SELECT last_processed_at FROM dream_cursor WHERE id = 1",
             [],
@@ -320,7 +347,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn set_dream_cursor(&self, cursor: DateTime<Utc>) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute(
             "INSERT INTO dream_cursor (id, last_processed_at) VALUES (1, ?1)
              ON CONFLICT(id) DO UPDATE SET last_processed_at = ?1",
@@ -334,7 +364,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Foresight signals ---
 
     async fn upsert_foresight(&self, signal: &crate::note::ForesightSignal) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let status_str = serde_json::to_string(&signal.status)?;
         conn.execute(
             "INSERT INTO foresight_signals (id, content, valid_from, valid_until, source_note_id, confidence, status)
@@ -355,7 +388,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_active_foresights(&self) -> Result<Vec<crate::note::ForesightSignal>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT id, content, valid_from, valid_until, source_note_id, confidence FROM foresight_signals WHERE status = 'Active'")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -370,7 +406,9 @@ impl crate::store::GraphStore for SqliteGraphStore {
                         .unwrap_or_default()
                         .with_timezone(&Utc),
                     valid_until: valid_until_str.and_then(|s| {
-                        DateTime::parse_from_rfc3339(&s).ok().map(|dt| dt.with_timezone(&Utc))
+                        DateTime::parse_from_rfc3339(&s)
+                            .ok()
+                            .map(|dt| dt.with_timezone(&Utc))
                     }),
                     source_note_id: row.get(4)?,
                     confidence: row.get(5)?,
@@ -385,7 +423,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn expire_foresights(&self, before: DateTime<Utc>) -> Result<usize> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let count = conn
             .execute(
                 "UPDATE foresight_signals SET status = 'Expired' WHERE status = 'Active' AND valid_until IS NOT NULL AND valid_until < ?1",
@@ -395,8 +436,14 @@ impl crate::store::GraphStore for SqliteGraphStore {
         Ok(count)
     }
 
-    async fn get_foresights_for_note(&self, note_id: &str) -> Result<Vec<crate::note::ForesightSignal>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn get_foresights_for_note(
+        &self,
+        note_id: &str,
+    ) -> Result<Vec<crate::note::ForesightSignal>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT id, content, valid_from, valid_until, source_note_id, confidence, status FROM foresight_signals WHERE source_note_id = ?1")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -417,7 +464,9 @@ impl crate::store::GraphStore for SqliteGraphStore {
                         .unwrap_or_default()
                         .with_timezone(&Utc),
                     valid_until: valid_until_str.and_then(|s| {
-                        DateTime::parse_from_rfc3339(&s).ok().map(|dt| dt.with_timezone(&Utc))
+                        DateTime::parse_from_rfc3339(&s)
+                            .ok()
+                            .map(|dt| dt.with_timezone(&Utc))
                     }),
                     source_note_id: row.get(4)?,
                     confidence: row.get(5)?,
@@ -434,7 +483,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Profiles ---
 
     async fn upsert_profile(&self, entity_id: &str, note_id: &str) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let now = Utc::now().to_rfc3339();
         conn.execute(
             "INSERT INTO profiles (entity_id, note_id, last_updated) VALUES (?1, ?2, ?3)
@@ -446,7 +498,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_profile_note_id(&self, entity_id: &str) -> Result<Option<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let result = conn.query_row(
             "SELECT note_id FROM profiles WHERE entity_id = ?1",
             rusqlite::params![entity_id],
@@ -460,7 +515,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_all_profiles(&self) -> Result<Vec<(String, String)>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT entity_id, note_id FROM profiles")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -475,7 +533,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Episodes ---
 
     async fn upsert_episode(&self, episode: &crate::note::Episode) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let tags_json = serde_json::to_string(&episode.topic_tags)?;
         conn.execute(
             "INSERT INTO episodes (id, narrative_note_id, start_time, end_time, session_id, topic_tags_json)
@@ -496,7 +557,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
 
     async fn get_episode(&self, id: &str) -> Result<Option<crate::note::Episode>> {
         let episode_result = {
-            let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
             conn.query_row(
                 "SELECT id, narrative_note_id, start_time, end_time, session_id, topic_tags_json FROM episodes WHERE id = ?1",
                 rusqlite::params![id],
@@ -530,9 +594,15 @@ impl crate::store::GraphStore for SqliteGraphStore {
         }
     }
 
-    async fn get_episodes_for_session(&self, session_id: &str) -> Result<Vec<crate::note::Episode>> {
+    async fn get_episodes_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<crate::note::Episode>> {
         let ids: Vec<String> = {
-            let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| KartaError::GraphStore(e.to_string()))?;
             let mut stmt = conn
                 .prepare("SELECT id FROM episodes WHERE session_id = ?1 ORDER BY start_time ASC")
                 .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -552,7 +622,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn add_note_to_episode(&self, note_id: &str, episode_id: &str) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute(
             "INSERT OR IGNORE INTO note_episodes (note_id, episode_id) VALUES (?1, ?2)",
             rusqlite::params![note_id, episode_id],
@@ -562,7 +635,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_episode_for_note(&self, note_id: &str) -> Result<Option<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let result = conn.query_row(
             "SELECT episode_id FROM note_episodes WHERE note_id = ?1 LIMIT 1",
             rusqlite::params![note_id],
@@ -576,7 +652,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_notes_for_episode(&self, episode_id: &str) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn
             .prepare("SELECT note_id FROM note_episodes WHERE episode_id = ?1")
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -591,7 +670,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Efficient link count ---
 
     async fn get_link_count(&self, note_id: &str) -> Result<usize> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let count: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM links WHERE from_id = ?1",
@@ -605,9 +687,15 @@ impl crate::store::GraphStore for SqliteGraphStore {
     // --- Episode Digests (Phase Next) ---
 
     async fn upsert_episode_digest(&self, digest: &crate::note::EpisodeDigest) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let entities_json = serde_json::to_string(&digest.entities)?;
-        let date_range_json = digest.date_range.as_ref().map(|d| serde_json::to_string(d).unwrap_or_default());
+        let date_range_json = digest
+            .date_range
+            .as_ref()
+            .map(|d| serde_json::to_string(d).unwrap_or_default());
         let aggregations_json = serde_json::to_string(&digest.aggregations)?;
         let topic_sequence_json = serde_json::to_string(&digest.topic_sequence)?;
         let events_json = serde_json::to_string(&digest.events)?;
@@ -618,8 +706,14 @@ impl crate::store::GraphStore for SqliteGraphStore {
         Ok(())
     }
 
-    async fn get_episode_digest(&self, episode_id: &str) -> Result<Option<crate::note::EpisodeDigest>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn get_episode_digest(
+        &self,
+        episode_id: &str,
+    ) -> Result<Option<crate::note::EpisodeDigest>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT id, episode_id, entities_json, date_range_json, aggregations_json, topic_sequence_json, events_json, digest_text, digest_note_id, created_at FROM episode_digests WHERE episode_id = ?1"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -642,7 +736,8 @@ impl crate::store::GraphStore for SqliteGraphStore {
                 digest_text: row.get(7)?,
                 digest_note_id: row.get(8)?,
                 created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
-                    .unwrap_or_default().with_timezone(&chrono::Utc),
+                    .unwrap_or_default()
+                    .with_timezone(&chrono::Utc),
             })
         });
 
@@ -654,49 +749,65 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_all_episode_digests(&self) -> Result<Vec<crate::note::EpisodeDigest>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT id, episode_id, entities_json, date_range_json, aggregations_json, topic_sequence_json, events_json, digest_text, digest_note_id, created_at FROM episode_digests ORDER BY created_at"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        let digests = stmt.query_map([], |row| {
-            let entities_str: String = row.get(2)?;
-            let date_range_str: Option<String> = row.get(3)?;
-            let agg_str: String = row.get(4)?;
-            let topic_str: String = row.get(5)?;
-            let events_str: String = row.get(6)?;
-            let created_str: String = row.get(9)?;
-            Ok(crate::note::EpisodeDigest {
-                id: row.get(0)?,
-                episode_id: row.get(1)?,
-                entities: serde_json::from_str(&entities_str).unwrap_or_default(),
-                date_range: date_range_str.and_then(|s| serde_json::from_str(&s).ok()),
-                aggregations: serde_json::from_str(&agg_str).unwrap_or_default(),
-                topic_sequence: serde_json::from_str(&topic_str).unwrap_or_default(),
-                events: serde_json::from_str(&events_str).unwrap_or_default(),
-                digest_text: row.get(7)?,
-                digest_note_id: row.get(8)?,
-                created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
-                    .unwrap_or_default().with_timezone(&chrono::Utc),
+        let digests = stmt
+            .query_map([], |row| {
+                let entities_str: String = row.get(2)?;
+                let date_range_str: Option<String> = row.get(3)?;
+                let agg_str: String = row.get(4)?;
+                let topic_str: String = row.get(5)?;
+                let events_str: String = row.get(6)?;
+                let created_str: String = row.get(9)?;
+                Ok(crate::note::EpisodeDigest {
+                    id: row.get(0)?,
+                    episode_id: row.get(1)?,
+                    entities: serde_json::from_str(&entities_str).unwrap_or_default(),
+                    date_range: date_range_str.and_then(|s| serde_json::from_str(&s).ok()),
+                    aggregations: serde_json::from_str(&agg_str).unwrap_or_default(),
+                    topic_sequence: serde_json::from_str(&topic_str).unwrap_or_default(),
+                    events: serde_json::from_str(&events_str).unwrap_or_default(),
+                    digest_text: row.get(7)?,
+                    digest_note_id: row.get(8)?,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .unwrap_or_default()
+                        .with_timezone(&chrono::Utc),
+                })
             })
-        }).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         Ok(digests.filter_map(|r| r.ok()).collect())
     }
 
     async fn get_undigested_episode_ids(&self) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT e.id FROM episodes e LEFT JOIN episode_digests d ON e.id = d.episode_id WHERE d.id IS NULL"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        let ids = stmt.query_map([], |row| row.get(0))
+        let ids = stmt
+            .query_map([], |row| row.get(0))
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(ids.filter_map(|r| r.ok()).collect())
     }
 
-    async fn upsert_cross_episode_digest(&self, digest: &crate::note::CrossEpisodeDigest) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn upsert_cross_episode_digest(
+        &self,
+        digest: &crate::note::CrossEpisodeDigest,
+    ) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let entity_timeline_json = serde_json::to_string(&digest.entity_timeline)?;
         let cross_aggregations_json = serde_json::to_string(&digest.cross_aggregations)?;
         let events_json = serde_json::to_string(&digest.events)?;
@@ -709,37 +820,52 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_all_cross_episode_digests(&self) -> Result<Vec<crate::note::CrossEpisodeDigest>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT id, scope_id, entity_timeline_json, cross_aggregations_json, events_json, topic_progression_json, digest_text, created_at FROM cross_episode_digests ORDER BY created_at"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
-        let digests = stmt.query_map([], |row| {
-            let timeline_str: String = row.get(2)?;
-            let agg_str: String = row.get(3)?;
-            let events_str: String = row.get(4)?;
-            let topic_str: String = row.get(5)?;
-            let created_str: String = row.get(7)?;
-            Ok(crate::note::CrossEpisodeDigest {
-                id: row.get(0)?,
-                scope_id: row.get(1)?,
-                entity_timeline: serde_json::from_str(&timeline_str).unwrap_or_default(),
-                cross_aggregations: serde_json::from_str(&agg_str).unwrap_or_default(),
-                events: serde_json::from_str(&events_str).unwrap_or_default(),
-                topic_progression: serde_json::from_str(&topic_str).unwrap_or_default(),
-                digest_text: row.get(6)?,
-                created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
-                    .unwrap_or_default().with_timezone(&chrono::Utc),
+        let digests = stmt
+            .query_map([], |row| {
+                let timeline_str: String = row.get(2)?;
+                let agg_str: String = row.get(3)?;
+                let events_str: String = row.get(4)?;
+                let topic_str: String = row.get(5)?;
+                let created_str: String = row.get(7)?;
+                Ok(crate::note::CrossEpisodeDigest {
+                    id: row.get(0)?,
+                    scope_id: row.get(1)?,
+                    entity_timeline: serde_json::from_str(&timeline_str).unwrap_or_default(),
+                    cross_aggregations: serde_json::from_str(&agg_str).unwrap_or_default(),
+                    events: serde_json::from_str(&events_str).unwrap_or_default(),
+                    topic_progression: serde_json::from_str(&topic_str).unwrap_or_default(),
+                    digest_text: row.get(6)?,
+                    created_at: chrono::DateTime::parse_from_rfc3339(&created_str)
+                        .unwrap_or_default()
+                        .with_timezone(&chrono::Utc),
+                })
             })
-        }).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
 
         Ok(digests.filter_map(|r| r.ok()).collect())
     }
 
     // --- Atomic Fact Metadata (Phase Next) ---
 
-    async fn record_fact(&self, fact_id: &str, source_note_id: &str, ordinal: u32, subject: Option<&str>) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn record_fact(
+        &self,
+        fact_id: &str,
+        source_note_id: &str,
+        ordinal: u32,
+        subject: Option<&str>,
+    ) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute(
             "INSERT OR REPLACE INTO atomic_facts (id, source_note_id, ordinal, subject) VALUES (?1, ?2, ?3, ?4)",
             rusqlite::params![fact_id, source_note_id, ordinal, subject],
@@ -748,19 +874,33 @@ impl crate::store::GraphStore for SqliteGraphStore {
     }
 
     async fn get_facts_by_subject(&self, subject: &str) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
-        let mut stmt = conn.prepare(
-            "SELECT id FROM atomic_facts WHERE subject = ?1 ORDER BY created_at"
-        ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
-        let ids = stmt.query_map(rusqlite::params![subject], |row| row.get(0))
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let mut stmt = conn
+            .prepare("SELECT id FROM atomic_facts WHERE subject = ?1 ORDER BY created_at")
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let ids = stmt
+            .query_map(rusqlite::params![subject], |row| row.get(0))
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(ids.filter_map(|r| r.ok()).collect())
     }
 
     // --- Episode Links (Phase Next) ---
 
-    async fn add_episode_link(&self, from_id: &str, to_id: &str, link_type: &str, entity: Option<&str>, reason: &str) -> Result<()> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn add_episode_link(
+        &self,
+        from_id: &str,
+        to_id: &str,
+        link_type: &str,
+        entity: Option<&str>,
+        reason: &str,
+    ) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         conn.execute(
             "INSERT OR IGNORE INTO episode_links (from_episode_id, to_episode_id, link_type, entity, reason) VALUES (?1, ?2, ?3, ?4, ?5)",
             rusqlite::params![from_id, to_id, link_type, entity, reason],
@@ -768,24 +908,44 @@ impl crate::store::GraphStore for SqliteGraphStore {
         Ok(())
     }
 
-    async fn get_episode_links(&self, episode_id: &str) -> Result<Vec<(String, String, Option<String>)>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+    async fn get_episode_links(
+        &self,
+        episode_id: &str,
+    ) -> Result<Vec<(String, String, Option<String>)>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT to_episode_id, link_type, entity FROM episode_links WHERE from_episode_id = ?1 UNION SELECT from_episode_id, link_type, entity FROM episode_links WHERE to_episode_id = ?1"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
-        let links = stmt.query_map(rusqlite::params![episode_id], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-        }).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let links = stmt
+            .query_map(rusqlite::params![episode_id], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(links.filter_map(|r| r.ok()).collect())
     }
 
     async fn get_episodes_for_entity(&self, entity: &str) -> Result<Vec<String>> {
-        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT DISTINCT from_episode_id FROM episode_links WHERE entity = ?1 AND link_type = 'entity_continuity' UNION SELECT DISTINCT to_episode_id FROM episode_links WHERE entity = ?1 AND link_type = 'entity_continuity'"
         ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
-        let ids = stmt.query_map(rusqlite::params![entity], |row| row.get(0))
+        let ids = stmt
+            .query_map(rusqlite::params![entity], |row| row.get(0))
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(ids.filter_map(|r| r.ok()).collect())
+    }
+
+    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        migrate::load_schema_meta(&conn)
     }
 }

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -147,5 +147,12 @@ pub trait GraphStore: Send + Sync {
     async fn init(&self) -> Result<()>;
 
     /// Get current schema metadata (version, applied/pending migrations).
-    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta>;
+    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta> {
+        Ok(crate::migrate::SchemaMeta::new(
+            0,
+            vec![],
+            vec![],
+            vec!["schema_meta unsupported by this backend".into()],
+        ))
+    }
 }

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -145,4 +145,7 @@ pub trait GraphStore: Send + Sync {
 
     /// Initialize tables/schema if needed.
     async fn init(&self) -> Result<()>;
+
+    /// Get current schema metadata (version, applied/pending migrations).
+    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta>;
 }

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -230,4 +230,19 @@ pub trait GraphStore: Send + Sync {
             vec!["Migration tracking unavailable for this graph store".to_string()],
         ))
     }
+
+    // --- Procedural Rules (Issue #6) ---
+
+    async fn upsert_procedural_rule(&self, _rule: &crate::rules::ProceduralRule) -> Result<()> {
+        Ok(())
+    }
+    async fn list_procedural_rules(&self) -> Result<Vec<crate::rules::ProceduralRule>> {
+        Ok(Vec::new())
+    }
+    async fn disable_procedural_rule(&self, _rule_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn increment_rule_fire_count(&self, _rule_id: &str) -> Result<()> {
+        Ok(())
+    }
 }

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
 
 use crate::error::Result;
-use crate::note::{AtomicFact, CrossEpisodeDigest, Episode, EpisodeDigest, ForesightSignal, MemoryNote};
+use crate::note::{
+    AtomicFact, CrossEpisodeDigest, Episode, EpisodeDigest, ForesightSignal, MemoryNote,
+};
 
 /// Stores note embeddings and metadata. Provides ANN similarity search.
 #[async_trait]
@@ -35,7 +37,9 @@ pub trait VectorStore: Send + Sync {
     // --- Atomic Facts (Phase Next) ---
 
     /// Insert or update an atomic fact with its embedding.
-    async fn upsert_fact(&self, _fact: &AtomicFact) -> Result<()> { Ok(()) }
+    async fn upsert_fact(&self, _fact: &AtomicFact) -> Result<()> {
+        Ok(())
+    }
 
     /// Find the top-K most similar atomic facts by embedding.
     async fn find_similar_facts(
@@ -43,10 +47,14 @@ pub trait VectorStore: Send + Sync {
         _embedding: &[f32],
         _top_k: usize,
         _exclude_source_note_ids: &[&str],
-    ) -> Result<Vec<(AtomicFact, f32)>> { Ok(Vec::new()) }
+    ) -> Result<Vec<(AtomicFact, f32)>> {
+        Ok(Vec::new())
+    }
 
     /// Get all facts for a given source note.
-    async fn get_facts_for_note(&self, _note_id: &str) -> Result<Vec<AtomicFact>> { Ok(Vec::new()) }
+    async fn get_facts_for_note(&self, _note_id: &str) -> Result<Vec<AtomicFact>> {
+        Ok(Vec::new())
+    }
 }
 
 /// Stores graph edges (links), evolution history, dream state,
@@ -80,7 +88,10 @@ pub trait GraphStore: Send + Sync {
     ) -> Result<()>;
 
     /// Get evolution history for a note.
-    async fn get_evolution_history(&self, note_id: &str) -> Result<Vec<crate::note::EvolutionRecord>>;
+    async fn get_evolution_history(
+        &self,
+        note_id: &str,
+    ) -> Result<Vec<crate::note::EvolutionRecord>>;
 
     // --- Dream state ---
 
@@ -95,54 +106,128 @@ pub trait GraphStore: Send + Sync {
 
     // --- Foresight signals (Phase 2B.2) ---
 
-    async fn upsert_foresight(&self, _signal: &ForesightSignal) -> Result<()> { Ok(()) }
-    async fn get_active_foresights(&self) -> Result<Vec<ForesightSignal>> { Ok(Vec::new()) }
-    async fn expire_foresights(&self, _before: chrono::DateTime<chrono::Utc>) -> Result<usize> { Ok(0) }
-    async fn get_foresights_for_note(&self, _note_id: &str) -> Result<Vec<ForesightSignal>> { Ok(Vec::new()) }
+    async fn upsert_foresight(&self, _signal: &ForesightSignal) -> Result<()> {
+        Ok(())
+    }
+    async fn get_active_foresights(&self) -> Result<Vec<ForesightSignal>> {
+        Ok(Vec::new())
+    }
+    async fn expire_foresights(&self, _before: chrono::DateTime<chrono::Utc>) -> Result<usize> {
+        Ok(0)
+    }
+    async fn get_foresights_for_note(&self, _note_id: &str) -> Result<Vec<ForesightSignal>> {
+        Ok(Vec::new())
+    }
 
     // --- Episodes (Phase 2B.1) ---
 
-    async fn upsert_episode(&self, _episode: &Episode) -> Result<()> { Ok(()) }
-    async fn get_episode(&self, _id: &str) -> Result<Option<Episode>> { Ok(None) }
-    async fn get_episodes_for_session(&self, _session_id: &str) -> Result<Vec<Episode>> { Ok(Vec::new()) }
-    async fn add_note_to_episode(&self, _note_id: &str, _episode_id: &str) -> Result<()> { Ok(()) }
-    async fn get_episode_for_note(&self, _note_id: &str) -> Result<Option<String>> { Ok(None) }
-    async fn get_notes_for_episode(&self, _episode_id: &str) -> Result<Vec<String>> { Ok(Vec::new()) }
+    async fn upsert_episode(&self, _episode: &Episode) -> Result<()> {
+        Ok(())
+    }
+    async fn get_episode(&self, _id: &str) -> Result<Option<Episode>> {
+        Ok(None)
+    }
+    async fn get_episodes_for_session(&self, _session_id: &str) -> Result<Vec<Episode>> {
+        Ok(Vec::new())
+    }
+    async fn add_note_to_episode(&self, _note_id: &str, _episode_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn get_episode_for_note(&self, _note_id: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+    async fn get_notes_for_episode(&self, _episode_id: &str) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 
     // --- Profiles (Phase 2B.3) ---
 
-    async fn upsert_profile(&self, _entity_id: &str, _note_id: &str) -> Result<()> { Ok(()) }
-    async fn get_profile_note_id(&self, _entity_id: &str) -> Result<Option<String>> { Ok(None) }
-    async fn get_all_profiles(&self) -> Result<Vec<(String, String)>> { Ok(Vec::new()) }
+    async fn upsert_profile(&self, _entity_id: &str, _note_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn get_profile_note_id(&self, _entity_id: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+    async fn get_all_profiles(&self) -> Result<Vec<(String, String)>> {
+        Ok(Vec::new())
+    }
 
     // --- Episode Digests (Phase Next) ---
 
-    async fn upsert_episode_digest(&self, _digest: &EpisodeDigest) -> Result<()> { Ok(()) }
-    async fn get_episode_digest(&self, _episode_id: &str) -> Result<Option<EpisodeDigest>> { Ok(None) }
-    async fn get_all_episode_digests(&self) -> Result<Vec<EpisodeDigest>> { Ok(Vec::new()) }
+    async fn upsert_episode_digest(&self, _digest: &EpisodeDigest) -> Result<()> {
+        Ok(())
+    }
+    async fn get_episode_digest(&self, _episode_id: &str) -> Result<Option<EpisodeDigest>> {
+        Ok(None)
+    }
+    async fn get_all_episode_digests(&self) -> Result<Vec<EpisodeDigest>> {
+        Ok(Vec::new())
+    }
     /// Get episode IDs that have no digest yet (for incremental dream processing).
-    async fn get_undigested_episode_ids(&self) -> Result<Vec<String>> { Ok(Vec::new()) }
+    async fn get_undigested_episode_ids(&self) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 
     // --- Cross-Episode Digests ---
 
-    async fn upsert_cross_episode_digest(&self, _digest: &CrossEpisodeDigest) -> Result<()> { Ok(()) }
-    async fn get_all_cross_episode_digests(&self) -> Result<Vec<CrossEpisodeDigest>> { Ok(Vec::new()) }
+    async fn upsert_cross_episode_digest(&self, _digest: &CrossEpisodeDigest) -> Result<()> {
+        Ok(())
+    }
+    async fn get_all_cross_episode_digests(&self) -> Result<Vec<CrossEpisodeDigest>> {
+        Ok(Vec::new())
+    }
 
     // --- Atomic Fact Metadata (Phase Next) ---
 
-    async fn record_fact(&self, _fact_id: &str, _source_note_id: &str, _ordinal: u32, _subject: Option<&str>) -> Result<()> { Ok(()) }
-    async fn get_facts_by_subject(&self, _subject: &str) -> Result<Vec<String>> { Ok(Vec::new()) }
+    async fn record_fact(
+        &self,
+        _fact_id: &str,
+        _source_note_id: &str,
+        _ordinal: u32,
+        _subject: Option<&str>,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn get_facts_by_subject(&self, _subject: &str) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 
     // --- Episode Links (Phase Next) ---
 
-    async fn add_episode_link(&self, _from_id: &str, _to_id: &str, _link_type: &str, _entity: Option<&str>, _reason: &str) -> Result<()> { Ok(()) }
+    async fn add_episode_link(
+        &self,
+        _from_id: &str,
+        _to_id: &str,
+        _link_type: &str,
+        _entity: Option<&str>,
+        _reason: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
     /// Returns (linked_episode_id, link_type, entity).
-    async fn get_episode_links(&self, _episode_id: &str) -> Result<Vec<(String, String, Option<String>)>> { Ok(Vec::new()) }
+    async fn get_episode_links(
+        &self,
+        _episode_id: &str,
+    ) -> Result<Vec<(String, String, Option<String>)>> {
+        Ok(Vec::new())
+    }
     /// Get all episode IDs linked to a given entity via entity_continuity.
-    async fn get_episodes_for_entity(&self, _entity: &str) -> Result<Vec<String>> { Ok(Vec::new()) }
+    async fn get_episodes_for_entity(&self, _entity: &str) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 
     // --- Lifecycle ---
 
     /// Initialize tables/schema if needed.
     async fn init(&self) -> Result<()>;
+
+    /// Get current schema metadata (version, applied/pending migrations).
+    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta> {
+        Ok(crate::migrate::SchemaMeta::new(
+            0,
+            Vec::new(),
+            Vec::new(),
+            vec!["Migration tracking unavailable for this graph store".to_string()],
+        ))
+    }
 }

--- a/crates/karta-core/src/write.rs
+++ b/crates/karta-core/src/write.rs
@@ -40,20 +40,17 @@ impl WriteEngine {
         let preview_end = {
             let max = 60;
             let mut end = content.len().min(max);
-            while end > 0 && !content.is_char_boundary(end) { end -= 1; }
+            while end > 0 && !content.is_char_boundary(end) {
+                end -= 1;
+            }
             end
         };
         info!("Adding note: \"{}...\"", &content[..preview_end]);
 
         // 1. Generate attributes + embed raw content in parallel
         let content_owned = content.to_string();
-        let embed_fut = async {
-            self.llm.embed(&[&content_owned]).await
-        };
-        let (attrs, raw_embeddings) = tokio::join!(
-            self.generate_attributes(content),
-            embed_fut
-        );
+        let embed_fut = async { self.llm.embed(&[&content_owned]).await };
+        let (attrs, raw_embeddings) = tokio::join!(self.generate_attributes(content), embed_fut);
         let attrs = attrs?;
         let raw_embedding = raw_embeddings?.into_iter().next().unwrap_or_default();
         debug!(context = %attrs.context, "Generated attributes");
@@ -71,12 +68,7 @@ impl WriteEngine {
             .await?;
 
         // 4. Compute enriched embedding for storage (content + context + keywords)
-        let embedding_text = format!(
-            "{} {} {}",
-            content,
-            note.context,
-            note.keywords.join(" ")
-        );
+        let embedding_text = format!("{} {} {}", content, note.context, note.keywords.join(" "));
         let enriched_embeddings = self.llm.embed(&[&embedding_text]).await?;
         note.embedding = enriched_embeddings.into_iter().next().unwrap_or_default();
 
@@ -89,7 +81,8 @@ impl WriteEngine {
 
         // 5. LLM decides which candidates to link
         let link_decisions = if !candidates.is_empty() {
-            self.decide_links(content, &note.context, &candidates).await?
+            self.decide_links(content, &note.context, &candidates)
+                .await?
         } else {
             Vec::new()
         };
@@ -101,10 +94,8 @@ impl WriteEngine {
             for decision in &link_decisions {
                 if let Some(existing) = self.vector_store.get(&decision.note_id).await? {
                     // Check evolution count — skip if over threshold (needs consolidation instead)
-                    let evolution_history = self
-                        .graph_store
-                        .get_evolution_history(&existing.id)
-                        .await?;
+                    let evolution_history =
+                        self.graph_store.get_evolution_history(&existing.id).await?;
 
                     if evolution_history.len() >= self.config.max_evolutions_per_note {
                         debug!(
@@ -180,15 +171,19 @@ impl WriteEngine {
 
         // 10. Store atomic facts (each with its own embedding for fine-grained retrieval)
         if !attrs.atomic_facts.is_empty() {
-            let fact_texts: Vec<&str> = attrs.atomic_facts.iter()
+            let fact_texts: Vec<&str> = attrs
+                .atomic_facts
+                .iter()
                 .take(self.config.max_facts_per_note)
                 .map(|f| f.content.as_str())
                 .collect();
 
             match self.llm.embed(&fact_texts).await {
                 Ok(fact_embeddings) => {
-                    for (i, (extraction, embedding)) in attrs.atomic_facts.iter()
-                        .take(5)
+                    for (i, (extraction, embedding)) in attrs
+                        .atomic_facts
+                        .iter()
+                        .take(fact_texts.len())
                         .zip(fact_embeddings)
                         .enumerate()
                     {
@@ -202,9 +197,10 @@ impl WriteEngine {
                         fact.created_at = note.created_at;
 
                         let _ = self.vector_store.upsert_fact(&fact).await;
-                        let _ = self.graph_store.record_fact(
-                            &fact.id, &note.id, i as u32, fact.subject.as_deref()
-                        ).await;
+                        let _ = self
+                            .graph_store
+                            .record_fact(&fact.id, &note.id, i as u32, fact.subject.as_deref())
+                            .await;
                     }
                     debug!(count = fact_texts.len(), note_id = %note.id, "Stored atomic facts");
                 }
@@ -245,9 +241,7 @@ impl WriteEngine {
         let should_new_episode = match current_episode {
             None => true,
             Some(ep) => {
-                let time_gap = Utc::now()
-                    .signed_duration_since(ep.end_time)
-                    .num_seconds();
+                let time_gap = Utc::now().signed_duration_since(ep.end_time).num_seconds();
 
                 // Hard boundary: time gap exceeds threshold
                 if time_gap > self.episode_config.time_gap_threshold_secs {
@@ -267,12 +261,8 @@ impl WriteEngine {
                     if last_note_content.is_empty() {
                         false
                     } else {
-                        self.detect_episode_boundary(
-                            &last_note_content,
-                            content,
-                            time_gap,
-                        )
-                        .await?
+                        self.detect_episode_boundary(&last_note_content, content, time_gap)
+                            .await?
                     }
                 }
             }
@@ -290,9 +280,7 @@ impl WriteEngine {
             episode.topic_tags = tags;
 
             // Create narrative note
-            let narrative_note = self
-                .create_narrative_note(&narrative, &episode.id)
-                .await?;
+            let narrative_note = self.create_narrative_note(&narrative, &episode.id).await?;
             episode.narrative_note_id = Some(narrative_note.id.clone());
 
             self.graph_store.upsert_episode(&episode).await?;
@@ -308,10 +296,7 @@ impl WriteEngine {
                 .await?;
 
             // Re-synthesize narrative with all notes in the episode
-            let all_note_ids = self
-                .graph_store
-                .get_notes_for_episode(&ep.id)
-                .await?;
+            let all_note_ids = self.graph_store.get_notes_for_episode(&ep.id).await?;
             let all_refs: Vec<&str> = all_note_ids.iter().map(|s| s.as_str()).collect();
             let all_notes = self.vector_store.get_many(&all_refs).await?;
             let contents: Vec<&str> = all_notes.iter().map(|n| n.content.as_str()).collect();
@@ -325,14 +310,14 @@ impl WriteEngine {
             updated.topic_tags = tags;
 
             // Update or create narrative note
-            if let Some(ref nar_id) = updated.narrative_note_id {
-                if let Some(mut nar_note) = self.vector_store.get(nar_id).await? {
-                    nar_note.content = narrative;
-                    nar_note.updated_at = Utc::now();
-                    let emb = self.llm.embed(&[&nar_note.content]).await?;
-                    nar_note.embedding = emb.into_iter().next().unwrap_or_default();
-                    self.vector_store.upsert(&nar_note).await?;
-                }
+            if let Some(ref nar_id) = updated.narrative_note_id
+                && let Some(mut nar_note) = self.vector_store.get(nar_id).await?
+            {
+                nar_note.content = narrative;
+                nar_note.updated_at = Utc::now();
+                let emb = self.llm.embed(&[&nar_note.content]).await?;
+                nar_note.embedding = emb.into_iter().next().unwrap_or_default();
+                self.vector_store.upsert(&nar_note).await?;
             }
 
             self.graph_store.upsert_episode(&updated).await?;
@@ -364,8 +349,7 @@ impl WriteEngine {
         ];
 
         let response = self.llm.chat(&messages, &GenConfig::default()).await?;
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         // If sameEpisode is false, we need a new episode
         Ok(!parsed["sameEpisode"].as_bool().unwrap_or(true))
@@ -391,8 +375,7 @@ impl WriteEngine {
         ];
 
         let response = self.llm.chat(&messages, &GenConfig::default()).await?;
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         let narrative = parsed["narrative"]
             .as_str()
@@ -400,17 +383,17 @@ impl WriteEngine {
             .to_string();
         let tags = parsed["topicTags"]
             .as_array()
-            .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
             .unwrap_or_default();
 
         Ok((narrative, tags))
     }
 
-    async fn create_narrative_note(
-        &self,
-        narrative: &str,
-        episode_id: &str,
-    ) -> Result<MemoryNote> {
+    async fn create_narrative_note(&self, narrative: &str, episode_id: &str) -> Result<MemoryNote> {
         let embeddings = self.llm.embed(&[narrative]).await?;
         let embedding = embeddings.into_iter().next().unwrap_or_default();
 
@@ -460,21 +443,25 @@ impl WriteEngine {
 
         let response = self.llm.chat(&messages, &config).await?;
 
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         Ok(NoteAttributes {
-            context: parsed["context"]
-                .as_str()
-                .unwrap_or(content)
-                .to_string(),
+            context: parsed["context"].as_str().unwrap_or(content).to_string(),
             keywords: parsed["keywords"]
                 .as_array()
-                .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
                 .unwrap_or_default(),
             tags: parsed["tags"]
                 .as_array()
-                .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
                 .unwrap_or_default(),
             foresight_signals: parsed["foresight_signals"]
                 .as_array()
@@ -491,9 +478,7 @@ impl WriteEngine {
                             } else {
                                 Some(crate::note::ForesightExtraction {
                                     content: v["content"].as_str()?.to_string(),
-                                    valid_until: v["valid_until"]
-                                        .as_str()
-                                        .map(String::from),
+                                    valid_until: v["valid_until"].as_str().map(String::from),
                                 })
                             }
                         })
@@ -551,8 +536,7 @@ impl WriteEngine {
 
         let response = self.llm.chat(&messages, &GenConfig::default()).await?;
 
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         let links = parsed["links"]
             .as_array()
@@ -596,8 +580,7 @@ impl WriteEngine {
 
         let response = self.llm.chat(&messages, &GenConfig::default()).await?;
 
-        let parsed: serde_json::Value =
-            serde_json::from_str(&response.content).unwrap_or_default();
+        let parsed: serde_json::Value = serde_json::from_str(&response.content).unwrap_or_default();
 
         Ok(parsed["updatedContext"]
             .as_str()

--- a/crates/karta-core/tests/beam_100k.rs
+++ b/crates/karta-core/tests/beam_100k.rs
@@ -16,9 +16,9 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
+use karta_core::Karta;
 use karta_core::config::KartaConfig;
 use karta_core::note::AskResult;
-use karta_core::Karta;
 
 #[derive(serde::Deserialize)]
 #[allow(dead_code)] // Some fields are parsed for schema completeness but unread by the harness.
@@ -99,6 +99,7 @@ fn load_dataset(path: &str) -> BeamDataset {
 ///   1. `BEAM_DATASET_PATH` env (explicit override, absolute or relative)
 ///   2. `data/beam-100k.json` relative to CWD
 ///   3. `<CARGO_MANIFEST_DIR>/../../data/beam-100k.json` (workspace root)
+///
 /// Panic loudly if none exist, so a missing dataset fails the test instead
 /// of making it pass with zero work.
 fn resolve_dataset_path() -> String {
@@ -117,8 +118,8 @@ fn resolve_dataset_path() -> String {
         return cwd_relative.to_string();
     }
 
-    let workspace_relative = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../data/beam-100k.json");
+    let workspace_relative =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../data/beam-100k.json");
     if workspace_relative.exists() {
         return workspace_relative.to_string_lossy().into_owned();
     }
@@ -215,12 +216,7 @@ async fn llm_judge_rubric_arc(
 
 /// LLM-as-judge using the exact BEAM official prompt and 3-tier scoring (1.0/0.5/0.0).
 /// Returns score 0.0, 0.5, or 1.0.
-async fn llm_judge_rubric(
-    karta: &Karta,
-    question: &str,
-    answer: &str,
-    rubric_item: &str,
-) -> f64 {
+async fn llm_judge_rubric(karta: &Karta, question: &str, answer: &str, rubric_item: &str) -> f64 {
     use karta_core::llm::{ChatMessage, GenConfig, Role};
 
     // Build the prompt exactly as BEAM does: substitute placeholders
@@ -247,9 +243,13 @@ async fn llm_judge_rubric(
                 serde_json::from_str(&response.content).unwrap_or_default();
             let score = parsed["score"].as_f64().unwrap_or(0.0);
             // Clamp to valid BEAM scores
-            if score >= 0.75 { 1.0 }
-            else if score >= 0.25 { 0.5 }
-            else { 0.0 }
+            if score >= 0.75 {
+                1.0
+            } else if score >= 0.25 {
+                0.5
+            } else {
+                0.0
+            }
         }
         Err(e) => {
             eprintln!("    Judge error: {}", e);
@@ -259,13 +259,22 @@ async fn llm_judge_rubric(
 }
 
 fn env_f32(key: &str, default: f32) -> f32 {
-    std::env::var(key).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
 }
 fn env_bool(key: &str, default: bool) -> bool {
-    std::env::var(key).ok().map(|s| s == "1" || s == "true").unwrap_or(default)
+    std::env::var(key)
+        .ok()
+        .map(|s| s == "1" || s == "true")
+        .unwrap_or(default)
 }
 fn env_usize(key: &str, default: usize) -> usize {
-    std::env::var(key).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
 }
 
 fn apply_config_env(config: &mut KartaConfig) {
@@ -287,10 +296,16 @@ fn apply_config_env(config: &mut KartaConfig) {
     config.read.fact_match_boost = env_f32("K_FACT_BOOST", 0.1);
 
     let exp = std::env::var("K_EXPERIMENT").unwrap_or_else(|_| "default".to_string());
-    println!("  Config [{}]: episode={}, ep_retrieval={}, graph={}, foresight={}, reranker={}, abstention_thresh={}",
-        exp, config.episode.enabled, config.read.episode_retrieval_enabled,
-        config.read.graph_weight, config.read.foresight_boost,
-        config.reranker.enabled, config.reranker.abstention_threshold);
+    println!(
+        "  Config [{}]: episode={}, ep_retrieval={}, graph={}, foresight={}, reranker={}, abstention_thresh={}",
+        exp,
+        config.episode.enabled,
+        config.read.episode_retrieval_enabled,
+        config.read.graph_weight,
+        config.read.foresight_boost,
+        config.reranker.enabled,
+        config.reranker.abstention_threshold
+    );
 }
 
 /// Find a data directory for a conversation ID.
@@ -310,7 +325,9 @@ fn find_latest_data_dir(conv_id: &str) -> Option<String> {
         .ok()?
         .filter_map(|e| e.ok())
         .filter(|e| {
-            e.file_name().to_string_lossy().starts_with(&format!("karta-beam100k-{}-", conv_id))
+            e.file_name()
+                .to_string_lossy()
+                .starts_with(&format!("karta-beam100k-{}-", conv_id))
                 && e.path().is_dir()
         })
         .filter_map(|e| {
@@ -326,7 +343,7 @@ fn find_latest_data_dir(conv_id: &str) -> Option<String> {
             }
         })
         .collect();
-    dirs.sort_by(|a, b| b.1.cmp(&a.1)); // most recently created first
+    dirs.sort_by_key(|(_, created)| std::cmp::Reverse(*created)); // most recently created first
     dirs.into_iter().next().map(|(path, _)| path)
 }
 
@@ -342,7 +359,10 @@ async fn create_karta(conv_id: &str) -> Karta {
                 .await
                 .expect("Failed to open existing Karta data dir");
         } else {
-            panic!("BEAM_SKIP_INGEST=true but no data dir found for conv {}", conv_id);
+            panic!(
+                "BEAM_SKIP_INGEST=true but no data dir found for conv {}",
+                conv_id
+            );
         }
     }
 
@@ -427,11 +447,19 @@ async fn eval_conversation(
                 format!("[{}] {}", msg.time_anchor, msg.content)
             };
 
-            match karta.add_note_with_metadata(&content, &session_id, Some(i as u32), source_timestamp).await {
+            match karta
+                .add_note_with_metadata(&content, &session_id, Some(i as u32), source_timestamp)
+                .await
+            {
                 Ok(note) => {
                     ingested += 1;
                     if (i + 1) % 20 == 0 || i == 0 {
-                        println!("  Ingested {}/{} notes ({} links)", i + 1, conv.user_messages.len(), note.links.len());
+                        println!(
+                            "  Ingested {}/{} notes ({} links)",
+                            i + 1,
+                            conv.user_messages.len(),
+                            note.links.len()
+                        );
                     }
                 }
                 Err(e) => {
@@ -472,18 +500,26 @@ async fn eval_conversation(
 
     // JSONL debug log setup
     let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent().unwrap().parent().unwrap();
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
     let results_dir = repo_root.join(".results");
     let _ = std::fs::create_dir_all(&results_dir);
-    let run_ts = std::env::var("BEAM_RUN_ID").unwrap_or_else(|_| {
-        chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string()
+    let run_ts = std::env::var("BEAM_RUN_ID")
+        .unwrap_or_else(|_| chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string());
+    let debug_path = std::env::var("BEAM_DEBUG_PATH").unwrap_or_else(|_| {
+        results_dir
+            .join(format!("beam-debug-{}-{}.jsonl", conv.id, run_ts))
+            .to_string_lossy()
+            .to_string()
     });
-    let debug_path = std::env::var("BEAM_DEBUG_PATH")
-        .unwrap_or_else(|_| results_dir.join(format!("beam-debug-{}-{}.jsonl", conv.id, run_ts)).to_string_lossy().to_string());
 
     // Phase 1: Ask questions with bounded concurrency via semaphore
     let query_concurrency: usize = std::env::var("BEAM_QUERY_CONCURRENCY")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(3);
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
     let semaphore = Arc::new(tokio::sync::Semaphore::new(query_concurrency));
     let mut ask_handles = Vec::new();
 
@@ -538,7 +574,8 @@ async fn eval_conversation(
             let question = q.question.clone();
             let answer_clone = answer.clone();
             judge_handles.push(tokio::spawn(async move {
-                let score = llm_judge_rubric_arc(&karta_ref, &question, &answer_clone, &rubric).await;
+                let score =
+                    llm_judge_rubric_arc(&karta_ref, &question, &answer_clone, &rubric).await;
                 (qi, ri, rubric, score)
             }));
         }
@@ -574,11 +611,14 @@ async fn eval_conversation(
 
         println!(
             "\n  [{}] Q{}: {}",
-            q.ability, qi + 1, safe_truncate(&q.question, 80)
+            q.ability,
+            qi + 1,
+            safe_truncate(&q.question, 80)
         );
         println!(
             "  A ({:.1}s): {}",
-            *query_ms as f64 / 1000.0, safe_truncate(answer, 200)
+            *query_ms as f64 / 1000.0,
+            safe_truncate(answer, 200)
         );
 
         let entry = ability_scores.entry(q.ability.clone()).or_insert((0, 0));
@@ -609,12 +649,24 @@ async fn eval_conversation(
                 entry.1 += 1;
                 rubric_score_sum += score;
 
-                let label = if *score >= 1.0 { "FULL" } else if *score >= 0.5 { "PART" } else { "FAIL" };
+                let label = if *score >= 1.0 {
+                    "FULL"
+                } else if *score >= 0.5 {
+                    "PART"
+                } else {
+                    "FAIL"
+                };
                 if *score >= 0.5 {
                     total_passed += 1;
                     entry.0 += 1;
                 }
-                println!("    [{}] R{}: {:.1} ({})", label, ri + 1, score, safe_truncate(rubric, 70));
+                println!(
+                    "    [{}] R{}: {:.1} ({})",
+                    label,
+                    ri + 1,
+                    score,
+                    safe_truncate(rubric, 70)
+                );
 
                 rubric_scores_debug.push(serde_json::json!({
                     "item": rubric, "score": score, "grade": label,
@@ -650,7 +702,12 @@ async fn eval_conversation(
         }
     }
 
-    (conv.questions.len(), total_passed, total_checks, ability_scores)
+    (
+        conv.questions.len(),
+        total_passed,
+        total_checks,
+        ability_scores,
+    )
 }
 
 /// Run BEAM 100K on a single conversation (for quick testing).
@@ -679,14 +736,22 @@ async fn beam_100k_single() {
     println!("  Questions: {}", questions);
     println!("  Rubric checks: {}/{} passed (>= 0.5)", passed, total);
 
-    let pass_rate = if total > 0 { passed as f64 / total as f64 } else { 0.0 };
+    let pass_rate = if total > 0 {
+        passed as f64 / total as f64
+    } else {
+        0.0
+    };
     println!("  Pass rate: {:.1}%", pass_rate * 100.0);
 
     println!("\n  Per-ability (rubric items >= 0.5):");
     let mut abilities: Vec<_> = ability_scores.into_iter().collect();
     abilities.sort_by_key(|(name, _)| name.clone());
     for (name, (p, t)) in &abilities {
-        let rate = if *t > 0 { *p as f64 / *t as f64 * 100.0 } else { 0.0 };
+        let rate = if *t > 0 {
+            *p as f64 / *t as f64 * 100.0
+        } else {
+            0.0
+        };
         println!("    {:30} {}/{} ({:.0}%)", name, p, t, rate);
     }
 }
@@ -701,8 +766,10 @@ async fn beam_100k_single() {
 async fn beam_100k_full() {
     let dataset_path = resolve_dataset_path();
     let dataset = load_dataset(&dataset_path);
-    println!("BEAM 100K Full Benchmark: {} conversations, {} questions",
-        dataset.num_conversations, dataset.total_questions);
+    println!(
+        "BEAM 100K Full Benchmark: {} conversations, {} questions",
+        dataset.num_conversations, dataset.total_questions
+    );
 
     let concurrency: usize = std::env::var("BEAM_CONCURRENCY")
         .ok()
@@ -794,7 +861,10 @@ async fn beam_100k_full() {
     println!("{}", "=".repeat(70));
     println!("  Conversations: {}", dataset.num_conversations);
     println!("  Questions:     {}", grand_total_q);
-    println!("  Passed:        {}/{}", grand_total_passed, grand_total_checks);
+    println!(
+        "  Passed:        {}/{}",
+        grand_total_passed, grand_total_checks
+    );
 
     let pass_rate = if grand_total_checks > 0 {
         grand_total_passed as f64 / grand_total_checks as f64
@@ -808,7 +878,11 @@ async fn beam_100k_full() {
     let mut abilities: Vec<_> = grand_ability.into_iter().collect();
     abilities.sort_by_key(|(name, _)| name.clone());
     for (name, (p, t)) in &abilities {
-        let rate = if *t > 0 { *p as f64 / *t as f64 * 100.0 } else { 0.0 };
+        let rate = if *t > 0 {
+            *p as f64 / *t as f64 * 100.0
+        } else {
+            0.0
+        };
         println!("    {:30} {}/{} ({:.0}%)", name, p, t, rate);
     }
 }

--- a/crates/karta-core/tests/bench_beam.rs
+++ b/crates/karta-core/tests/bench_beam.rs
@@ -37,13 +37,13 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use karta_core::Karta;
 use karta_core::config::KartaConfig;
+use karta_core::llm::LlmProvider;
 use karta_core::llm::MockLlmProvider;
 use karta_core::store::lance::LanceVectorStore;
 use karta_core::store::sqlite::SqliteGraphStore;
 use karta_core::store::{GraphStore, VectorStore};
-use karta_core::llm::LlmProvider;
-use karta_core::Karta;
 
 // ---------------------------------------------------------------------------
 // Data structures (aligned with BEAM's format)
@@ -160,16 +160,14 @@ fn safe_truncate(s: &str, max_bytes: usize) -> &str {
 /// Normalize unicode dashes/quotes to ASCII equivalents for matching.
 fn normalize_for_matching(s: &str) -> String {
     s.to_lowercase()
-        .replace('\u{2010}', "-") // hyphen
-        .replace('\u{2011}', "-") // non-breaking hyphen
-        .replace('\u{2012}', "-") // figure dash
-        .replace('\u{2013}', "-") // en dash
-        .replace('\u{2014}', "-") // em dash
-        .replace('\u{2015}', "-") // horizontal bar
-        .replace('\u{2018}', "'") // left single quote
-        .replace('\u{2019}', "'") // right single quote
-        .replace('\u{201C}', "\"") // left double quote
-        .replace('\u{201D}', "\"") // right double quote
+        .replace(
+            [
+                '\u{2010}', '\u{2011}', '\u{2012}', '\u{2013}', '\u{2014}', '\u{2015}',
+            ],
+            "-",
+        ) // dash and hyphen-like characters
+        .replace(['\u{2018}', '\u{2019}'], "'") // left and right single quotes
+        .replace(['\u{201C}', '\u{201D}'], "\"") // left and right double quotes
 }
 
 /// Check if `answer` contains at least one alternative from a `|`-separated pattern.
@@ -218,24 +216,23 @@ async fn ingest_sessions(karta: &Karta, sessions: &[Session]) -> usize {
 }
 
 fn data_dir(prefix: &str, scenario_name: &str) -> String {
-    format!(
-        "/tmp/karta-{}-{}",
+    let dir_name = format!(
+        "karta-{}-{}",
         prefix,
-        scenario_name
-            .replace(' ', "-")
-            .replace('/', "-")
-            .to_lowercase()
-    )
+        scenario_name.replace([' ', '/'], "-").to_lowercase()
+    );
+    std::env::temp_dir()
+        .join(dir_name)
+        .to_string_lossy()
+        .into_owned()
 }
 
 async fn create_karta_mock(scenario_name: &str) -> Karta {
     let dir = data_dir("beam-mock", scenario_name);
     let _ = std::fs::remove_dir_all(&dir);
 
-    let vector_store = Arc::new(LanceVectorStore::new(&dir).await.unwrap())
-        as Arc<dyn VectorStore>;
-    let graph_store =
-        Arc::new(SqliteGraphStore::new(&dir).unwrap()) as Arc<dyn GraphStore>;
+    let vector_store = Arc::new(LanceVectorStore::new(&dir).await.unwrap()) as Arc<dyn VectorStore>;
+    let graph_store = Arc::new(SqliteGraphStore::new(&dir).unwrap()) as Arc<dyn GraphStore>;
     let llm = Arc::new(MockLlmProvider::new()) as Arc<dyn LlmProvider>;
 
     let mut config = KartaConfig::default();
@@ -273,13 +270,34 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 session_id: 1,
                 label: "2025-03-10",
                 messages: vec![
-                    Message { role: "user", content: "I just hired Elena Vasquez as our new VP of Engineering. She's coming from Stripe where she led the payments infrastructure team." },
-                    Message { role: "assistant", content: "Great hire! What's her start date?" },
-                    Message { role: "user", content: "She starts April 1st. Her first project will be migrating our monolith to microservices." },
-                    Message { role: "assistant", content: "Makes sense given her infrastructure background." },
-                    Message { role: "user", content: "Elena's team will be 12 engineers. She wants to use Kubernetes on GCP, not AWS — she had bad experiences with EKS at Stripe." },
-                    Message { role: "assistant", content: "Noted. GCP + GKE it is." },
-                    Message { role: "user", content: "Budget for the migration is $2.4M over 18 months. Elena has full authority on technical decisions." },
+                    Message {
+                        role: "user",
+                        content: "I just hired Elena Vasquez as our new VP of Engineering. She's coming from Stripe where she led the payments infrastructure team.",
+                    },
+                    Message {
+                        role: "assistant",
+                        content: "Great hire! What's her start date?",
+                    },
+                    Message {
+                        role: "user",
+                        content: "She starts April 1st. Her first project will be migrating our monolith to microservices.",
+                    },
+                    Message {
+                        role: "assistant",
+                        content: "Makes sense given her infrastructure background.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "Elena's team will be 12 engineers. She wants to use Kubernetes on GCP, not AWS — she had bad experiences with EKS at Stripe.",
+                    },
+                    Message {
+                        role: "assistant",
+                        content: "Noted. GCP + GKE it is.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "Budget for the migration is $2.4M over 18 months. Elena has full authority on technical decisions.",
+                    },
                 ],
             }],
             questions: vec![
@@ -303,7 +321,6 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 },
             ],
         },
-
         // --- 2. Cross-session reasoning + Multi-hop ---
         BeamScenario {
             name: "Cross-session multi-hop reasoning",
@@ -312,27 +329,54 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                     session_id: 1,
                     label: "2025-01-10",
                     messages: vec![
-                        Message { role: "user", content: "Our data warehouse is on Snowflake. We're paying $8K/month and growing 20% quarter over quarter." },
-                        Message { role: "assistant", content: "That's solid growth. Any cost concerns?" },
-                        Message { role: "user", content: "Not yet, but our CFO Rachel wants a cost projection for the next 12 months." },
+                        Message {
+                            role: "user",
+                            content: "Our data warehouse is on Snowflake. We're paying $8K/month and growing 20% quarter over quarter.",
+                        },
+                        Message {
+                            role: "assistant",
+                            content: "That's solid growth. Any cost concerns?",
+                        },
+                        Message {
+                            role: "user",
+                            content: "Not yet, but our CFO Rachel wants a cost projection for the next 12 months.",
+                        },
                     ],
                 },
                 Session {
                     session_id: 2,
                     label: "2025-02-15",
                     messages: vec![
-                        Message { role: "user", content: "We just signed a deal with MegaCorp — they'll send us 50GB of event data daily starting March 1." },
-                        Message { role: "assistant", content: "That's a lot of data. Will your Snowflake setup handle it?" },
-                        Message { role: "user", content: "That's exactly what I'm worried about. The MegaCorp data needs to be queryable within 4 hours of arrival." },
+                        Message {
+                            role: "user",
+                            content: "We just signed a deal with MegaCorp — they'll send us 50GB of event data daily starting March 1.",
+                        },
+                        Message {
+                            role: "assistant",
+                            content: "That's a lot of data. Will your Snowflake setup handle it?",
+                        },
+                        Message {
+                            role: "user",
+                            content: "That's exactly what I'm worried about. The MegaCorp data needs to be queryable within 4 hours of arrival.",
+                        },
                     ],
                 },
                 Session {
                     session_id: 3,
                     label: "2025-03-05",
                     messages: vec![
-                        Message { role: "user", content: "Snowflake costs jumped to $18K this month after the MegaCorp data started flowing. Rachel is not happy." },
-                        Message { role: "assistant", content: "That's more than double. What changed?" },
-                        Message { role: "user", content: "The auto-scaling warehouses are running hot processing the MegaCorp ingestion. We need a cheaper approach." },
+                        Message {
+                            role: "user",
+                            content: "Snowflake costs jumped to $18K this month after the MegaCorp data started flowing. Rachel is not happy.",
+                        },
+                        Message {
+                            role: "assistant",
+                            content: "That's more than double. What changed?",
+                        },
+                        Message {
+                            role: "user",
+                            content: "The auto-scaling warehouses are running hot processing the MegaCorp ingestion. We need a cheaper approach.",
+                        },
                     ],
                 },
             ],
@@ -351,7 +395,6 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 },
             ],
         },
-
         // --- 3. Temporal reasoning ---
         BeamScenario {
             name: "Temporal ordering and awareness",
@@ -359,23 +402,26 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 Session {
                     session_id: 1,
                     label: "2025-01-05",
-                    messages: vec![
-                        Message { role: "user", content: "We decided to use PostgreSQL as our primary database. The team evaluated MongoDB and Postgres and chose Postgres for ACID compliance." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "We decided to use PostgreSQL as our primary database. The team evaluated MongoDB and Postgres and chose Postgres for ACID compliance.",
+                    }],
                 },
                 Session {
                     session_id: 2,
                     label: "2025-02-20",
-                    messages: vec![
-                        Message { role: "user", content: "We're hitting performance issues with PostgreSQL on our analytics queries. Looking at adding a read replica." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "We're hitting performance issues with PostgreSQL on our analytics queries. Looking at adding a read replica.",
+                    }],
                 },
                 Session {
                     session_id: 3,
                     label: "2025-03-15",
-                    messages: vec![
-                        Message { role: "user", content: "We've decided to move analytics workloads off Postgres entirely. We'll use ClickHouse for analytics and keep Postgres for OLTP only." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "We've decided to move analytics workloads off Postgres entirely. We'll use ClickHouse for analytics and keep Postgres for OLTP only.",
+                    }],
                 },
             ],
             questions: vec![
@@ -399,7 +445,6 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 },
             ],
         },
-
         // --- 4. Contradiction resolution ---
         BeamScenario {
             name: "Contradiction detection and resolution",
@@ -408,18 +453,36 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                     session_id: 1,
                     label: "2025-01-20",
                     messages: vec![
-                        Message { role: "user", content: "Our security policy requires all data to be encrypted at rest using AES-256. No exceptions — the CISO signed off on this." },
-                        Message { role: "assistant", content: "Clear. AES-256 at rest, no exceptions." },
-                        Message { role: "user", content: "We also require all API traffic to go through our API gateway. Direct service-to-service calls over the public internet are banned." },
+                        Message {
+                            role: "user",
+                            content: "Our security policy requires all data to be encrypted at rest using AES-256. No exceptions — the CISO signed off on this.",
+                        },
+                        Message {
+                            role: "assistant",
+                            content: "Clear. AES-256 at rest, no exceptions.",
+                        },
+                        Message {
+                            role: "user",
+                            content: "We also require all API traffic to go through our API gateway. Direct service-to-service calls over the public internet are banned.",
+                        },
                     ],
                 },
                 Session {
                     session_id: 2,
                     label: "2025-03-01",
                     messages: vec![
-                        Message { role: "user", content: "The new CTO says we can relax encryption to AES-128 for non-PII data to save on compute costs. PII data stays AES-256." },
-                        Message { role: "assistant", content: "That contradicts the earlier blanket AES-256 policy." },
-                        Message { role: "user", content: "Yes, the CTO overrode the CISO on this. The updated policy is AES-128 for non-PII, AES-256 for PII." },
+                        Message {
+                            role: "user",
+                            content: "The new CTO says we can relax encryption to AES-128 for non-PII data to save on compute costs. PII data stays AES-256.",
+                        },
+                        Message {
+                            role: "assistant",
+                            content: "That contradicts the earlier blanket AES-256 policy.",
+                        },
+                        Message {
+                            role: "user",
+                            content: "Yes, the CTO overrode the CISO on this. The updated policy is AES-128 for non-PII, AES-256 for PII.",
+                        },
                     ],
                 },
             ],
@@ -438,7 +501,6 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 },
             ],
         },
-
         // --- 5. Preference following ---
         BeamScenario {
             name: "Evolving user preferences",
@@ -446,23 +508,26 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 Session {
                     session_id: 1,
                     label: "2025-01-10",
-                    messages: vec![
-                        Message { role: "user", content: "I prefer getting status updates via email. Send me a daily digest every morning at 9am." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "I prefer getting status updates via email. Send me a daily digest every morning at 9am.",
+                    }],
                 },
                 Session {
                     session_id: 2,
                     label: "2025-02-05",
-                    messages: vec![
-                        Message { role: "user", content: "Actually, email is too slow. Switch all my notifications to Slack. Use the #ops-alerts channel." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "Actually, email is too slow. Switch all my notifications to Slack. Use the #ops-alerts channel.",
+                    }],
                 },
                 Session {
                     session_id: 3,
                     label: "2025-03-01",
-                    messages: vec![
-                        Message { role: "user", content: "Keep Slack for urgent alerts only. For routine status updates, go back to email but make it a weekly digest on Mondays." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "Keep Slack for urgent alerts only. For routine status updates, go back to email but make it a weekly digest on Mondays.",
+                    }],
                 },
             ],
             questions: vec![
@@ -480,7 +545,6 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 },
             ],
         },
-
         // --- 6. Instruction following ---
         BeamScenario {
             name: "Sustained instruction adherence",
@@ -489,17 +553,27 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                     session_id: 1,
                     label: "",
                     messages: vec![
-                        Message { role: "user", content: "Important rule: never suggest deploying to production on Fridays. Our change freeze runs Friday 3pm through Monday 8am." },
-                        Message { role: "assistant", content: "Understood. No Friday deploys." },
-                        Message { role: "user", content: "Also, always recommend staging environment testing before any production deployment. This is non-negotiable." },
+                        Message {
+                            role: "user",
+                            content: "Important rule: never suggest deploying to production on Fridays. Our change freeze runs Friday 3pm through Monday 8am.",
+                        },
+                        Message {
+                            role: "assistant",
+                            content: "Understood. No Friday deploys.",
+                        },
+                        Message {
+                            role: "user",
+                            content: "Also, always recommend staging environment testing before any production deployment. This is non-negotiable.",
+                        },
                     ],
                 },
                 Session {
                     session_id: 2,
                     label: "",
-                    messages: vec![
-                        Message { role: "user", content: "We have a critical bug fix for the payment system. It's Thursday evening and the fix is ready. When should we deploy?" },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "We have a critical bug fix for the payment system. It's Thursday evening and the fix is ready. When should we deploy?",
+                    }],
                 },
             ],
             questions: vec![
@@ -517,7 +591,6 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 },
             ],
         },
-
         // --- 7. Entity tracking across sessions ---
         BeamScenario {
             name: "Entity tracking across sessions",
@@ -526,26 +599,45 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                     session_id: 1,
                     label: "2025-01-15",
                     messages: vec![
-                        Message { role: "user", content: "Our client Nexus Corp has 3 active projects with us: Project Alpha (data pipeline), Project Beta (ML platform), and Project Gamma (dashboard)." },
-                        Message { role: "assistant", content: "Got it, 3 Nexus projects tracked." },
-                        Message { role: "user", content: "Project Alpha's lead is Tom Chen. Budget: $500K. Deadline: March 30." },
+                        Message {
+                            role: "user",
+                            content: "Our client Nexus Corp has 3 active projects with us: Project Alpha (data pipeline), Project Beta (ML platform), and Project Gamma (dashboard).",
+                        },
+                        Message {
+                            role: "assistant",
+                            content: "Got it, 3 Nexus projects tracked.",
+                        },
+                        Message {
+                            role: "user",
+                            content: "Project Alpha's lead is Tom Chen. Budget: $500K. Deadline: March 30.",
+                        },
                     ],
                 },
                 Session {
                     session_id: 2,
                     label: "2025-02-10",
                     messages: vec![
-                        Message { role: "user", content: "Project Beta at Nexus Corp just got cancelled. Budget was reallocated to Project Alpha, which now has $750K." },
-                        Message { role: "assistant", content: "Noted. Beta cancelled, Alpha budget increased." },
-                        Message { role: "user", content: "Also, Tom Chen moved to Project Gamma. The new Alpha lead is Priya Sharma." },
+                        Message {
+                            role: "user",
+                            content: "Project Beta at Nexus Corp just got cancelled. Budget was reallocated to Project Alpha, which now has $750K.",
+                        },
+                        Message {
+                            role: "assistant",
+                            content: "Noted. Beta cancelled, Alpha budget increased.",
+                        },
+                        Message {
+                            role: "user",
+                            content: "Also, Tom Chen moved to Project Gamma. The new Alpha lead is Priya Sharma.",
+                        },
                     ],
                 },
                 Session {
                     session_id: 3,
                     label: "2025-03-01",
-                    messages: vec![
-                        Message { role: "user", content: "Project Alpha at Nexus Corp was delivered on time. Nexus is very happy. They want to expand Gamma's scope." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "Project Alpha at Nexus Corp was delivered on time. Nexus is very happy. They want to expand Gamma's scope.",
+                    }],
                 },
             ],
             questions: vec![
@@ -569,7 +661,6 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 },
             ],
         },
-
         // --- 8. Abstention (unanswerable questions) ---
         BeamScenario {
             name: "Abstention on unknown information",
@@ -577,9 +668,18 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 session_id: 1,
                 label: "",
                 messages: vec![
-                    Message { role: "user", content: "Our vendor for cloud hosting is AWS. We pay them about $45K/month." },
-                    Message { role: "assistant", content: "Got it." },
-                    Message { role: "user", content: "The DevOps team lead is Kai Nakamura. He manages 5 engineers." },
+                    Message {
+                        role: "user",
+                        content: "Our vendor for cloud hosting is AWS. We pay them about $45K/month.",
+                    },
+                    Message {
+                        role: "assistant",
+                        content: "Got it.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "The DevOps team lead is Kai Nakamura. He manages 5 engineers.",
+                    },
                 ],
             }],
             questions: vec![
@@ -604,7 +704,6 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 },
             ],
         },
-
         // --- 9. Summarization ---
         BeamScenario {
             name: "Summarization across sessions",
@@ -612,63 +711,92 @@ fn beam_scenarios() -> Vec<BeamScenario> {
                 Session {
                     session_id: 1,
                     label: "2025-01-05",
-                    messages: vec![
-                        Message { role: "user", content: "We launched the customer portal v2 today. Key features: SSO integration, real-time usage dashboard, and self-service billing." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "We launched the customer portal v2 today. Key features: SSO integration, real-time usage dashboard, and self-service billing.",
+                    }],
                 },
                 Session {
                     session_id: 2,
                     label: "2025-01-20",
-                    messages: vec![
-                        Message { role: "user", content: "Portal v2 bug reports are coming in. The SSO flow breaks on Safari, and the billing page shows wrong currency for EU customers." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "Portal v2 bug reports are coming in. The SSO flow breaks on Safari, and the billing page shows wrong currency for EU customers.",
+                    }],
                 },
                 Session {
                     session_id: 3,
                     label: "2025-02-10",
-                    messages: vec![
-                        Message { role: "user", content: "Fixed the Safari SSO bug. The billing currency issue is still open — waiting on the payments team to expose a locale API." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "Fixed the Safari SSO bug. The billing currency issue is still open — waiting on the payments team to expose a locale API.",
+                    }],
                 },
                 Session {
                     session_id: 4,
                     label: "2025-03-01",
-                    messages: vec![
-                        Message { role: "user", content: "Portal v2 is now stable. All bugs resolved. Customer satisfaction score went from 3.2 to 4.5 after the fixes." },
-                    ],
+                    messages: vec![Message {
+                        role: "user",
+                        content: "Portal v2 is now stable. All bugs resolved. Customer satisfaction score went from 3.2 to 4.5 after the fixes.",
+                    }],
                 },
             ],
-            questions: vec![
-                BeamQuestion {
-                    question: "Summarize the customer portal v2 journey from launch to stabilization.",
-                    ability: BeamAbility::Summarization,
-                    must_contain: vec!["SSO|portal", "bug|issue", "stable|fixed|resolved"],
-                    expects_abstention: false,
-                },
-            ],
+            questions: vec![BeamQuestion {
+                question: "Summarize the customer portal v2 journey from launch to stabilization.",
+                ability: BeamAbility::Summarization,
+                must_contain: vec!["SSO|portal", "bug|issue", "stable|fixed|resolved"],
+                expects_abstention: false,
+            }],
         },
-
         // --- 10. Token efficiency scenario (many messages, few relevant) ---
         BeamScenario {
             name: "Token efficiency under noise",
-            sessions: vec![
-                Session {
-                    session_id: 1,
-                    label: "",
-                    messages: vec![
-                        Message { role: "user", content: "The marketing team wants to try TikTok ads for Q2. Budget: $15K." },
-                        Message { role: "user", content: "Lunch order for the team meeting: 10 pizzas from Mario's." },
-                        Message { role: "user", content: "Reminder: office party next Friday at 5pm." },
-                        Message { role: "user", content: "CRITICAL: Our database backup job has been failing silently for 3 weeks. Last successful backup was February 28." },
-                        Message { role: "user", content: "New coffee machine in the break room. It's a Breville Barista Express." },
-                        Message { role: "user", content: "IT ticket #4521: Replace the projector in conference room B." },
-                        Message { role: "user", content: "CRITICAL: The backup failure means we have no point-in-time recovery capability. RTO is currently infinite." },
-                        Message { role: "user", content: "Company retreat is scheduled for June 15-17 in Lake Tahoe." },
-                        Message { role: "user", content: "The backup runs on a cron job at 2am. The job's S3 credential expired and nobody rotated it." },
-                        Message { role: "user", content: "Fantasy football draft is Thursday. Don't forget to set your lineups." },
-                    ],
-                },
-            ],
+            sessions: vec![Session {
+                session_id: 1,
+                label: "",
+                messages: vec![
+                    Message {
+                        role: "user",
+                        content: "The marketing team wants to try TikTok ads for Q2. Budget: $15K.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "Lunch order for the team meeting: 10 pizzas from Mario's.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "Reminder: office party next Friday at 5pm.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "CRITICAL: Our database backup job has been failing silently for 3 weeks. Last successful backup was February 28.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "New coffee machine in the break room. It's a Breville Barista Express.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "IT ticket #4521: Replace the projector in conference room B.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "CRITICAL: The backup failure means we have no point-in-time recovery capability. RTO is currently infinite.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "Company retreat is scheduled for June 15-17 in Lake Tahoe.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "The backup runs on a cron job at 2am. The job's S3 credential expired and nobody rotated it.",
+                    },
+                    Message {
+                        role: "user",
+                        content: "Fantasy football draft is Thursday. Don't forget to set your lineups.",
+                    },
+                ],
+            }],
             questions: vec![
                 BeamQuestion {
                     question: "What is the critical infrastructure issue and what caused it?",
@@ -742,16 +870,8 @@ async fn run_beam_benchmark(scenarios: &[BeamScenario], use_real_llm: bool) -> B
             metrics.query_latencies_ms.push(query_ms);
             report.total_query_ms += query_ms;
 
-            println!(
-                "\n  [{}] Q: {}",
-                q.ability.as_str(),
-                q.question
-            );
-            println!(
-                "  A ({}ms): {}...",
-                query_ms,
-                safe_truncate(&answer, 200)
-            );
+            println!("\n  [{}] Q: {}", q.ability.as_str(), q.question);
+            println!("  A ({}ms): {}...", query_ms, safe_truncate(&answer, 200));
 
             let mut question_passed = true;
 
@@ -761,9 +881,7 @@ async fn run_beam_benchmark(scenarios: &[BeamScenario], use_real_llm: bool) -> B
                 // With MockLlm this is hard to test precisely, so we just
                 // track it as a pass if the answer is short or hedging.
                 metrics.checks_total += 1;
-                let entry = ability_map
-                    .entry(q.ability)
-                    .or_insert((0, 0));
+                let entry = ability_map.entry(q.ability).or_insert((0, 0));
                 entry.1 += 1;
 
                 let lower = answer.to_lowercase();
@@ -784,9 +902,7 @@ async fn run_beam_benchmark(scenarios: &[BeamScenario], use_real_llm: bool) -> B
             } else {
                 for pattern in &q.must_contain {
                     metrics.checks_total += 1;
-                    let entry = ability_map
-                        .entry(q.ability)
-                        .or_insert((0, 0));
+                    let entry = ability_map.entry(q.ability).or_insert((0, 0));
                     entry.1 += 1;
 
                     if check_must_contain(&answer, pattern) {
@@ -807,9 +923,7 @@ async fn run_beam_benchmark(scenarios: &[BeamScenario], use_real_llm: bool) -> B
 
         // Collect ability scores
         for (ability, (passed, total)) in &ability_map {
-            metrics
-                .ability_scores
-                .push((*ability, *passed, *total));
+            metrics.ability_scores.push((*ability, *passed, *total));
         }
 
         report.scenario_metrics.push(metrics);
@@ -893,10 +1007,7 @@ fn print_report(report: &BenchmarkReport) {
         } else {
             0.0
         };
-        println!(
-            "    {:30} {}/{} ({:.0}%)",
-            name, passed, total, rate
-        );
+        println!("    {:30} {}/{} ({:.0}%)", name, passed, total, rate);
     }
 }
 
@@ -916,10 +1027,18 @@ async fn beam_mock_sanity() {
     print_report(&report);
 
     let total_checks: usize = report.scenario_metrics.iter().map(|m| m.checks_total).sum();
-    let passed_checks: usize = report.scenario_metrics.iter().map(|m| m.checks_passed).sum();
+    let passed_checks: usize = report
+        .scenario_metrics
+        .iter()
+        .map(|m| m.checks_passed)
+        .sum();
     if total_checks > 0 {
         let rate = passed_checks as f64 / total_checks as f64;
-        assert!(rate >= 0.40, "Mock sanity pass rate {:.1}% below 40%", rate * 100.0);
+        assert!(
+            rate >= 0.40,
+            "Mock sanity pass rate {:.1}% below 40%",
+            rate * 100.0
+        );
     }
 }
 
@@ -934,11 +1053,19 @@ async fn beam_real() {
     print_report(&report);
 
     let total_checks: usize = report.scenario_metrics.iter().map(|m| m.checks_total).sum();
-    let passed_checks: usize = report.scenario_metrics.iter().map(|m| m.checks_passed).sum();
+    let passed_checks: usize = report
+        .scenario_metrics
+        .iter()
+        .map(|m| m.checks_passed)
+        .sum();
     if total_checks > 0 {
         let rate = passed_checks as f64 / total_checks as f64;
         println!("\n  REAL LLM pass rate: {:.1}%", rate * 100.0);
-        assert!(rate >= 0.70, "Real LLM pass rate {:.1}% below 70%", rate * 100.0);
+        assert!(
+            rate >= 0.70,
+            "Real LLM pass rate {:.1}% below 70%",
+            rate * 100.0
+        );
     }
 }
 
@@ -959,7 +1086,10 @@ async fn beam_real_with_dreaming() {
         })
         .collect();
 
-    println!("Running {} dream-relevant scenarios with real LLM", dream_relevant.len());
+    println!(
+        "Running {} dream-relevant scenarios with real LLM",
+        dream_relevant.len()
+    );
 
     for scenario in &dream_relevant {
         println!("\n{}", "=".repeat(70));
@@ -976,10 +1106,7 @@ async fn beam_real_with_dreaming() {
 
         // Dream
         let dream_start = Instant::now();
-        let dream_run = karta
-            .run_dreaming("benchmark", "beam")
-            .await
-            .unwrap();
+        let dream_run = karta.run_dreaming("benchmark", "beam").await.unwrap();
         let dream_ms = dream_start.elapsed().as_millis();
 
         let post_dream_count = karta.note_count().await.unwrap();
@@ -991,8 +1118,11 @@ async fn beam_real_with_dreaming() {
 
         for d in &dream_run.dreams {
             let icon = if d.would_write { "W" } else { "." };
-            println!("    [{}] {} conf={:.2}: {}",
-                icon, d.dream_type.as_str(), d.confidence,
+            println!(
+                "    [{}] {} conf={:.2}: {}",
+                icon,
+                d.dream_type.as_str(),
+                d.confidence,
                 safe_truncate(&d.dream_content, 120)
             );
         }
@@ -1000,15 +1130,8 @@ async fn beam_real_with_dreaming() {
         // Query (post-dream)
         for q in &scenario.questions {
             let answer = karta.ask(q.question, 5).await.unwrap().answer;
-            println!(
-                "\n  [{}] Q: {}",
-                q.ability.as_str(),
-                q.question
-            );
-            println!(
-                "  A: {}...",
-                safe_truncate(&answer, 300)
-            );
+            println!("\n  [{}] Q: {}", q.ability.as_str(), q.question);
+            println!("  A: {}...", safe_truncate(&answer, 300));
 
             for pattern in &q.must_contain {
                 if check_must_contain(&answer, pattern) {

--- a/crates/karta-core/tests/eval.rs
+++ b/crates/karta-core/tests/eval.rs
@@ -3,13 +3,13 @@
 //! Uses MockLlmProvider + real LanceDB + real SQLite.
 //! Run: cargo test --test eval
 
-use std::sync::Arc;
+use karta_core::Karta;
 use karta_core::config::KartaConfig;
 use karta_core::llm::MockLlmProvider;
 use karta_core::store::lance::LanceVectorStore;
 use karta_core::store::sqlite::SqliteGraphStore;
 use karta_core::store::{GraphStore, VectorStore};
-use karta_core::Karta;
+use std::sync::Arc;
 
 struct Scenario {
     name: &'static str,
@@ -58,14 +58,12 @@ fn scenarios() -> Vec<Scenario> {
                 "TechCorp is running a SOC 2 Type II audit in Q3 2025 and needs all vendor tooling to be compliant.",
                 "The ops team at TechCorp wants to automate their contractor onboarding — 50+ contractors per month.",
             ],
-            queries: vec![
-                Query {
-                    query: "What compliance requirements affect the TechCorp contractor onboarding automation?",
-                    must_contain: vec!["audit", "S3|SOC"],
-                    check_links: false,
-                    check_evolution: true,
-                },
-            ],
+            queries: vec![Query {
+                query: "What compliance requirements affect the TechCorp contractor onboarding automation?",
+                must_contain: vec!["audit", "S3|SOC"],
+                check_links: false,
+                check_evolution: true,
+            }],
         },
         Scenario {
             name: "Cross-entity knowledge graph",
@@ -76,14 +74,12 @@ fn scenarios() -> Vec<Scenario> {
                 "Marcus at Acme has a hard deadline: the workflow needs to be live before their Q4 sales push starts Oct 1.",
                 "The deduplication issue in HubSpot/Salesforce syncs can be solved with a normalisation step that lowercases emails before comparison.",
             ],
-            queries: vec![
-                Query {
-                    query: "What technical issues should I warn Marcus about before building the Acme CRM sync?",
-                    must_contain: vec!["deduplication|dedup", "conflict"],
-                    check_links: true,
-                    check_evolution: false,
-                },
-            ],
+            queries: vec![Query {
+                query: "What technical issues should I warn Marcus about before building the Acme CRM sync?",
+                must_contain: vec!["deduplication|dedup", "conflict"],
+                check_links: true,
+                check_evolution: false,
+            }],
         },
         Scenario {
             name: "Procedural memory",
@@ -142,14 +138,12 @@ fn scenarios() -> Vec<Scenario> {
                 "Dr. Amara Osei (CMIO at Pinnacle Health) requires all patient data pipelines to be HIPAA-compliant with end-to-end encryption and audit logging.",
                 "Pinnacle Health's previous vendor failed because they tried real-time sync via the FHIR API and hit the rate limit wall during peak hours.",
             ],
-            queries: vec![
-                Query {
-                    query: "Design the data flow for the Pinnacle Health appointment sync. What are the constraints at each stage?",
-                    must_contain: vec!["FHIR", "rate limit|100 request", "Snowflake", "HIPAA"],
-                    check_links: true,
-                    check_evolution: false,
-                },
-            ],
+            queries: vec![Query {
+                query: "Design the data flow for the Pinnacle Health appointment sync. What are the constraints at each stage?",
+                must_contain: vec!["FHIR", "rate limit|100 request", "Snowflake", "HIPAA"],
+                check_links: true,
+                check_evolution: false,
+            }],
         },
         Scenario {
             name: "Noisy context with distractors",
@@ -187,14 +181,12 @@ fn scenarios() -> Vec<Scenario> {
                 "Vanguard Logistics has a DPA (Data Processing Agreement) that specifies EU-only data residency. The DPA was signed Jan 2025 and is valid for 2 years.",
                 "The Vanguard Logistics engineering team started provisioning resources in us-east-1 on Mar 15 without informing the compliance team.",
             ],
-            queries: vec![
-                Query {
-                    query: "Where should Vanguard Logistics data be processed?",
-                    must_contain: vec!["EU|Frankfurt|eu-central", "US-East|Virginia|us-east"],
-                    check_links: false,
-                    check_evolution: false,
-                },
-            ],
+            queries: vec![Query {
+                query: "Where should Vanguard Logistics data be processed?",
+                must_contain: vec!["EU|Frankfurt|eu-central", "US-East|Virginia|us-east"],
+                check_links: false,
+                check_evolution: false,
+            }],
         },
         Scenario {
             name: "Implicit entity resolution",
@@ -206,14 +198,12 @@ fn scenarios() -> Vec<Scenario> {
                 "Apex Analytics uses Databricks as their lakehouse. All metrics must be pulled from Delta Lake tables, not raw source systems.",
                 "Jordan Reeves flagged a hard constraint: the dashboard must support SSO via Okta — no separate login credentials.",
             ],
-            queries: vec![
-                Query {
-                    query: "What are all of Jordan's requirements for the Apex dashboard?",
-                    must_contain: vec!["real-time|30 second|refresh", "Slack|alert", "SSO|Okta"],
-                    check_links: true,
-                    check_evolution: false,
-                },
-            ],
+            queries: vec![Query {
+                query: "What are all of Jordan's requirements for the Apex dashboard?",
+                must_contain: vec!["real-time|30 second|refresh", "Slack|alert", "SSO|Okta"],
+                check_links: true,
+                check_evolution: false,
+            }],
         },
         Scenario {
             name: "Long-chain dependency reasoning",
@@ -225,14 +215,12 @@ fn scenarios() -> Vec<Scenario> {
                 "ClearView's IT team has budget approval to modernize one system per quarter. The AS/400 migration is scheduled for Q1 2026.",
                 "The 2-minute SLA was promised to ClearView's board by the COO and is considered non-negotiable for the current quarter.",
             ],
-            queries: vec![
-                Query {
-                    query: "Can ClearView meet their 2-minute claims processing target? What's blocking it?",
-                    must_contain: vec!["AS/400|AS400|legacy", "nightly|batch", "SFTP"],
-                    check_links: true,
-                    check_evolution: false,
-                },
-            ],
+            queries: vec![Query {
+                query: "Can ClearView meet their 2-minute claims processing target? What's blocking it?",
+                must_contain: vec!["AS/400|AS400|legacy", "nightly|batch", "SFTP"],
+                check_links: true,
+                check_evolution: false,
+            }],
         },
     ]
 }
@@ -248,21 +236,15 @@ fn check_must_contain(answer: &str, pattern: &str) -> bool {
 async fn create_karta(scenario_name: &str) -> Karta {
     let data_dir = format!(
         "/tmp/karta-test-{}",
-        scenario_name
-            .replace(' ', "-")
-            .replace('/', "-")
-            .to_lowercase()
+        scenario_name.replace([' ', '/'], "-").to_lowercase()
     );
     // Clean up from previous runs
     let _ = std::fs::remove_dir_all(&data_dir);
 
-    let vector_store = Arc::new(
-        LanceVectorStore::new(&data_dir).await.unwrap(),
-    ) as Arc<dyn VectorStore>;
+    let vector_store =
+        Arc::new(LanceVectorStore::new(&data_dir).await.unwrap()) as Arc<dyn VectorStore>;
 
-    let graph_store = Arc::new(
-        SqliteGraphStore::new(&data_dir).unwrap(),
-    ) as Arc<dyn GraphStore>;
+    let graph_store = Arc::new(SqliteGraphStore::new(&data_dir).unwrap()) as Arc<dyn GraphStore>;
 
     let llm = Arc::new(MockLlmProvider::new()) as Arc<dyn karta_core::llm::LlmProvider>;
 
@@ -435,10 +417,16 @@ async fn eval_dreaming() {
             dream.dream_type.as_str(),
             dream.confidence
         );
-        println!("    Content: {}...", &dream.dream_content[..dream.dream_content.len().min(100)]);
+        println!(
+            "    Content: {}...",
+            &dream.dream_content[..dream.dream_content.len().min(100)]
+        );
     }
 
-    assert!(dream_run.dreams_attempted > 0, "Should have attempted dreams");
+    assert!(
+        dream_run.dreams_attempted > 0,
+        "Should have attempted dreams"
+    );
     assert!(dream_run.notes_inspected > 0, "Should have inspected notes");
 
     // After dreaming, note count should have increased (dreams written back)
@@ -458,23 +446,41 @@ async fn eval_incremental_dreaming() {
     let karta = create_karta("incremental-dreaming").await;
 
     // First batch of notes
-    karta.add_note("Alpha Corp uses AWS for all infrastructure.").await.unwrap();
-    karta.add_note("Alpha Corp requires SOC 2 compliance.").await.unwrap();
+    karta
+        .add_note("Alpha Corp uses AWS for all infrastructure.")
+        .await
+        .unwrap();
+    karta
+        .add_note("Alpha Corp requires SOC 2 compliance.")
+        .await
+        .unwrap();
 
     // First dream pass
     let run1 = karta.run_dreaming("workspace", "test").await.unwrap();
-    println!("Dream run 1: {} inspected, {} attempted", run1.notes_inspected, run1.dreams_attempted);
+    println!(
+        "Dream run 1: {} inspected, {} attempted",
+        run1.notes_inspected, run1.dreams_attempted
+    );
 
     // Add more notes
-    karta.add_note("Alpha Corp's CTO prefers serverless architectures.").await.unwrap();
+    karta
+        .add_note("Alpha Corp's CTO prefers serverless architectures.")
+        .await
+        .unwrap();
 
     // Second dream pass — should only process new/updated notes
     let run2 = karta.run_dreaming("workspace", "test").await.unwrap();
-    println!("Dream run 2: {} inspected, {} attempted", run2.notes_inspected, run2.dreams_attempted);
+    println!(
+        "Dream run 2: {} inspected, {} attempted",
+        run2.notes_inspected, run2.dreams_attempted
+    );
 
     // The second run should inspect fewer or equal notes (incremental cursor)
     // We can't strictly assert less because linked neighbors get pulled in,
     // but we verify the cursor mechanism works by checking it ran at all
     // Verify the second dream run completed successfully
-    println!("Second run completed: {} dreams attempted", run2.dreams_attempted);
+    println!(
+        "Second run completed: {} dreams attempted",
+        run2.dreams_attempted
+    );
 }

--- a/crates/karta-core/tests/inspect.rs
+++ b/crates/karta-core/tests/inspect.rs
@@ -3,9 +3,8 @@
 //!
 //! Run: cargo test --test inspect -- --ignored --nocapture
 
-use std::sync::Arc;
-use karta_core::config::KartaConfig;
 use karta_core::Karta;
+use karta_core::config::KartaConfig;
 
 async fn create_karta() -> Karta {
     let data_dir = "/tmp/karta-inspect";
@@ -58,7 +57,10 @@ async fn inspect_ingestion() {
             result.links.len(),
             result.keywords.join(", ")
         );
-        println!("  Context: {}", &result.context[..result.context.len().min(120)]);
+        println!(
+            "  Context: {}",
+            &result.context[..result.context.len().min(120)]
+        );
         println!();
     }
 
@@ -81,17 +83,33 @@ async fn inspect_ingestion() {
             );
         }
     }
-    println!("Total links: {} (avg {:.1}/note)", total_links, total_links as f64 / all_notes.len() as f64);
+    println!(
+        "Total links: {} (avg {:.1}/note)",
+        total_links,
+        total_links as f64 / all_notes.len() as f64
+    );
 
     // Test retrieval for the abstention question
     println!("\n=== RETRIEVAL TESTS ===\n");
 
     let test_queries = vec![
-        ("ABSTENTION TEST", "Can you tell me about my background and previous development projects?"),
+        (
+            "ABSTENTION TEST",
+            "Can you tell me about my background and previous development projects?",
+        ),
         ("TEMPORAL TEST", "When does my first sprint end?"),
-        ("CONTRADICTION TEST", "Have I integrated Flask-Login for session management?"),
-        ("SUMMARIZATION TEST", "Give me a comprehensive summary of my project progress"),
-        ("INSTRUCTION TEST", "Could you show me how to implement a login feature?"),
+        (
+            "CONTRADICTION TEST",
+            "Have I integrated Flask-Login for session management?",
+        ),
+        (
+            "SUMMARIZATION TEST",
+            "Give me a comprehensive summary of my project progress",
+        ),
+        (
+            "INSTRUCTION TEST",
+            "Could you show me how to implement a login feature?",
+        ),
     ];
 
     for (label, query) in &test_queries {

--- a/crates/karta-core/tests/locomo.rs
+++ b/crates/karta-core/tests/locomo.rs
@@ -19,8 +19,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::Instant;
 
-use karta_core::config::KartaConfig;
 use karta_core::Karta;
+use karta_core::config::KartaConfig;
 
 // ---------------------------------------------------------------------------
 // Data model (mirrors output of data/convert_locomo.py)
@@ -342,9 +342,7 @@ async fn eval_conversation(conv: &LocomoConversation) -> ConvResult {
         let score = llm_judge(&karta, &q.question, &answer, &q.answer, adv).await;
 
         total_judged += 1;
-        let entry = category_scores
-            .entry(q.category.clone())
-            .or_insert((0, 0));
+        let entry = category_scores.entry(q.category.clone()).or_insert((0, 0));
         entry.1 += 1;
 
         if score >= 0.5 {
@@ -413,13 +411,15 @@ fn print_category_table(scores: &HashMap<String, (usize, usize)>) {
 #[tokio::test]
 #[ignore]
 async fn locomo_single() {
-    let dataset_path = std::env::var("LOCOMO_DATASET_PATH")
-        .unwrap_or_else(|_| "data/locomo.json".to_string());
+    let dataset_path =
+        std::env::var("LOCOMO_DATASET_PATH").unwrap_or_else(|_| "data/locomo.json".to_string());
 
     if !Path::new(&dataset_path).exists() {
         eprintln!("LOCOMO dataset not found at {}.", dataset_path);
         eprintln!("Download and convert:");
-        eprintln!("  curl -L https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json -o data/locomo10_raw.json");
+        eprintln!(
+            "  curl -L https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json -o data/locomo10_raw.json"
+        );
         eprintln!("  python3 data/convert_locomo.py data/locomo10_raw.json data/locomo.json");
         return;
     }
@@ -433,7 +433,10 @@ async fn locomo_single() {
     println!("LOCOMO SINGLE CONVERSATION RESULT");
     println!("{}", "=".repeat(70));
     println!("  Questions: {}", result.questions_asked);
-    println!("  Passed:    {}/{}", result.total_passed, result.total_judged);
+    println!(
+        "  Passed:    {}/{}",
+        result.total_passed, result.total_judged
+    );
 
     let pass_rate = if result.total_judged > 0 {
         result.total_passed as f64 / result.total_judged as f64
@@ -460,13 +463,15 @@ async fn locomo_single() {
 #[tokio::test]
 #[ignore]
 async fn locomo_full() {
-    let dataset_path = std::env::var("LOCOMO_DATASET_PATH")
-        .unwrap_or_else(|_| "data/locomo.json".to_string());
+    let dataset_path =
+        std::env::var("LOCOMO_DATASET_PATH").unwrap_or_else(|_| "data/locomo.json".to_string());
 
     if !Path::new(&dataset_path).exists() {
         eprintln!("LOCOMO dataset not found at {}.", dataset_path);
         eprintln!("Download and convert:");
-        eprintln!("  curl -L https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json -o data/locomo10_raw.json");
+        eprintln!(
+            "  curl -L https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json -o data/locomo10_raw.json"
+        );
         eprintln!("  python3 data/convert_locomo.py data/locomo10_raw.json data/locomo.json");
         return;
     }

--- a/crates/karta-core/tests/longmem.rs
+++ b/crates/karta-core/tests/longmem.rs
@@ -24,9 +24,9 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::Instant;
 
+use karta_core::Karta;
 use karta_core::config::KartaConfig;
 use karta_core::llm::{ChatMessage, GenConfig, Role};
-use karta_core::Karta;
 
 // ---------------------------------------------------------------------------
 // Data model matching the JSON from convert_longmem.py
@@ -63,6 +63,7 @@ struct LongMemMessage {
     #[serde(default)]
     date: String,
     #[serde(default)]
+    #[allow(dead_code)]
     session_id: String,
 }
 
@@ -81,11 +82,21 @@ where
         fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             f.write_str("string or number")
         }
-        fn visit_str<E: de::Error>(self, v: &str) -> std::result::Result<String, E> { Ok(v.to_string()) }
-        fn visit_string<E: de::Error>(self, v: String) -> std::result::Result<String, E> { Ok(v) }
-        fn visit_u64<E: de::Error>(self, v: u64) -> std::result::Result<String, E> { Ok(v.to_string()) }
-        fn visit_i64<E: de::Error>(self, v: i64) -> std::result::Result<String, E> { Ok(v.to_string()) }
-        fn visit_f64<E: de::Error>(self, v: f64) -> std::result::Result<String, E> { Ok(v.to_string()) }
+        fn visit_str<E: de::Error>(self, v: &str) -> std::result::Result<String, E> {
+            Ok(v.to_string())
+        }
+        fn visit_string<E: de::Error>(self, v: String) -> std::result::Result<String, E> {
+            Ok(v)
+        }
+        fn visit_u64<E: de::Error>(self, v: u64) -> std::result::Result<String, E> {
+            Ok(v.to_string())
+        }
+        fn visit_i64<E: de::Error>(self, v: i64) -> std::result::Result<String, E> {
+            Ok(v.to_string())
+        }
+        fn visit_f64<E: de::Error>(self, v: f64) -> std::result::Result<String, E> {
+            Ok(v.to_string())
+        }
     }
     deserializer.deserialize_any(StringOrNumber)
 }
@@ -262,15 +273,16 @@ impl CategoryResults {
 
     fn merge(&mut self, other: &CategoryResults) {
         for (cat, scores) in &other.scores {
-            self.scores
-                .entry(cat.clone())
-                .or_default()
-                .extend(scores);
+            self.scores.entry(cat.clone()).or_default().extend(scores);
         }
     }
 
     fn total_correct(&self) -> usize {
-        self.scores.values().flat_map(|v| v.iter()).filter(|&&b| b).count()
+        self.scores
+            .values()
+            .flat_map(|v| v.iter())
+            .filter(|&&b| b)
+            .count()
     }
 
     fn total_count(&self) -> usize {
@@ -300,7 +312,11 @@ impl CategoryResults {
             let scores = &self.scores[cat];
             let c = scores.iter().filter(|&&b| b).count();
             let t = scores.len();
-            let rate = if t > 0 { c as f64 / t as f64 * 100.0 } else { 0.0 };
+            let rate = if t > 0 {
+                c as f64 / t as f64 * 100.0
+            } else {
+                0.0
+            };
             println!("    {:40} {}/{} ({:.0}%)", cat, c, t, rate);
         }
     }
@@ -311,10 +327,7 @@ impl CategoryResults {
 /// 1. Ingest all user messages from all sessions as notes (with date prefix for temporal context)
 /// 2. Ask the evaluation question via karta.ask()
 /// 3. Use LLM-as-judge to score the answer
-async fn eval_entry(
-    entry: &LongMemEntry,
-    results: &mut CategoryResults,
-) {
+async fn eval_entry(entry: &LongMemEntry, results: &mut CategoryResults) {
     println!(
         "\n  --- [{}] {} ---",
         entry.question_type, entry.question_id
@@ -374,14 +387,8 @@ async fn eval_entry(
     };
     let query_ms = query_start.elapsed().as_millis();
 
-    println!(
-        "    Q: {}",
-        safe_truncate(&entry.question, 100)
-    );
-    println!(
-        "    Expected: {}",
-        safe_truncate(&entry.answer, 100)
-    );
+    println!("    Q: {}", safe_truncate(&entry.question, 100));
+    println!("    Expected: {}", safe_truncate(&entry.answer, 100));
     println!(
         "    Got ({:.1}s): {}",
         query_ms as f64 / 1000.0,
@@ -424,9 +431,7 @@ async fn longmem_single() {
 
     if !Path::new(&dataset_path).exists() {
         eprintln!("LongMemEval dataset not found at {}.", dataset_path);
-        eprintln!(
-            "Run: python3 data/convert_longmem.py oracle data/longmemeval-oracle.json"
-        );
+        eprintln!("Run: python3 data/convert_longmem.py oracle data/longmemeval-oracle.json");
         return;
     }
 
@@ -459,17 +464,15 @@ async fn longmem_ten() {
 
     let dataset = load_dataset(&dataset_path);
     let count = dataset.questions.len().min(10);
-    println!("LongMemEval [{}]: running first {} of {} questions", dataset.split, count, dataset.total_questions);
+    println!(
+        "LongMemEval [{}]: running first {} of {} questions",
+        dataset.split, count, dataset.total_questions
+    );
 
     let mut results = CategoryResults::new();
 
     for (i, entry) in dataset.questions.iter().take(count).enumerate() {
-        println!(
-            "\n{} [{}/{}]",
-            "=".repeat(70),
-            i + 1,
-            count,
-        );
+        println!("\n{} [{}/{}]", "=".repeat(70), i + 1, count,);
         eval_entry(entry, &mut results).await;
     }
 
@@ -489,17 +492,14 @@ async fn longmem_full() {
 
     if !Path::new(&dataset_path).exists() {
         eprintln!("LongMemEval dataset not found at {}.", dataset_path);
-        eprintln!(
-            "Run: python3 data/convert_longmem.py oracle data/longmemeval-oracle.json"
-        );
+        eprintln!("Run: python3 data/convert_longmem.py oracle data/longmemeval-oracle.json");
         return;
     }
 
     let dataset = load_dataset(&dataset_path);
     println!(
         "LongMemEval Full [{}]: {} questions",
-        dataset.split,
-        dataset.total_questions,
+        dataset.split, dataset.total_questions,
     );
 
     let full_start = Instant::now();
@@ -522,7 +522,11 @@ async fn longmem_full() {
         if (i + 1) % 10 == 0 {
             let c = results.total_correct();
             let t = results.total_count();
-            let rate = if t > 0 { c as f64 / t as f64 * 100.0 } else { 0.0 };
+            let rate = if t > 0 {
+                c as f64 / t as f64 * 100.0
+            } else {
+                0.0
+            };
             println!(
                 "\n  Running total: {}/{} ({:.1}%) after {} entries",
                 c,

--- a/crates/karta-core/tests/real_eval.rs
+++ b/crates/karta-core/tests/real_eval.rs
@@ -4,28 +4,29 @@
 //!
 //! This test is #[ignore]d by default so `cargo test` won't hit your API.
 
-use karta_core::config::KartaConfig;
 use karta_core::Karta;
+use karta_core::config::KartaConfig;
 
 async fn create_real_karta(name: &str) -> Karta {
-    let data_dir = format!(
-        "/tmp/karta-real-{}",
-        name.replace(' ', "-").to_lowercase()
-    );
+    let data_dir = format!("/tmp/karta-real-{}", name.replace(' ', "-").to_lowercase());
     let _ = std::fs::remove_dir_all(&data_dir);
 
     let mut config = KartaConfig::default();
     config.storage.data_dir = data_dir;
 
-    Karta::with_defaults(config).await.expect("Failed to create Karta — check .env credentials")
+    Karta::with_defaults(config)
+        .await
+        .expect("Failed to create Karta — check .env credentials")
 }
 
 fn check_contains(answer: &str, pattern: &str) -> bool {
-    let norm = answer.to_lowercase()
-        .replace('\u{2010}', "-").replace('\u{2011}', "-")
-        .replace('\u{2013}', "-").replace('\u{2014}', "-")
-        .replace('\u{2018}', "'").replace('\u{2019}', "'");
-    pattern.split('|').any(|alt| norm.contains(&alt.to_lowercase()))
+    let norm = answer
+        .to_lowercase()
+        .replace(['\u{2010}', '\u{2011}', '\u{2013}', '\u{2014}'], "-")
+        .replace(['\u{2018}', '\u{2019}'], "'");
+    pattern
+        .split('|')
+        .any(|alt| norm.contains(&alt.to_lowercase()))
 }
 
 #[tokio::test]
@@ -33,7 +34,7 @@ fn check_contains(answer: &str, pattern: &str) -> bool {
 async fn real_eval_user_preference_linking() {
     let karta = create_real_karta("user-pref").await;
 
-    let notes = vec![
+    let notes = [
         "Sarah Chen, head of Marketing Ops at Brightline, prefers all workflow notifications to go via Slack rather than email — she says her team ignores email alerts.",
         "Brightline's IT policy requires all third-party integrations to go through an approved vendor list. Slack is on the list; most other tools are not.",
         "Sarah asked Fay to build a lead routing workflow. She wants it to assign leads based on territory, not round-robin.",
@@ -42,19 +43,38 @@ async fn real_eval_user_preference_linking() {
 
     for (i, note) in notes.iter().enumerate() {
         let result = karta.add_note(note).await.unwrap();
-        println!("Note {}: {} links, id={}", i + 1, result.links.len(), &result.id[..8]);
+        println!(
+            "Note {}: {} links, id={}",
+            i + 1,
+            result.links.len(),
+            &result.id[..8]
+        );
     }
 
     println!("\n--- Query 1 ---");
-    let answer = karta.ask("What should I know before building a notification system for Sarah?", 5).await.unwrap().answer;
+    let answer = karta
+        .ask(
+            "What should I know before building a notification system for Sarah?",
+            5,
+        )
+        .await
+        .unwrap()
+        .answer;
     println!("A: {}\n", answer);
     assert!(check_contains(&answer, "Slack"), "Should mention Slack");
     assert!(check_contains(&answer, "Sarah"), "Should mention Sarah");
 
     println!("--- Query 2 ---");
-    let answer = karta.ask("What constraints exist for Brightline integrations?", 5).await.unwrap().answer;
+    let answer = karta
+        .ask("What constraints exist for Brightline integrations?", 5)
+        .await
+        .unwrap()
+        .answer;
     println!("A: {}\n", answer);
-    assert!(check_contains(&answer, "vendor|approved"), "Should mention vendor list");
+    assert!(
+        check_contains(&answer, "vendor|approved"),
+        "Should mention vendor list"
+    );
 
     println!("--- Stats ---");
     println!("Notes: {}", karta.note_count().await.unwrap());
@@ -65,7 +85,7 @@ async fn real_eval_user_preference_linking() {
 async fn real_eval_retroactive_evolution() {
     let karta = create_real_karta("retro-evo").await;
 
-    let notes = vec![
+    let notes = [
         "The CISO at TechCorp requires all automations to produce audit logs stored in their internal S3 bucket, not in Fay's cloud.",
         "TechCorp is running a SOC 2 Type II audit in Q3 2025 and needs all vendor tooling to be compliant.",
         "The ops team at TechCorp wants to automate their contractor onboarding — 50+ contractors per month.",
@@ -77,10 +97,23 @@ async fn real_eval_retroactive_evolution() {
     }
 
     println!("\n--- Query ---");
-    let answer = karta.ask("What compliance requirements affect the TechCorp contractor onboarding automation?", 5).await.unwrap().answer;
+    let answer = karta
+        .ask(
+            "What compliance requirements affect the TechCorp contractor onboarding automation?",
+            5,
+        )
+        .await
+        .unwrap()
+        .answer;
     println!("A: {}\n", answer);
-    assert!(check_contains(&answer, "audit|S3"), "Should mention audit/S3");
-    assert!(check_contains(&answer, "SOC|compliance"), "Should mention SOC 2/compliance");
+    assert!(
+        check_contains(&answer, "audit|S3"),
+        "Should mention audit/S3"
+    );
+    assert!(
+        check_contains(&answer, "SOC|compliance"),
+        "Should mention SOC 2/compliance"
+    );
 }
 
 #[tokio::test]
@@ -88,7 +121,7 @@ async fn real_eval_retroactive_evolution() {
 async fn real_eval_cross_entity() {
     let karta = create_real_karta("cross-entity").await;
 
-    let notes = vec![
+    let notes = [
         "HubSpot-to-Salesforce sync workflows consistently fail on contact deduplication when both systems have the same email with different capitalisation.",
         "Acme Corp is building a CRM sync between HubSpot and Salesforce. Their ops lead, Marcus, wants bidirectional sync.",
         "A bidirectional CRM sync requires a conflict resolution strategy — last-write-wins is the default but causes data loss in practice.",
@@ -102,10 +135,23 @@ async fn real_eval_cross_entity() {
     }
 
     println!("\n--- Query ---");
-    let answer = karta.ask("What technical issues should I warn Marcus about before building the Acme CRM sync?", 5).await.unwrap().answer;
+    let answer = karta
+        .ask(
+            "What technical issues should I warn Marcus about before building the Acme CRM sync?",
+            5,
+        )
+        .await
+        .unwrap()
+        .answer;
     println!("A: {}\n", answer);
-    assert!(check_contains(&answer, "dedup|deduplication"), "Should mention deduplication");
-    assert!(check_contains(&answer, "conflict"), "Should mention conflict resolution");
+    assert!(
+        check_contains(&answer, "dedup|deduplication"),
+        "Should mention deduplication"
+    );
+    assert!(
+        check_contains(&answer, "conflict"),
+        "Should mention conflict resolution"
+    );
 }
 
 #[tokio::test]
@@ -113,7 +159,7 @@ async fn real_eval_cross_entity() {
 async fn real_eval_contradiction() {
     let karta = create_real_karta("contradiction").await;
 
-    let notes = vec![
+    let notes = [
         "Vanguard Logistics confirmed in writing on Feb 10 that their data must stay in the EU region (Frankfurt). They cited GDPR as the reason.",
         "Vanguard Logistics' new CTO, hired Mar 1, emailed saying they want all Fay workloads to run in US-East for latency reasons — their main operations center moved to Virginia.",
         "Vanguard Logistics processes 200K shipment records daily. Their current pipeline runs on AWS eu-central-1.",
@@ -127,10 +173,20 @@ async fn real_eval_contradiction() {
     }
 
     println!("\n--- Query ---");
-    let answer = karta.ask("Where should Vanguard Logistics data be processed?", 5).await.unwrap().answer;
+    let answer = karta
+        .ask("Where should Vanguard Logistics data be processed?", 5)
+        .await
+        .unwrap()
+        .answer;
     println!("A: {}\n", answer);
-    assert!(check_contains(&answer, "EU|Frankfurt|eu-central"), "Should mention EU");
-    assert!(check_contains(&answer, "US-East|Virginia|us-east"), "Should mention US-East");
+    assert!(
+        check_contains(&answer, "EU|Frankfurt|eu-central"),
+        "Should mention EU"
+    );
+    assert!(
+        check_contains(&answer, "US-East|Virginia|us-east"),
+        "Should mention US-East"
+    );
 
     println!("--- Dreaming ---");
     let dream_run = karta.run_dreaming("workspace", "vanguard").await.unwrap();
@@ -138,7 +194,8 @@ async fn real_eval_contradiction() {
     println!("Dreams written:   {}", dream_run.dreams_written);
     for dream in &dream_run.dreams {
         let icon = if dream.would_write { "W" } else { "." };
-        println!("  [{}] {} conf={:.2}: {}",
+        println!(
+            "  [{}] {} conf={:.2}: {}",
             icon,
             dream.dream_type.as_str(),
             dream.confidence,
@@ -152,7 +209,7 @@ async fn real_eval_contradiction() {
 async fn real_eval_long_chain() {
     let karta = create_real_karta("long-chain").await;
 
-    let notes = vec![
+    let notes = [
         "ClearView Insurance wants to automate claims adjudication. Target: process a claim decision within 2 minutes of submission.",
         "ClearView's claims data lives in a legacy IBM AS/400 system. The only extraction method is a nightly batch SFTP export — no real-time API.",
         "The claims adjudication model (ML) requires the claimant's full policy history, which is only in the AS/400 system.",
@@ -167,8 +224,21 @@ async fn real_eval_long_chain() {
     }
 
     println!("\n--- Query ---");
-    let answer = karta.ask("Can ClearView meet their 2-minute claims processing target? What's blocking it?", 5).await.unwrap().answer;
+    let answer = karta
+        .ask(
+            "Can ClearView meet their 2-minute claims processing target? What's blocking it?",
+            5,
+        )
+        .await
+        .unwrap()
+        .answer;
     println!("A: {}\n", answer);
-    assert!(check_contains(&answer, "AS/400|AS400|legacy"), "Should mention AS/400");
-    assert!(check_contains(&answer, "nightly|batch|SFTP"), "Should mention batch/SFTP constraint");
+    assert!(
+        check_contains(&answer, "AS/400|AS400|legacy"),
+        "Should mention AS/400"
+    );
+    assert!(
+        check_contains(&answer, "nightly|batch|SFTP"),
+        "Should mention batch/SFTP constraint"
+    );
 }

--- a/crates/karta-core/tests/synthetic_memory_eval.rs
+++ b/crates/karta-core/tests/synthetic_memory_eval.rs
@@ -1,0 +1,125 @@
+//! Synthetic memory evaluation tests that require no external API keys.
+//!
+//! These tests verify core data structures, decay logic, and schema
+//! pipelines using deterministic mock data.
+//!
+//! Run with: cargo test -p karta-core --test synthetic_memory_eval
+
+use karta_core::migrate::{CURRENT_SCHEMA_VERSION, SchemaMeta};
+use karta_core::note::{MemoryNote, Provenance};
+
+// ─── Synthetic Dataset: Preference Update ──────────────────────────────────
+
+#[tokio::test]
+async fn test_preference_update_flow() {
+    let note1 = MemoryNote::new("I prefer dark mode for all UIs".into());
+    let note2 = MemoryNote::new("Actually, I switched back to light mode".into());
+
+    assert!(note1.content.contains("dark mode"));
+    assert!(note2.content.contains("light mode"));
+    assert_ne!(note1.id, note2.id);
+}
+
+// ─── Synthetic Dataset: Temporal Sequence ─────────────────────────────────
+
+#[tokio::test]
+async fn test_temporal_sequence_ordering() {
+    let mut notes = Vec::new();
+    for i in 0..5 {
+        let mut note = MemoryNote::new(format!("Step {} of the process", i));
+        note.turn_index = Some(i);
+        notes.push(note);
+    }
+
+    notes.sort_by_key(|n| n.turn_index.unwrap_or(0));
+
+    for (i, note) in notes.iter().enumerate() {
+        assert_eq!(note.turn_index, Some(i as u32));
+    }
+}
+
+// ─── Synthetic Dataset: Forgetting Decay ──────────────────────────────────
+
+#[tokio::test]
+#[ignore = "spec stub until production ForgetConfig decay scoring API is exposed"]
+async fn test_forgetting_decay_scoring() {
+    use chrono::{Duration, Utc};
+
+    let decay_half_life_days = 30.0;
+    let archive_threshold = 0.15;
+
+    let mut old_note = MemoryNote::new("Old memory".into());
+    old_note.last_accessed_at = Utc::now() - Duration::days(90);
+
+    let mut recent_note = MemoryNote::new("Recent memory".into());
+    recent_note.last_accessed_at = Utc::now() - Duration::days(1);
+
+    // TODO: replace this specification stub with the production ForgetConfig scoring API.
+    // Compute decay scores manually: score = 0.5^(elapsed / half_life)
+    let old_score = 0.5_f64.powf(90.0 / decay_half_life_days); // 0.5^3 = 0.125
+    let recent_score = 0.5_f64.powf(1.0 / decay_half_life_days); // ~0.977
+
+    assert!(
+        old_score < 0.13,
+        "Old note should have low decay score: {}",
+        old_score
+    );
+    assert!(
+        recent_score > 0.95,
+        "Recent note should have high decay score: {}",
+        recent_score
+    );
+    assert!(
+        old_score < archive_threshold,
+        "Old note should be below archive threshold"
+    );
+    assert!(
+        recent_score > archive_threshold,
+        "Recent note should be above archive threshold"
+    );
+}
+
+#[tokio::test]
+async fn test_forgetting_protected_notes() {
+    let mut profile_note = MemoryNote::new("Profile: John is a developer".into());
+    assert!(!profile_note.is_profile());
+
+    profile_note.provenance = Provenance::Profile {
+        entity_id: "john".into(),
+    };
+
+    assert!(profile_note.is_profile());
+}
+
+// ─── Synthetic Dataset: Schema Meta ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_schema_meta_structure() {
+    let current_schema_version = CURRENT_SCHEMA_VERSION;
+    assert!(current_schema_version >= 1);
+
+    let meta = SchemaMeta::new(1, vec!["001_initial".into()], vec![], vec![]);
+
+    assert_eq!(meta.schema_version, 1);
+    assert_eq!(meta.applied_migrations.len(), 1);
+    assert!(meta.pending_migrations.is_empty());
+    assert!(meta.warnings.is_empty());
+}
+
+// ─── Synthetic Dataset: Entity Profile ────────────────────────────────────
+
+// ─── Synthetic Dataset: Contradiction Resolution ──────────────────────────
+
+#[tokio::test]
+async fn test_note_lifecycle_states() {
+    use karta_core::note::NoteStatus;
+
+    let mut note = MemoryNote::new("Active note".into());
+    assert_eq!(note.status, NoteStatus::Active);
+
+    note.status = NoteStatus::Deprecated { by: "test".into() };
+    assert!(!note.is_active());
+
+    note.status = NoteStatus::Archived;
+    assert!(!note.is_active());
+}

--- a/crates/karta-server/src/config.rs
+++ b/crates/karta-server/src/config.rs
@@ -27,7 +27,10 @@ impl std::fmt::Debug for ServerConfig {
             .field("github_client_id", &self.github_client_id)
             .field("github_client_secret", &"[REDACTED]")
             .field("db_path", &self.db_path)
-            .field("registration_token", &self.registration_token.as_ref().map(|_| "[REDACTED]"))
+            .field(
+                "registration_token",
+                &self.registration_token.as_ref().map(|_| "[REDACTED]"),
+            )
             .field("allowed_origins", &self.allowed_origins)
             .finish()
     }
@@ -46,14 +49,17 @@ impl ServerConfig {
             &base64::engine::general_purpose::URL_SAFE_NO_PAD,
             &cookie_secret_b64,
         )
-        .or_else(|_| base64::Engine::decode(
-            &base64::engine::general_purpose::STANDARD,
-            &cookie_secret_b64,
-        ))
+        .or_else(|_| {
+            base64::Engine::decode(
+                &base64::engine::general_purpose::STANDARD,
+                &cookie_secret_b64,
+            )
+        })
         .map_err(|e| ServerError::Config(format!("Invalid KARTA_COOKIE_SECRET base64: {e}")))?;
         if cookie_secret.len() < 64 {
             return Err(ServerError::Config(
-                "KARTA_COOKIE_SECRET must decode to at least 64 bytes (88 base64 chars)".to_string(),
+                "KARTA_COOKIE_SECRET must decode to at least 64 bytes (88 base64 chars)"
+                    .to_string(),
             ));
         }
 
@@ -62,13 +68,18 @@ impl ServerConfig {
         let github_client_id = required_env("GITHUB_CLIENT_ID")?;
         let github_client_secret = required_env("GITHUB_CLIENT_SECRET")?;
 
-        let db_path = std::env::var("KARTA_AUTH_DB_PATH")
-            .unwrap_or_else(|_| "karta-auth.db".to_string());
+        let db_path =
+            std::env::var("KARTA_AUTH_DB_PATH").unwrap_or_else(|_| "karta-auth.db".to_string());
 
         let registration_token = std::env::var("KARTA_REGISTRATION_TOKEN").ok();
 
         let allowed_origins = std::env::var("KARTA_ALLOWED_ORIGINS")
-            .map(|v| v.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect())
+            .map(|v| {
+                v.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
             .unwrap_or_else(|_| vec![base_url.clone()]);
 
         Ok(Self {

--- a/crates/karta-server/src/db.rs
+++ b/crates/karta-server/src/db.rs
@@ -335,7 +335,10 @@ impl AuthDb {
     }
 
     /// Validate an access token by its hash. Returns (user_id, scope) if valid.
-    pub fn validate_access_token(&self, token_hash: &str) -> Result<Option<(String, Option<String>)>> {
+    pub fn validate_access_token(
+        &self,
+        token_hash: &str,
+    ) -> Result<Option<(String, Option<String>)>> {
         let conn = self.lock()?;
         let mut stmt = conn.prepare(
             "SELECT user_id, scope, expires_at FROM access_tokens WHERE token_hash = ?1",
@@ -343,15 +346,18 @@ impl AuthDb {
         let result = stmt
             .query(params![token_hash])?
             .next()?
-            .map(|row| -> rusqlite::Result<(String, Option<String>, String)> {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-            })
+            .map(
+                |row| -> rusqlite::Result<(String, Option<String>, String)> {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                },
+            )
             .transpose()?;
 
         match result {
             Some((user_id, scope, expires_at)) => {
-                let expires = chrono::NaiveDateTime::parse_from_str(&expires_at, "%Y-%m-%dT%H:%M:%SZ")
-                    .map_err(|e| ServerError::Internal(format!("Bad expiry timestamp: {e}")))?;
+                let expires =
+                    chrono::NaiveDateTime::parse_from_str(&expires_at, "%Y-%m-%dT%H:%M:%SZ")
+                        .map_err(|e| ServerError::Internal(format!("Bad expiry timestamp: {e}")))?;
                 let expires_utc = expires.and_utc();
                 if expires_utc < chrono::Utc::now() {
                     Ok(None)
@@ -399,9 +405,9 @@ impl AuthDb {
 
         if conn.changes() == 0 {
             // Check if token exists but was already revoked (breach detection)
-            let already_revoked: bool = conn.prepare(
-                "SELECT 1 FROM refresh_tokens WHERE token_hash = ?1 AND revoked = 1",
-            )?.exists(params![token_hash])?;
+            let already_revoked: bool = conn
+                .prepare("SELECT 1 FROM refresh_tokens WHERE token_hash = ?1 AND revoked = 1")?
+                .exists(params![token_hash])?;
 
             if already_revoked {
                 // Revoke all tokens for this client+user (token theft detected)
@@ -435,9 +441,11 @@ impl AuthDb {
         let result = stmt
             .query(params![token_hash])?
             .next()?
-            .map(|row| -> rusqlite::Result<(String, String, Option<String>)> {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-            })
+            .map(
+                |row| -> rusqlite::Result<(String, String, Option<String>)> {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                },
+            )
             .transpose()?;
 
         Ok(result)
@@ -468,6 +476,36 @@ impl AuthDb {
             ],
         )?;
         Ok(())
+    }
+
+    /// Read a pending auth request without consuming it.
+    pub fn get_pending_auth(&self, idp_csrf: &str) -> Result<Option<PendingAuth>> {
+        let conn = self.lock()?;
+        let mut stmt = conn.prepare(
+            "SELECT state_token, client_id, redirect_uri, code_challenge, code_challenge_method,
+                    scope, original_state, idp_csrf, idp_nonce, idp_pkce_verifier, provider, expires_at
+             FROM pending_auth_requests WHERE idp_csrf = ?1",
+        )?;
+        stmt.query(params![idp_csrf])?
+            .next()?
+            .map(|row| -> rusqlite::Result<PendingAuth> {
+                Ok(PendingAuth {
+                    state_token: row.get(0)?,
+                    client_id: row.get(1)?,
+                    redirect_uri: row.get(2)?,
+                    code_challenge: row.get(3)?,
+                    code_challenge_method: row.get(4)?,
+                    scope: row.get(5)?,
+                    original_state: row.get(6)?,
+                    idp_csrf: row.get(7)?,
+                    idp_nonce: row.get(8)?,
+                    idp_pkce_verifier: row.get(9)?,
+                    provider: row.get(10)?,
+                    expires_at: row.get(11)?,
+                })
+            })
+            .transpose()
+            .map_err(Into::into)
     }
 
     /// Consume a pending auth request by the IdP CSRF token.

--- a/crates/karta-server/src/main.rs
+++ b/crates/karta-server/src/main.rs
@@ -10,14 +10,13 @@ mod state;
 use std::sync::Arc;
 
 use axum::Router;
-use axum::http::{Method, HeaderValue, header};
+use axum::http::{HeaderValue, Method, header};
 use axum::routing::{get, post};
-use tower_http::cors::{CorsLayer, AllowOrigin, Any as CorsAny};
-use tower_http::trace::TraceLayer;
 use rmcp::transport::streamable_http_server::{
-    StreamableHttpService, StreamableHttpServerConfig,
-    session::local::LocalSessionManager,
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };
+use tower_http::cors::{AllowOrigin, Any as CorsAny, CorsLayer};
+use tower_http::trace::TraceLayer;
 
 use config::ServerConfig;
 use db::AuthDb;
@@ -138,12 +137,11 @@ async fn main() -> anyhow::Result<()> {
             .and_then(|u| u.host_str().map(String::from))
             .unwrap_or_else(|| "localhost".to_string());
 
-        let mcp_config = StreamableHttpServerConfig::default()
-            .with_allowed_hosts([
-                "localhost".to_string(),
-                "127.0.0.1".to_string(),
-                allowed_host,
-            ]);
+        let mcp_config = StreamableHttpServerConfig::default().with_allowed_hosts([
+            "localhost".to_string(),
+            "127.0.0.1".to_string(),
+            allowed_host,
+        ]);
 
         let base_url = config.base_url.clone();
         let mcp_service: StreamableHttpService<mcp::KartaService, LocalSessionManager> =

--- a/crates/karta-server/src/mcp.rs
+++ b/crates/karta-server/src/mcp.rs
@@ -1,11 +1,8 @@
 use std::sync::Arc;
 
 use rmcp::{
-    ErrorData as McpError, ServerHandler,
-    handler::server::router::tool::ToolRouter,
-    handler::server::wrapper::Parameters,
-    model::*,
-    schemars, tool, tool_handler, tool_router,
+    ErrorData as McpError, ServerHandler, handler::server::router::tool::ToolRouter,
+    handler::server::wrapper::Parameters, model::*, schemars, tool, tool_handler, tool_router,
 };
 use serde::Deserialize;
 
@@ -95,7 +92,9 @@ impl KartaService {
     }
 
     /// Store a new memory note in the knowledge graph.
-    #[tool(description = "Store a new memory note in the knowledge graph. The note will be automatically enriched with LLM-extracted attributes, linked to related notes, and indexed for retrieval.")]
+    #[tool(
+        description = "Store a new memory note in the knowledge graph. The note will be automatically enriched with LLM-extracted attributes, linked to related notes, and indexed for retrieval."
+    )]
     async fn add_note(
         &self,
         Parameters(params): Parameters<AddNoteParams>,
@@ -133,12 +132,14 @@ impl KartaService {
     }
 
     /// Search stored memories by semantic similarity.
-    #[tool(description = "Search stored memories by semantic similarity. Returns the most relevant notes ranked by a combination of vector similarity, recency, and graph connectivity.")]
+    #[tool(
+        description = "Search stored memories by semantic similarity. Returns the most relevant notes ranked by a combination of vector similarity, recency, and graph connectivity."
+    )]
     async fn search(
         &self,
         Parameters(params): Parameters<SearchParams>,
     ) -> Result<CallToolResult, McpError> {
-        let top_k = params.top_k.min(100).max(1);
+        let top_k = params.top_k.clamp(1, 100);
         match self.karta.search(&params.query, top_k).await {
             Ok(results) => {
                 let response: Vec<serde_json::Value> = results
@@ -169,12 +170,14 @@ impl KartaService {
     }
 
     /// Ask a question and get a synthesized answer from stored memories.
-    #[tool(description = "Ask a question against stored memories and get a synthesized answer. Uses retrieval-augmented generation: searches for relevant notes, then synthesizes a coherent answer using an LLM.")]
+    #[tool(
+        description = "Ask a question against stored memories and get a synthesized answer. Uses retrieval-augmented generation: searches for relevant notes, then synthesizes a coherent answer using an LLM."
+    )]
     async fn ask(
         &self,
         Parameters(params): Parameters<AskParams>,
     ) -> Result<CallToolResult, McpError> {
-        let top_k = params.top_k.min(100).max(1);
+        let top_k = params.top_k.clamp(1, 100);
         match self.karta.ask(&params.query, top_k).await {
             Ok(result) => {
                 let response = serde_json::json!({
@@ -198,7 +201,9 @@ impl KartaService {
     }
 
     /// Retrieve a specific note by its ID.
-    #[tool(description = "Retrieve a specific memory note by its ID. Returns the full note content and metadata.")]
+    #[tool(
+        description = "Retrieve a specific memory note by its ID. Returns the full note content and metadata."
+    )]
     async fn get_note(
         &self,
         Parameters(params): Parameters<GetNoteParams>,
@@ -249,14 +254,22 @@ impl KartaService {
     }
 
     /// Run background reasoning over the knowledge graph.
-    #[tool(description = "Run background reasoning over the knowledge graph. Produces new inferred notes via deduction, induction, abduction, consolidation, contradiction detection, and episode digests.")]
+    #[tool(
+        description = "Run background reasoning over the knowledge graph. Produces new inferred notes via deduction, induction, abduction, consolidation, contradiction detection, and episode digests."
+    )]
     async fn dream(
         &self,
         Parameters(params): Parameters<DreamParams>,
     ) -> Result<CallToolResult, McpError> {
-        match self.karta.run_dreaming(&params.scope_type, &params.scope_id).await {
+        match self
+            .karta
+            .run_dreaming(&params.scope_type, &params.scope_id)
+            .await
+        {
             Ok(run) => {
-                let types: Vec<String> = run.dreams.iter()
+                let types: Vec<String> = run
+                    .dreams
+                    .iter()
                     .filter(|d| d.would_write)
                     .map(|d| d.dream_type.as_str().to_string())
                     .collect();

--- a/crates/karta-server/src/middleware.rs
+++ b/crates/karta-server/src/middleware.rs
@@ -25,9 +25,11 @@ impl FromRequestParts<AppState> for AuthenticatedUser {
             .get("authorization")
             .ok_or_else(|| ServerError::Unauthorized("Missing Authorization header".to_string()))?;
 
-        let auth_header = auth_header_value
-            .to_str()
-            .map_err(|_| ServerError::Unauthorized("Authorization header contains invalid characters".to_string()))?;
+        let auth_header = auth_header_value.to_str().map_err(|_| {
+            ServerError::Unauthorized(
+                "Authorization header contains invalid characters".to_string(),
+            )
+        })?;
 
         let token = auth_header
             .strip_prefix("Bearer ")

--- a/crates/karta-server/src/oauth/authorize.rs
+++ b/crates/karta-server/src/oauth/authorize.rs
@@ -52,10 +52,7 @@ pub async fn authorize(
         .code_challenge
         .as_deref()
         .ok_or_else(|| ServerError::BadRequest("code_challenge is required (PKCE)".to_string()))?;
-    let code_challenge_method = params
-        .code_challenge_method
-        .as_deref()
-        .unwrap_or("S256");
+    let code_challenge_method = params.code_challenge_method.as_deref().unwrap_or("S256");
     let client_state = params
         .state
         .as_deref()
@@ -83,14 +80,13 @@ pub async fn authorize(
     }
 
     // Validate client exists and redirect_uri matches
-    let client = state
-        .db
-        .get_client(client_id)?
-        .ok_or_else(|| ServerError::oauth(
+    let client = state.db.get_client(client_id)?.ok_or_else(|| {
+        ServerError::oauth(
             "invalid_client",
             "Unknown client_id",
             StatusCode::BAD_REQUEST,
-        ))?;
+        )
+    })?;
 
     if !client.redirect_uris.iter().any(|u| u == redirect_uri) {
         return Err(ServerError::oauth(
@@ -206,10 +202,7 @@ fn render_login_page(base_url: &str, params: &AuthorizeParams) -> Html<String> {
         qs.push(format!("code_challenge={}", urlencoding::encode(v)));
     }
     if let Some(v) = &params.code_challenge_method {
-        qs.push(format!(
-            "code_challenge_method={}",
-            urlencoding::encode(v)
-        ));
+        qs.push(format!("code_challenge_method={}", urlencoding::encode(v)));
     }
     if let Some(v) = &params.state {
         qs.push(format!("state={}", urlencoding::encode(v)));
@@ -219,12 +212,8 @@ fn render_login_page(base_url: &str, params: &AuthorizeParams) -> Html<String> {
     }
 
     let query_string = qs.join("&");
-    let google_url = format!(
-        "{base_url}/oauth/authorize?{query_string}&provider=google"
-    );
-    let github_url = format!(
-        "{base_url}/oauth/authorize?{query_string}&provider=github"
-    );
+    let google_url = format!("{base_url}/oauth/authorize?{query_string}&provider=google");
+    let github_url = format!("{base_url}/oauth/authorize?{query_string}&provider=github");
 
     Html(format!(
         r#"<!DOCTYPE html>

--- a/crates/karta-server/src/oauth/callback.rs
+++ b/crates/karta-server/src/oauth/callback.rs
@@ -1,9 +1,10 @@
 use axum::extract::{Query, State};
 use axum::response::{IntoResponse, Redirect, Response};
+use oauth2::TokenResponse as _; // for access_token() on GitHub response
 use oauth2::{AuthorizationCode, PkceCodeVerifier};
-use oauth2::TokenResponse as _;  // for access_token() on GitHub response
 use openidconnect::TokenResponse as _; // for id_token() on Google response
 use serde::Deserialize;
+use url::Url;
 
 use crate::db::AuthCode;
 use crate::error::{Result, ServerError};
@@ -23,8 +24,13 @@ pub async fn google_callback(
     Query(params): Query<CallbackParams>,
 ) -> Result<Response> {
     if let Some(err) = &params.error {
-        let desc = params.error_description.as_deref().unwrap_or("Unknown error");
-        return Err(ServerError::IdpError(format!("Google OAuth error: {err}: {desc}")));
+        let desc = params
+            .error_description
+            .as_deref()
+            .unwrap_or("Unknown error");
+        return Err(ServerError::IdpError(format!(
+            "Google OAuth error: {err}: {desc}"
+        )));
     }
 
     let idp_code = params
@@ -36,21 +42,30 @@ pub async fn google_callback(
         .as_deref()
         .ok_or_else(|| ServerError::BadRequest("Missing state parameter".to_string()))?;
 
-    // Look up pending auth request by IdP CSRF token
+    // Validate provider before consuming the pending auth request.
+    let pending = state
+        .db
+        .get_pending_auth(idp_state)?
+        .ok_or_else(|| ServerError::BadRequest("Unknown or expired state".to_string()))?;
+
+    if pending.provider != "google" {
+        return Err(ServerError::BadRequest(
+            "State does not match Google provider".to_string(),
+        ));
+    }
+
     let pending = state
         .db
         .consume_pending_auth(idp_state)?
         .ok_or_else(|| ServerError::BadRequest("Unknown or expired state".to_string()))?;
 
-    if pending.provider != "google" {
-        return Err(ServerError::BadRequest("State does not match Google provider".to_string()));
-    }
-
     // Check expiry
     let expires = chrono::NaiveDateTime::parse_from_str(&pending.expires_at, "%Y-%m-%dT%H:%M:%SZ")
         .map_err(|e| ServerError::Internal(format!("Bad expiry: {e}")))?;
     if expires.and_utc() < chrono::Utc::now() {
-        return Err(ServerError::BadRequest("Authorization request expired".to_string()));
+        return Err(ServerError::BadRequest(
+            "Authorization request expired".to_string(),
+        ));
     }
 
     // Exchange code for tokens at Google
@@ -95,13 +110,16 @@ pub async fn google_callback(
         });
 
     // Upsert user
-    let user = state.db.upsert_user("google", &sub, email.as_deref(), name.as_deref())?;
+    let user = state
+        .db
+        .upsert_user("google", &sub, email.as_deref(), name.as_deref())?;
 
     // Generate authorization code for the downstream client
     let auth_code = generate_auth_code(&state, &pending, &user.id)?;
 
     // Redirect to client's redirect_uri
-    let redirect_url = build_client_redirect(&pending.redirect_uri, &auth_code, &pending.original_state);
+    let redirect_url =
+        build_client_redirect(&pending.redirect_uri, &auth_code, &pending.original_state);
     tracing::info!(user_id = %user.id, provider = "google", "User authenticated");
 
     Ok(Redirect::temporary(&redirect_url).into_response())
@@ -113,8 +131,13 @@ pub async fn github_callback(
     Query(params): Query<CallbackParams>,
 ) -> Result<Response> {
     if let Some(err) = &params.error {
-        let desc = params.error_description.as_deref().unwrap_or("Unknown error");
-        return Err(ServerError::IdpError(format!("GitHub OAuth error: {err}: {desc}")));
+        let desc = params
+            .error_description
+            .as_deref()
+            .unwrap_or("Unknown error");
+        return Err(ServerError::IdpError(format!(
+            "GitHub OAuth error: {err}: {desc}"
+        )));
     }
 
     let idp_code = params
@@ -126,21 +149,30 @@ pub async fn github_callback(
         .as_deref()
         .ok_or_else(|| ServerError::BadRequest("Missing state parameter".to_string()))?;
 
-    // Look up pending auth request
+    // Validate provider before consuming the pending auth request.
+    let pending = state
+        .db
+        .get_pending_auth(idp_state)?
+        .ok_or_else(|| ServerError::BadRequest("Unknown or expired state".to_string()))?;
+
+    if pending.provider != "github" {
+        return Err(ServerError::BadRequest(
+            "State does not match GitHub provider".to_string(),
+        ));
+    }
+
     let pending = state
         .db
         .consume_pending_auth(idp_state)?
         .ok_or_else(|| ServerError::BadRequest("Unknown or expired state".to_string()))?;
 
-    if pending.provider != "github" {
-        return Err(ServerError::BadRequest("State does not match GitHub provider".to_string()));
-    }
-
     // Check expiry
     let expires = chrono::NaiveDateTime::parse_from_str(&pending.expires_at, "%Y-%m-%dT%H:%M:%SZ")
         .map_err(|e| ServerError::Internal(format!("Bad expiry: {e}")))?;
     if expires.and_utc() < chrono::Utc::now() {
-        return Err(ServerError::BadRequest("Authorization request expired".to_string()));
+        return Err(ServerError::BadRequest(
+            "Authorization request expired".to_string(),
+        ));
     }
 
     // Exchange code for tokens at GitHub
@@ -186,13 +218,16 @@ pub async fn github_callback(
     let name = github_user.name.or(github_user.login);
 
     // Upsert user
-    let user = state.db.upsert_user("github", &sub, email.as_deref(), name.as_deref())?;
+    let user = state
+        .db
+        .upsert_user("github", &sub, email.as_deref(), name.as_deref())?;
 
     // Generate authorization code
     let auth_code = generate_auth_code(&state, &pending, &user.id)?;
 
     // Redirect to client's redirect_uri
-    let redirect_url = build_client_redirect(&pending.redirect_uri, &auth_code, &pending.original_state);
+    let redirect_url =
+        build_client_redirect(&pending.redirect_uri, &auth_code, &pending.original_state);
     tracing::info!(user_id = %user.id, provider = "github", "User authenticated");
 
     Ok(Redirect::temporary(&redirect_url).into_response())
@@ -235,8 +270,16 @@ fn generate_auth_code(
 }
 
 fn build_client_redirect(redirect_uri: &str, code: &str, state: &str) -> String {
+    if let Ok(mut url) = Url::parse(redirect_uri) {
+        url.query_pairs_mut()
+            .append_pair("code", code)
+            .append_pair("state", state);
+        return url.to_string();
+    }
+
+    let separator = if redirect_uri.contains('?') { "&" } else { "?" };
     format!(
-        "{redirect_uri}?code={}&state={}",
+        "{redirect_uri}{separator}code={}&state={}",
         urlencoding::encode(code),
         urlencoding::encode(state),
     )

--- a/crates/karta-server/src/oauth/discovery.rs
+++ b/crates/karta-server/src/oauth/discovery.rs
@@ -1,5 +1,5 @@
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 use serde_json::{Value, json};
 
 use crate::state::AppState;

--- a/crates/karta-server/src/oauth/register.rs
+++ b/crates/karta-server/src/oauth/register.rs
@@ -1,6 +1,6 @@
+use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::Json;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -38,11 +38,15 @@ pub async fn register_client(
             .get("authorization")
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "))
-            .ok_or_else(|| ServerError::Unauthorized(
-                "Registration requires Authorization: Bearer <token>".to_string(),
-            ))?;
+            .ok_or_else(|| {
+                ServerError::Unauthorized(
+                    "Registration requires Authorization: Bearer <token>".to_string(),
+                )
+            })?;
         if provided != expected_token {
-            return Err(ServerError::Unauthorized("Invalid registration token".to_string()));
+            return Err(ServerError::Unauthorized(
+                "Invalid registration token".to_string(),
+            ));
         }
     }
 
@@ -66,15 +70,12 @@ pub async fn register_client(
         }
     }
 
-    let auth_method = req
-        .token_endpoint_auth_method
-        .as_deref()
-        .unwrap_or("none");
+    let auth_method = req.token_endpoint_auth_method.as_deref().unwrap_or("none");
 
     if auth_method != "none" && auth_method != "client_secret_post" {
-        return Err(ServerError::BadRequest(
-            format!("Unsupported token_endpoint_auth_method: {auth_method}. Supported: none, client_secret_post")
-        ));
+        return Err(ServerError::BadRequest(format!(
+            "Unsupported token_endpoint_auth_method: {auth_method}. Supported: none, client_secret_post"
+        )));
     }
 
     let client_id = uuid::Uuid::new_v4().to_string();

--- a/crates/karta-server/src/oauth/token.rs
+++ b/crates/karta-server/src/oauth/token.rs
@@ -1,6 +1,6 @@
+use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::Json;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -34,14 +34,13 @@ pub async fn token(
     State(state): State<AppState>,
     axum::Form(req): axum::Form<TokenRequest>,
 ) -> Result<Json<TokenResponse>> {
-    let grant_type = req
-        .grant_type
-        .as_deref()
-        .ok_or_else(|| ServerError::oauth(
+    let grant_type = req.grant_type.as_deref().ok_or_else(|| {
+        ServerError::oauth(
             "invalid_request",
             "grant_type is required",
             StatusCode::BAD_REQUEST,
-        ))?;
+        )
+    })?;
 
     match grant_type {
         "authorization_code" => handle_auth_code_grant(&state, &req).await,
@@ -58,58 +57,52 @@ async fn handle_auth_code_grant(
     state: &AppState,
     req: &TokenRequest,
 ) -> Result<Json<TokenResponse>> {
-    let code = req
-        .code
-        .as_deref()
-        .ok_or_else(|| ServerError::oauth(
+    let code = req.code.as_deref().ok_or_else(|| {
+        ServerError::oauth(
             "invalid_request",
             "code is required",
             StatusCode::BAD_REQUEST,
-        ))?;
-    let redirect_uri = req
-        .redirect_uri
-        .as_deref()
-        .ok_or_else(|| ServerError::oauth(
+        )
+    })?;
+    let redirect_uri = req.redirect_uri.as_deref().ok_or_else(|| {
+        ServerError::oauth(
             "invalid_request",
             "redirect_uri is required",
             StatusCode::BAD_REQUEST,
-        ))?;
-    let code_verifier = req
-        .code_verifier
-        .as_deref()
-        .ok_or_else(|| ServerError::oauth(
+        )
+    })?;
+    let code_verifier = req.code_verifier.as_deref().ok_or_else(|| {
+        ServerError::oauth(
             "invalid_request",
             "code_verifier is required",
             StatusCode::BAD_REQUEST,
-        ))?;
-    let client_id = req
-        .client_id
-        .as_deref()
-        .ok_or_else(|| ServerError::oauth(
+        )
+    })?;
+    let client_id = req.client_id.as_deref().ok_or_else(|| {
+        ServerError::oauth(
             "invalid_request",
             "client_id is required",
             StatusCode::BAD_REQUEST,
-        ))?;
+        )
+    })?;
 
     // Look up the client and verify client_secret if the client has one
-    let client = state
-        .db
-        .get_client(client_id)?
-        .ok_or_else(|| ServerError::oauth(
+    let client = state.db.get_client(client_id)?.ok_or_else(|| {
+        ServerError::oauth(
             "invalid_client",
             "Unknown client_id",
             StatusCode::UNAUTHORIZED,
-        ))?;
+        )
+    })?;
 
     if let Some(expected_hash) = &client.client_secret_hash {
-        let provided_secret = req
-            .client_secret
-            .as_deref()
-            .ok_or_else(|| ServerError::oauth(
+        let provided_secret = req.client_secret.as_deref().ok_or_else(|| {
+            ServerError::oauth(
                 "invalid_client",
                 "client_secret is required for this client",
                 StatusCode::UNAUTHORIZED,
-            ))?;
+            )
+        })?;
         let provided_hash = hash_token(provided_secret);
         if provided_hash != *expected_hash {
             return Err(ServerError::oauth(
@@ -121,14 +114,13 @@ async fn handle_auth_code_grant(
     }
 
     // Consume the auth code atomically (one-time use, expiry checked in SQL)
-    let auth_code = state
-        .db
-        .consume_auth_code(code)?
-        .ok_or_else(|| ServerError::oauth(
+    let auth_code = state.db.consume_auth_code(code)?.ok_or_else(|| {
+        ServerError::oauth(
             "invalid_grant",
             "Invalid, expired, or already used authorization code",
             StatusCode::BAD_REQUEST,
-        ))?;
+        )
+    })?;
 
     // Verify client_id matches the auth code
     if auth_code.client_id != client_id {
@@ -167,49 +159,50 @@ async fn handle_auth_code_grant(
     }
 
     // Issue tokens
-    issue_tokens(state, &auth_code.client_id, &auth_code.user_id, auth_code.scope.as_deref())
+    issue_tokens(
+        state,
+        &auth_code.client_id,
+        &auth_code.user_id,
+        auth_code.scope.as_deref(),
+    )
 }
 
 async fn handle_refresh_token_grant(
     state: &AppState,
     req: &TokenRequest,
 ) -> Result<Json<TokenResponse>> {
-    let refresh_token = req
-        .refresh_token
-        .as_deref()
-        .ok_or_else(|| ServerError::oauth(
+    let refresh_token = req.refresh_token.as_deref().ok_or_else(|| {
+        ServerError::oauth(
             "invalid_request",
             "refresh_token is required",
             StatusCode::BAD_REQUEST,
-        ))?;
-    let client_id = req
-        .client_id
-        .as_deref()
-        .ok_or_else(|| ServerError::oauth(
+        )
+    })?;
+    let client_id = req.client_id.as_deref().ok_or_else(|| {
+        ServerError::oauth(
             "invalid_request",
             "client_id is required",
             StatusCode::BAD_REQUEST,
-        ))?;
+        )
+    })?;
 
     // Look up the client and verify client_secret if the client has one
-    let client = state
-        .db
-        .get_client(client_id)?
-        .ok_or_else(|| ServerError::oauth(
+    let client = state.db.get_client(client_id)?.ok_or_else(|| {
+        ServerError::oauth(
             "invalid_client",
             "Unknown client_id",
             StatusCode::UNAUTHORIZED,
-        ))?;
+        )
+    })?;
 
     if let Some(expected_hash) = &client.client_secret_hash {
-        let provided_secret = req
-            .client_secret
-            .as_deref()
-            .ok_or_else(|| ServerError::oauth(
+        let provided_secret = req.client_secret.as_deref().ok_or_else(|| {
+            ServerError::oauth(
                 "invalid_client",
                 "client_secret is required for this client",
                 StatusCode::UNAUTHORIZED,
-            ))?;
+            )
+        })?;
         let provided_hash = hash_token(provided_secret);
         if provided_hash != *expected_hash {
             return Err(ServerError::oauth(
@@ -225,11 +218,13 @@ async fn handle_refresh_token_grant(
     let (stored_client_id, user_id, scope) = state
         .db
         .consume_refresh_token(&token_hash)?
-        .ok_or_else(|| ServerError::oauth(
-            "invalid_grant",
-            "Invalid, expired, or revoked refresh token",
-            StatusCode::BAD_REQUEST,
-        ))?;
+        .ok_or_else(|| {
+            ServerError::oauth(
+                "invalid_grant",
+                "Invalid, expired, or revoked refresh token",
+                StatusCode::BAD_REQUEST,
+            )
+        })?;
 
     // Verify client_id matches the stored refresh token
     if stored_client_id != client_id {
@@ -257,7 +252,8 @@ fn issue_tokens(
 
     // Generate refresh token (32 random bytes, base64url)
     let refresh_token_bytes: [u8; 32] = rand::random();
-    let refresh_token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(refresh_token_bytes);
+    let refresh_token =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(refresh_token_bytes);
     let refresh_token_hash = hash_token(&refresh_token);
 
     let now = chrono::Utc::now();

--- a/crates/karta-server/src/state.rs
+++ b/crates/karta-server/src/state.rs
@@ -1,8 +1,11 @@
 use axum_extra::extract::cookie::Key;
 use oauth2::basic::BasicClient;
-use oauth2::{AuthUrl, ClientId, ClientSecret, EndpointMaybeSet, EndpointNotSet, EndpointSet, RedirectUrl, TokenUrl};
+use oauth2::{
+    AuthUrl, ClientId, ClientSecret, EndpointMaybeSet, EndpointNotSet, EndpointSet, RedirectUrl,
+    TokenUrl,
+};
 use openidconnect::core::CoreClient;
-use openidconnect::{IssuerUrl, ClientId as OidcClientId, ClientSecret as OidcClientSecret};
+use openidconnect::{ClientId as OidcClientId, ClientSecret as OidcClientSecret, IssuerUrl};
 
 use crate::config::ServerConfig;
 use crate::db::AuthDb;
@@ -19,13 +22,8 @@ pub type GoogleClient = CoreClient<
 >;
 
 /// The GitHub OAuth2 client type with auth + token URLs set.
-pub type GithubClient = BasicClient<
-    EndpointSet,
-    EndpointNotSet,
-    EndpointNotSet,
-    EndpointNotSet,
-    EndpointSet,
->;
+pub type GithubClient =
+    BasicClient<EndpointSet, EndpointNotSet, EndpointNotSet, EndpointNotSet, EndpointSet>;
 
 #[derive(Clone)]
 #[allow(dead_code)]
@@ -68,12 +66,10 @@ async fn build_google_client(
     let issuer = IssuerUrl::new("https://accounts.google.com".to_string())
         .map_err(|e| ServerError::Config(format!("Invalid Google issuer URL: {e}")))?;
 
-    let provider_metadata = openidconnect::core::CoreProviderMetadata::discover_async(
-        issuer,
-        http_client,
-    )
-    .await
-    .map_err(|e| ServerError::Config(format!("Failed to discover Google OIDC: {e}")))?;
+    let provider_metadata =
+        openidconnect::core::CoreProviderMetadata::discover_async(issuer, http_client)
+            .await
+            .map_err(|e| ServerError::Config(format!("Failed to discover Google OIDC: {e}")))?;
 
     let redirect_url = format!("{}/auth/google/callback", config.base_url);
 


### PR DESCRIPTION
## Summary
- Add `schema_meta` table with version tracking and applied migrations list
- New `migrate` module with `SchemaMeta`, `Migration` struct, and `apply_migrations()`
- Migrations are transactional — failed migration leaves DB unchanged (rollback)
- Idempotent: re-running on already-migrated DB is a no-op
- `GraphStore` trait gains `get_schema_meta()` method
- `Karta::health_check()` returns `KartaHealth` with store status, schema version, pending migrations, and warnings

## Acceptance criteria
- [x] Opening an old `.karta` directory migrates successfully (schema_meta table created on init)
- [x] Reopening an already migrated directory does nothing (no pending migrations)
- [x] Failed migration leaves database unchanged (unchecked_transaction + rollback)
- [x] `health_check()` detects schema drift (returns warnings for pending migrations)

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check API to verify vector store and graph store availability with consolidated status reporting
  * Introduced schema migration infrastructure with version tracking and pending migration detection
  * Exposed migration module in public API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->