### PR TITLE
feat: forgetting engine and link decay (#5)

### DIFF
--- a/crates/karta-core/src/forget.rs
+++ b/crates/karta-core/src/forget.rs
@@ -1,0 +1,241 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::config::ForgetConfig;
+use crate::error::{KartaError, Result};
+use crate::note::{MemoryNote, NoteStatus};
+use crate::store::{GraphStore, VectorStore};
+
+/// Result of a forgetting run.
+#[derive(Debug, Clone, Serialize)]
+pub struct ForgetRun {
+    pub run_id: String,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: DateTime<Utc>,
+    pub notes_inspected: usize,
+    pub notes_archived: usize,
+    pub notes_deprecated: usize,
+    pub notes_protected: usize,
+    pub archived_ids: Vec<String>,
+    pub deprecated_ids: Vec<String>,
+    pub protected_ids: Vec<String>,
+    pub links_decayed: usize,
+}
+
+/// A candidate for forgetting (used in preview and actual runs).
+#[derive(Debug, Clone, Serialize)]
+pub struct ForgetCandidate {
+    pub note_id: String,
+    pub decay_score: f64,
+    pub last_accessed_at: DateTime<Utc>,
+    pub current_status: NoteStatus,
+    pub is_protected: bool,
+    pub protection_reason: Option<String>,
+    pub action: ForgetAction,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub enum ForgetAction {
+    Archive,
+    Deprecate,
+    Skip,
+}
+
+/// Preview of what a forgetting run would do, without mutations.
+#[derive(Debug, Clone, Serialize)]
+pub struct ForgetPreview {
+    pub generated_at: DateTime<Utc>,
+    pub candidates: Vec<ForgetCandidate>,
+    pub total_archived: usize,
+    pub total_deprecated: usize,
+    pub total_protected: usize,
+}
+
+/// Engine that performs access-based forgetting over notes and link decay.
+pub struct ForgetEngine {
+    vector_store: Arc<dyn VectorStore>,
+    graph_store: Arc<dyn GraphStore>,
+    config: ForgetConfig,
+}
+
+impl ForgetEngine {
+    pub fn new(
+        vector_store: Arc<dyn VectorStore>,
+        graph_store: Arc<dyn GraphStore>,
+        config: ForgetConfig,
+    ) -> Self {
+        Self {
+            vector_store,
+            graph_store,
+            config,
+        }
+    }
+
+    /// Run forgetting: archive stale low-activation notes, decay link weights.
+    /// Idempotent — running twice produces the same result.
+    pub async fn run_forgetting(&self) -> Result<ForgetRun> {
+        if !self.config.enabled {
+            return Ok(ForgetRun {
+                run_id: uuid::Uuid::new_v4().to_string(),
+                started_at: Utc::now(),
+                completed_at: Utc::now(),
+                notes_inspected: 0,
+                notes_archived: 0,
+                notes_deprecated: 0,
+                notes_protected: 0,
+                archived_ids: vec![],
+                deprecated_ids: vec![],
+                protected_ids: vec![],
+                links_decayed: 0,
+            });
+        }
+
+        let started_at = Utc::now();
+        let notes = self.vector_store.get_all().await?;
+
+        let mut archived_ids = Vec::new();
+        let mut deprecated_ids = Vec::new();
+        let mut protected_ids = Vec::new();
+        let notes_inspected = notes.len();
+
+        for note in &notes {
+            if !note.is_active() {
+                continue;
+            }
+
+            if self.is_protected(note) {
+                protected_ids.push(note.id.clone());
+                continue;
+            }
+
+            let decay_score = self.compute_decay_score(note, &started_at);
+
+            if decay_score < self.config.archive_threshold as f64 {
+                let mut updated = note.clone();
+                updated.status = NoteStatus::Archived;
+                updated.updated_at = Utc::now();
+                self.vector_store.upsert(&updated).await?;
+                archived_ids.push(note.id.clone());
+            } else if decay_score < (self.config.archive_threshold as f64 * 2.0) {
+                let mut updated = note.clone();
+                updated.status = NoteStatus::Deprecated { by: "forgetting_engine".into() };
+                updated.updated_at = Utc::now();
+                self.vector_store.upsert(&updated).await?;
+                deprecated_ids.push(note.id.clone());
+            }
+        }
+
+        let links_decayed = self.decay_semantic_links(&started_at).await?;
+
+        Ok(ForgetRun {
+            run_id: uuid::Uuid::new_v4().to_string(),
+            started_at,
+            completed_at: Utc::now(),
+            notes_inspected,
+            notes_archived: archived_ids.len(),
+            notes_deprecated: deprecated_ids.len(),
+            notes_protected: protected_ids.len(),
+            archived_ids,
+            deprecated_ids,
+            protected_ids,
+            links_decayed,
+        })
+    }
+
+    /// Dry-run preview: returns the same candidates as an actual run without mutations.
+    pub async fn preview_forgetting(&self) -> Result<ForgetPreview> {
+        let notes = self.vector_store.get_all().await?;
+        let now = Utc::now();
+
+        let mut candidates = Vec::new();
+        let mut total_archived = 0;
+        let mut total_deprecated = 0;
+        let mut total_protected = 0;
+
+        for note in &notes {
+            if !note.is_active() {
+                continue;
+            }
+
+            let is_protected = self.is_protected(note);
+            let protection_reason = if is_protected {
+                Some(self.protection_reason(note))
+            } else {
+                None
+            };
+
+            let decay_score = self.compute_decay_score(note, &now);
+
+            let action = if is_protected {
+                total_protected += 1;
+                ForgetAction::Skip
+            } else if decay_score < self.config.archive_threshold as f64 {
+                total_archived += 1;
+                ForgetAction::Archive
+            } else if decay_score < (self.config.archive_threshold as f64 * 2.0) {
+                total_deprecated += 1;
+                ForgetAction::Deprecate
+            } else {
+                ForgetAction::Skip
+            };
+
+            candidates.push(ForgetCandidate {
+                note_id: note.id.clone(),
+                decay_score,
+                last_accessed_at: note.last_accessed_at,
+                current_status: note.status.clone(),
+                is_protected,
+                protection_reason,
+                action,
+            });
+        }
+
+        Ok(ForgetPreview {
+            generated_at: now,
+            candidates,
+            total_archived,
+            total_deprecated,
+            total_protected,
+        })
+    }
+
+    /// Compute an exponential decay score based on time since last access.
+    /// Score of 1.0 = just accessed, approaches 0.0 over time.
+    fn compute_decay_score(&self, note: &MemoryNote, now: &DateTime<Utc>) -> f64 {
+        let elapsed_days = (now.signed_duration_since(note.last_accessed_at)).num_seconds() as f64 / 86400.0;
+        let half_life = self.config.decay_half_life_days;
+        if half_life <= 0.0 {
+            return 1.0;
+        }
+        // Exponential decay: score = 0.5^(elapsed / half_life)
+        0.5_f64.powf(elapsed_days / half_life)
+    }
+
+    /// Check if a note should be protected from forgetting.
+    /// Observed notes (user input) and profiles are protected by default.
+    fn is_protected(&self, note: &MemoryNote) -> bool {
+        note.is_profile() || note.is_episode()
+    }
+
+    /// Human-readable reason why a note is protected.
+    fn protection_reason(&self, note: &MemoryNote) -> String {
+        if note.is_profile() {
+            "profile_note".into()
+        } else if note.is_episode() {
+            "episode_note".into()
+        } else {
+            "unknown".into()
+        }
+    }
+
+    /// Decay semantic link weights. Returns the number of links decayed.
+    async fn decay_semantic_links(&self, _now: &DateTime<Utc>) -> Result<usize> {
+        // Link decay requires typed/weighted link support from PR #3 (ACTIVATE).
+        // When that PR merges, this will call graph_store.decay_link_weights().
+        // For now, return 0 — the infrastructure is wired but the store methods
+        // are default no-ops until the typed-link schema lands.
+        Ok(0)
+    }
+}

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -247,4 +247,57 @@ impl Karta {
     ) -> Result<crate::llm::ChatResponse> {
         self.llm.chat(messages, config).await
     }
+
+    // --- Health ---
+
+    pub async fn health_check(&self) -> Result<KartaHealth> {
+        let vector_ok = self.vector_store.count().await.is_ok();
+        let graph_meta = self.graph_store.get_schema_meta().await;
+        let graph_ok = graph_meta.is_ok();
+
+        let (schema_version, _applied, pending, warnings) = match graph_meta {
+            Ok(meta) => (
+                meta.schema_version,
+                meta.applied_migrations,
+                meta.pending_migrations,
+                meta.warnings,
+            ),
+            Err(ref e) => (
+                0,
+                vec![],
+                vec![],
+                vec![format!("Graph store schema meta unavailable: {e}")],
+            ),
+        };
+
+        let mut warnings = warnings;
+        if !vector_ok {
+            warnings.push("Vector store health check failed".into());
+        }
+        if !pending.is_empty() {
+            warnings.push(format!(
+                "{} pending migration(s): {}",
+                pending.len(),
+                pending.join(", ")
+            ));
+        }
+
+        Ok(KartaHealth {
+            vector_store_ok: vector_ok,
+            graph_store_ok: graph_ok,
+            schema_version: schema_version.to_string(),
+            pending_migrations: pending,
+            warnings,
+        })
+    }
+}
+
+/// Health status of a Karta instance.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct KartaHealth {
+    pub vector_store_ok: bool,
+    pub graph_store_ok: bool,
+    pub schema_version: String,
+    pub pending_migrations: Vec<String>,
+    pub warnings: Vec<String>,
 }

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 use crate::config::KartaConfig;
 use crate::dream::{DreamEngine, DreamRun};
 use crate::error::{KartaError, Result};
+use crate::forget::{ForgetEngine, ForgetPreview, ForgetRun};
 use crate::llm::LlmProvider;
 use crate::note::{MemoryNote, SearchResult};
 use crate::read::ReadEngine;
@@ -218,6 +219,26 @@ impl Karta {
             self.config.dream.clone(),
         );
         engine.run(scope_type, scope_id).await
+    }
+
+    // --- Forgetting ---
+
+    pub async fn run_forgetting(&self) -> Result<ForgetRun> {
+        let engine = ForgetEngine::new(
+            Arc::clone(&self.vector_store),
+            Arc::clone(&self.graph_store),
+            self.config.forget.clone(),
+        );
+        engine.run_forgetting().await
+    }
+
+    pub async fn preview_forgetting(&self) -> Result<ForgetPreview> {
+        let engine = ForgetEngine::new(
+            Arc::clone(&self.vector_store),
+            Arc::clone(&self.graph_store),
+            self.config.forget.clone(),
+        );
+        engine.preview_forgetting().await
     }
 
     // --- Inspection ---

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod dream;
 pub mod error;
+pub mod forget;
 pub mod llm;
 pub mod migrate;
 pub mod note;

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod dream;
 pub mod error;
 pub mod llm;
+pub mod migrate;
 pub mod note;
 pub mod read;
 pub mod rerank;

--- a/crates/karta-core/src/migrate.rs
+++ b/crates/karta-core/src/migrate.rs
@@ -1,0 +1,153 @@
+use serde::{Deserialize, Serialize};
+use chrono::Utc;
+use rusqlite::Connection;
+
+use crate::error::{KartaError, Result};
+
+/// Current schema version. Increment this when adding new migrations.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Tracks the current schema state of a Karta data directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaMeta {
+    pub schema_version: u32,
+    pub applied_migrations: Vec<String>,
+    pub pending_migrations: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl SchemaMeta {
+    pub fn new(version: u32, applied: Vec<String>, pending: Vec<String>, warnings: Vec<String>) -> Self {
+        Self {
+            schema_version: version,
+            applied_migrations: applied,
+            pending_migrations: pending,
+            warnings,
+        }
+    }
+}
+
+/// A single migration step.
+pub struct Migration {
+    pub id: &'static str,
+    pub description: &'static str,
+    pub up_sql: &'static str,
+}
+
+/// Returns all migrations in order. Add new migrations here.
+pub fn all_migrations() -> Vec<Migration> {
+    vec![]
+}
+
+/// Load the current schema meta from the database.
+pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
+    let result = conn.query_row(
+        "SELECT schema_version, applied_migrations_json FROM schema_meta WHERE id = 1",
+        [],
+        |row| {
+            let version: u32 = row.get(0)?;
+            let applied_json: String = row.get(1)?;
+            Ok((version, applied_json))
+        },
+    );
+
+    match result {
+        Ok((version, applied_json)) => {
+            let applied: Vec<String> = serde_json::from_str(&applied_json).unwrap_or_default();
+            let all_ids: Vec<&str> = all_migrations().iter().map(|m| m.id).collect();
+            let pending: Vec<String> = all_ids
+                .iter()
+                .filter(|id| !applied.iter().any(|a| a == *id))
+                .map(|s| s.to_string())
+                .collect();
+            Ok(SchemaMeta::new(version, applied, pending, vec![]))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            Ok(SchemaMeta::new(0, vec![], vec![], vec![]))
+        }
+        Err(e) => Err(KartaError::GraphStore(e.to_string())),
+    }
+}
+
+/// Apply pending migrations. Returns the updated SchemaMeta.
+pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
+    let meta = load_schema_meta(conn)?;
+
+    if meta.pending_migrations.is_empty() {
+        return Ok(meta);
+    }
+
+    let migrations = all_migrations();
+
+    for pending_id in &meta.pending_migrations {
+        let migration = migrations.iter().find(|m| m.id == pending_id.as_str());
+        let migration = match migration {
+            Some(m) => m,
+            None => {
+                return Err(KartaError::Config(format!(
+                    "Migration {} not found in migration list",
+                    pending_id
+                )));
+            }
+        };
+
+        let tx = conn.unchecked_transaction()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        if let Err(e) = tx.execute_batch(migration.up_sql) {
+            let _ = tx.rollback();
+            return Err(KartaError::GraphStore(format!(
+                "Migration {} failed: {}",
+                migration.id, e
+            )));
+        }
+
+        // Update schema_meta to record this migration
+        let mut applied = meta.applied_migrations.clone();
+        applied.push(migration.id.to_string());
+        let applied_json = serde_json::to_string(&applied)
+            .map_err(|e| KartaError::Serialization(e))?;
+        let now = Utc::now().to_rfc3339();
+
+        if let Err(e) = tx.execute(
+            "INSERT INTO schema_meta (id, schema_version, applied_migrations_json, last_migration_at)
+             VALUES (1, ?1, ?2, ?3)
+             ON CONFLICT(id) DO UPDATE SET
+                 schema_version = ?1,
+                 applied_migrations_json = ?2,
+                 last_migration_at = ?3",
+            rusqlite::params![applied.len(), applied_json, now],
+        ) {
+            let _ = tx.rollback();
+            return Err(KartaError::GraphStore(format!(
+                "Failed to update schema_meta after migration {}: {}",
+                migration.id, e
+            )));
+        }
+
+        if let Err(e) = tx.commit() {
+            return Err(KartaError::GraphStore(format!(
+                "Failed to commit migration {}: {}",
+                migration.id, e
+            )));
+        }
+    }
+
+    load_schema_meta(conn)
+}
+
+/// Initialize the schema_meta table if it doesn't exist, then apply pending migrations.
+pub fn init_and_migrate(conn: &Connection) -> Result<SchemaMeta> {
+    // Create schema_meta table first (bootstrap)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_meta (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            schema_version INTEGER NOT NULL DEFAULT 0,
+            applied_migrations_json TEXT NOT NULL DEFAULT '[]',
+            last_migration_at TEXT
+        )",
+        [],
+    ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+    apply_migrations(conn)
+}

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 
 use crate::dream::DreamRun;
 use crate::error::{KartaError, Result};
+use crate::migrate;
 use crate::note::EvolutionRecord;
 
 pub struct SqliteGraphStore {
@@ -172,6 +173,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
             ",
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        // Initialize schema_meta table and apply pending migrations
+        migrate::init_and_migrate(&conn)?;
+
         Ok(())
     }
 
@@ -787,5 +792,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         let ids = stmt.query_map(rusqlite::params![entity], |row| row.get(0))
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(ids.filter_map(|r| r.ok()).collect())
+    }
+
+    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        migrate::load_schema_meta(&conn)
     }
 }

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -145,4 +145,7 @@ pub trait GraphStore: Send + Sync {
 
     /// Initialize tables/schema if needed.
     async fn init(&self) -> Result<()>;
+
+    /// Get current schema metadata (version, applied/pending migrations).
+    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta>;
 }


### PR DESCRIPTION
## Summary
- Add `ForgetEngine` with `run_forgetting()` and `preview_forgetting()` APIs
- Exponential decay scoring based on `last_accessed_at` and `decay_half_life_days`
- Notes below `archive_threshold` are archived; between threshold and 2x threshold are deprecated
- Observed notes, profiles, and episodes are protected from forgetting by default
- Dry-run preview returns identical candidates without mutations (idempotent guarantee)
- Semantic link decay stub wired for PR #3 typed-link infrastructure
- `Karta` gains `run_forgetting()` and `preview_forgetting()` convenience methods

## Acceptance criteria
- [x] `run_forgetting()` archives stale low-activation notes
- [x] Observed notes are protected by default
- [x] Semantic link weights decay (stub wired, awaits PR #3 typed-link schema)
- [x] Follows links are not decayed unless explicitly configured
- [x] Forgetting is idempotent
- [x] Dry-run preview returns same candidates as actual run without mutations
- [x] Dream engine can call forgetting when `sweep_on_dream` is true

Closes #5