### PR TITLE
feat: procedural memory and safe rule engine (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ system could find because they were never explicitly stored.
 - **Temporal awareness** — exponential decay scoring, foresight signals with validity windows
 - **Provenance tracking** — every note tagged as FACT or INFERRED with confidence scores
 - **Forgetting** — note lifecycle (Active → Deprecated → Superseded → Archived) with access-based decay
-- **Embedded by default** — LanceDB + SQLite, zero infrastructure. `cargo add karta` and go.
+- **Procedural memory** — `RuleEngine` with safe `ProceduralRule` DSL (query/session/contradiction conditions → prompt/retrieval actions only), fire-count tracking, note-sourced rules protected from forgetting
 
 ## Quick Start
 

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -9,6 +9,8 @@ use crate::llm::LlmProvider;
 use crate::note::{MemoryNote, SearchResult};
 use crate::read::ReadEngine;
 use crate::rerank::{JinaReranker, LlmReranker, NoopReranker, Reranker};
+use crate::rules::{ProceduralRule, RuleContext, RuleEvaluation};
+use crate::rules_engine::RuleEngine;
 use crate::store::{GraphStore, VectorStore};
 use crate::write::WriteEngine;
 
@@ -289,6 +291,28 @@ impl Karta {
             pending_migrations: pending,
             warnings,
         })
+    }
+
+    // --- Rules ---
+
+    pub async fn evaluate_rules(&self, ctx: &RuleContext) -> Result<RuleEvaluation> {
+        let engine = RuleEngine::new(Arc::clone(&self.graph_store));
+        engine.evaluate(ctx).await
+    }
+
+    pub async fn add_rule(&self, rule: ProceduralRule) -> Result<()> {
+        let engine = RuleEngine::new(Arc::clone(&self.graph_store));
+        engine.add_rule(rule).await
+    }
+
+    pub async fn disable_rule(&self, rule_id: &str) -> Result<()> {
+        let engine = RuleEngine::new(Arc::clone(&self.graph_store));
+        engine.disable_rule(rule_id).await
+    }
+
+    pub async fn list_rules(&self) -> Result<Vec<ProceduralRule>> {
+        let engine = RuleEngine::new(Arc::clone(&self.graph_store));
+        engine.list_rules().await
     }
 }
 

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -247,4 +247,57 @@ impl Karta {
     ) -> Result<crate::llm::ChatResponse> {
         self.llm.chat(messages, config).await
     }
+
+    // --- Health ---
+
+    pub async fn health_check(&self) -> Result<KartaHealth> {
+        let vector_ok = self.vector_store.count().await.is_ok();
+        let graph_meta = self.graph_store.get_schema_meta().await;
+        let graph_ok = graph_meta.is_ok();
+
+        let (schema_version, _applied, pending, warnings) = match graph_meta {
+            Ok(meta) => (
+                meta.schema_version,
+                meta.applied_migrations,
+                meta.pending_migrations,
+                meta.warnings,
+            ),
+            Err(ref e) => (
+                0,
+                vec![],
+                vec![],
+                vec![format!("Graph store schema meta unavailable: {e}")],
+            ),
+        };
+
+        let mut warnings = warnings;
+        if !vector_ok {
+            warnings.push("Vector store health check failed".into());
+        }
+        if !pending.is_empty() {
+            warnings.push(format!(
+                "{} pending migration(s): {}",
+                pending.len(),
+                pending.join(", ")
+            ));
+        }
+
+        Ok(KartaHealth {
+            vector_store_ok: vector_ok,
+            graph_store_ok: graph_ok,
+            schema_version: schema_version.to_string(),
+            pending_migrations: pending,
+            warnings,
+        })
+    }
+}
+
+/// Health status of a Karta instance.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct KartaHealth {
+    pub vector_store_ok: bool,
+    pub graph_store_ok: bool,
+    pub schema_version: String,
+    pub pending_migrations: Vec<String>,
+    pub warnings: Vec<String>,
 }

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -6,6 +6,8 @@ pub mod migrate;
 pub mod note;
 pub mod read;
 pub mod rerank;
+pub mod rules;
+pub mod rules_engine;
 pub mod store;
 pub mod write;
 

--- a/crates/karta-core/src/lib.rs
+++ b/crates/karta-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod dream;
 pub mod error;
 pub mod llm;
+pub mod migrate;
 pub mod note;
 pub mod read;
 pub mod rerank;

--- a/crates/karta-core/src/migrate.rs
+++ b/crates/karta-core/src/migrate.rs
@@ -1,0 +1,153 @@
+use serde::{Deserialize, Serialize};
+use chrono::Utc;
+use rusqlite::Connection;
+
+use crate::error::{KartaError, Result};
+
+/// Current schema version. Increment this when adding new migrations.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Tracks the current schema state of a Karta data directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaMeta {
+    pub schema_version: u32,
+    pub applied_migrations: Vec<String>,
+    pub pending_migrations: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl SchemaMeta {
+    pub fn new(version: u32, applied: Vec<String>, pending: Vec<String>, warnings: Vec<String>) -> Self {
+        Self {
+            schema_version: version,
+            applied_migrations: applied,
+            pending_migrations: pending,
+            warnings,
+        }
+    }
+}
+
+/// A single migration step.
+pub struct Migration {
+    pub id: &'static str,
+    pub description: &'static str,
+    pub up_sql: &'static str,
+}
+
+/// Returns all migrations in order. Add new migrations here.
+pub fn all_migrations() -> Vec<Migration> {
+    vec![]
+}
+
+/// Load the current schema meta from the database.
+pub fn load_schema_meta(conn: &Connection) -> Result<SchemaMeta> {
+    let result = conn.query_row(
+        "SELECT schema_version, applied_migrations_json FROM schema_meta WHERE id = 1",
+        [],
+        |row| {
+            let version: u32 = row.get(0)?;
+            let applied_json: String = row.get(1)?;
+            Ok((version, applied_json))
+        },
+    );
+
+    match result {
+        Ok((version, applied_json)) => {
+            let applied: Vec<String> = serde_json::from_str(&applied_json).unwrap_or_default();
+            let all_ids: Vec<&str> = all_migrations().iter().map(|m| m.id).collect();
+            let pending: Vec<String> = all_ids
+                .iter()
+                .filter(|id| !applied.iter().any(|a| a == *id))
+                .map(|s| s.to_string())
+                .collect();
+            Ok(SchemaMeta::new(version, applied, pending, vec![]))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            Ok(SchemaMeta::new(0, vec![], vec![], vec![]))
+        }
+        Err(e) => Err(KartaError::GraphStore(e.to_string())),
+    }
+}
+
+/// Apply pending migrations. Returns the updated SchemaMeta.
+pub fn apply_migrations(conn: &Connection) -> Result<SchemaMeta> {
+    let meta = load_schema_meta(conn)?;
+
+    if meta.pending_migrations.is_empty() {
+        return Ok(meta);
+    }
+
+    let migrations = all_migrations();
+
+    for pending_id in &meta.pending_migrations {
+        let migration = migrations.iter().find(|m| m.id == pending_id.as_str());
+        let migration = match migration {
+            Some(m) => m,
+            None => {
+                return Err(KartaError::Config(format!(
+                    "Migration {} not found in migration list",
+                    pending_id
+                )));
+            }
+        };
+
+        let tx = conn.unchecked_transaction()
+            .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        if let Err(e) = tx.execute_batch(migration.up_sql) {
+            let _ = tx.rollback();
+            return Err(KartaError::GraphStore(format!(
+                "Migration {} failed: {}",
+                migration.id, e
+            )));
+        }
+
+        // Update schema_meta to record this migration
+        let mut applied = meta.applied_migrations.clone();
+        applied.push(migration.id.to_string());
+        let applied_json = serde_json::to_string(&applied)
+            .map_err(|e| KartaError::Serialization(e))?;
+        let now = Utc::now().to_rfc3339();
+
+        if let Err(e) = tx.execute(
+            "INSERT INTO schema_meta (id, schema_version, applied_migrations_json, last_migration_at)
+             VALUES (1, ?1, ?2, ?3)
+             ON CONFLICT(id) DO UPDATE SET
+                 schema_version = ?1,
+                 applied_migrations_json = ?2,
+                 last_migration_at = ?3",
+            rusqlite::params![applied.len(), applied_json, now],
+        ) {
+            let _ = tx.rollback();
+            return Err(KartaError::GraphStore(format!(
+                "Failed to update schema_meta after migration {}: {}",
+                migration.id, e
+            )));
+        }
+
+        if let Err(e) = tx.commit() {
+            return Err(KartaError::GraphStore(format!(
+                "Failed to commit migration {}: {}",
+                migration.id, e
+            )));
+        }
+    }
+
+    load_schema_meta(conn)
+}
+
+/// Initialize the schema_meta table if it doesn't exist, then apply pending migrations.
+pub fn init_and_migrate(conn: &Connection) -> Result<SchemaMeta> {
+    // Create schema_meta table first (bootstrap)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_meta (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            schema_version INTEGER NOT NULL DEFAULT 0,
+            applied_migrations_json TEXT NOT NULL DEFAULT '[]',
+            last_migration_at TEXT
+        )",
+        [],
+    ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+    apply_migrations(conn)
+}

--- a/crates/karta-core/src/rules.rs
+++ b/crates/karta-core/src/rules.rs
@@ -1,0 +1,89 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A safe action that a rule can perform. Constrained to prompt/retrieval
+/// modifications only — rules cannot mutate storage or execute arbitrary code.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleAction {
+    AppendSystemPrompt { text: String },
+    RewriteQuery { prefix: String },
+    FilterByTags { tags: Vec<String> },
+    BoostKeywords { keywords: Vec<String>, boost: f32 },
+    LimitTopK { top_k: usize },
+    WarnContradiction { message: String },
+}
+
+/// Condition that triggers a rule.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleCondition {
+    QueryContains { keywords: Vec<String> },
+    SessionMatches { session_id: String },
+    ContradictionForEntity { entity: String },
+    RetrievedTagPresent { tag: String },
+    Always,
+}
+
+/// A procedural rule that modifies retrieval/answer behavior when its condition matches.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProceduralRule {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub condition: RuleCondition,
+    pub actions: Vec<RuleAction>,
+    pub enabled: bool,
+    pub protected: bool,
+    pub source_note_id: Option<String>,
+    pub fire_count: u64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl ProceduralRule {
+    pub fn new(name: String, description: String, condition: RuleCondition, actions: Vec<RuleAction>) -> Self {
+        let now = Utc::now();
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            name,
+            description,
+            condition,
+            actions,
+            enabled: true,
+            protected: false,
+            source_note_id: None,
+            fire_count: 0,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn with_source(mut self, note_id: &str) -> Self {
+        self.source_note_id = Some(note_id.to_string());
+        self.protected = true;
+        self
+    }
+}
+
+/// Context passed to the rule engine for evaluation.
+#[derive(Debug, Clone, Default)]
+pub struct RuleContext {
+    pub query: String,
+    pub session_id: Option<String>,
+    pub retrieved_tags: Vec<String>,
+    pub contradiction_entities: Vec<String>,
+}
+
+/// Result of rule evaluation.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RuleEvaluation {
+    pub fired_rules: Vec<FiredRule>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FiredRule {
+    pub rule_id: String,
+    pub rule_name: String,
+    pub actions: Vec<RuleAction>,
+}

--- a/crates/karta-core/src/rules_engine.rs
+++ b/crates/karta-core/src/rules_engine.rs
@@ -1,0 +1,85 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde::Serialize;
+
+use crate::error::Result;
+use crate::rules::{FiredRule, ProceduralRule, RuleCondition, RuleContext, RuleEvaluation};
+use crate::store::GraphStore;
+
+/// Engine that evaluates procedural rules against retrieval context.
+pub struct RuleEngine {
+    graph_store: Arc<dyn GraphStore>,
+}
+
+impl RuleEngine {
+    pub fn new(graph_store: Arc<dyn GraphStore>) -> Self {
+        Self { graph_store }
+    }
+
+    /// Evaluate all enabled rules against the given context.
+    pub async fn evaluate(&self, ctx: &RuleContext) -> Result<RuleEvaluation> {
+        let rules = self.list_rules().await?;
+        let mut fired_rules = Vec::new();
+
+        for rule in &rules {
+            if !rule.enabled {
+                continue;
+            }
+
+            if Self::matches(&rule.condition, ctx) {
+                fired_rules.push(FiredRule {
+                    rule_id: rule.id.clone(),
+                    rule_name: rule.name.clone(),
+                    actions: rule.actions.clone(),
+                });
+                let _ = self.graph_store.increment_rule_fire_count(&rule.id).await;
+            }
+        }
+
+        Ok(RuleEvaluation { fired_rules })
+    }
+
+    pub async fn add_rule(&self, rule: ProceduralRule) -> Result<()> {
+        self.graph_store.upsert_procedural_rule(&rule).await
+    }
+
+    pub async fn disable_rule(&self, rule_id: &str) -> Result<()> {
+        self.graph_store.disable_procedural_rule(rule_id).await
+    }
+
+    pub async fn list_rules(&self) -> Result<Vec<ProceduralRule>> {
+        self.graph_store.list_procedural_rules().await
+    }
+
+    fn matches(condition: &RuleCondition, ctx: &RuleContext) -> bool {
+        match condition {
+            RuleCondition::QueryContains { keywords } => {
+                let query_lower = ctx.query.to_lowercase();
+                keywords.iter().any(|k| query_lower.contains(&k.to_lowercase()))
+            }
+            RuleCondition::SessionMatches { session_id } => {
+                ctx.session_id.as_ref().is_some_and(|s| s == session_id)
+            }
+            RuleCondition::ContradictionForEntity { entity } => {
+                ctx.contradiction_entities.contains(entity)
+            }
+            RuleCondition::RetrievedTagPresent { tag } => {
+                ctx.retrieved_tags.contains(tag)
+            }
+            RuleCondition::Always => true,
+        }
+    }
+}
+
+/// Trace output showing which rules fired during a query.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RuleTrace {
+    pub fired_rules: Vec<FiredRuleTrace>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FiredRuleTrace {
+    pub rule_id: String,
+    pub rule_name: String,
+}

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -170,6 +170,22 @@ impl crate::store::GraphStore for SqliteGraphStore {
             CREATE INDEX IF NOT EXISTS idx_ep_links_from ON episode_links(from_episode_id);
             CREATE INDEX IF NOT EXISTS idx_ep_links_to ON episode_links(to_episode_id);
             CREATE INDEX IF NOT EXISTS idx_ep_links_entity ON episode_links(entity);
+
+            -- Procedural rules (Issue #6)
+            CREATE TABLE IF NOT EXISTS procedural_rules (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                condition_json TEXT NOT NULL,
+                actions_json TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                protected INTEGER NOT NULL DEFAULT 0,
+                source_note_id TEXT,
+                fire_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_rules_enabled ON procedural_rules(enabled);
             ",
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
@@ -797,5 +813,75 @@ impl crate::store::GraphStore for SqliteGraphStore {
     async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta> {
         let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
         migrate::load_schema_meta(&conn)
+    }
+
+    // --- Procedural Rules ---
+
+    async fn upsert_procedural_rule(&self, rule: &crate::rules::ProceduralRule) -> Result<()> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let condition_json = serde_json::to_string(&rule.condition).map_err(|e| KartaError::Serialization(e))?;
+        let actions_json = serde_json::to_string(&rule.actions).map_err(|e| KartaError::Serialization(e))?;
+        conn.execute(
+            "INSERT INTO procedural_rules (id, name, description, condition_json, actions_json, enabled, protected, source_note_id, fire_count, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+             ON CONFLICT(id) DO UPDATE SET
+                 name=?2, description=?3, condition_json=?4, actions_json=?5,
+                 enabled=?6, protected=?7, source_note_id=?8, fire_count=?9, updated_at=?11",
+            rusqlite::params![
+                rule.id, rule.name, rule.description, condition_json, actions_json,
+                rule.enabled as i32, rule.protected as i32, rule.source_note_id,
+                rule.fire_count as i64, rule.created_at.to_rfc3339(), rule.updated_at.to_rfc3339(),
+            ],
+        ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn list_procedural_rules(&self) -> Result<Vec<crate::rules::ProceduralRule>> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let mut stmt = conn.prepare(
+            "SELECT id, name, description, condition_json, actions_json, enabled, protected, source_note_id, fire_count, created_at, updated_at FROM procedural_rules ORDER BY name"
+        ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let rows = stmt.query_map([], |row| {
+            let condition: crate::rules::RuleCondition = serde_json::from_str(&row.get::<_, String>(3)?).unwrap_or(crate::rules::RuleCondition::Always);
+            let actions: Vec<crate::rules::RuleAction> = serde_json::from_str(&row.get::<_, String>(4)?).unwrap_or_default();
+            let created_at = DateTime::parse_from_rfc3339(&row.get::<_, String>(9)?)
+                .unwrap_or_default().with_timezone(&Utc);
+            let updated_at = DateTime::parse_from_rfc3339(&row.get::<_, String>(10)?)
+                .unwrap_or_default().with_timezone(&Utc);
+            Ok(crate::rules::ProceduralRule {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                description: row.get(2)?,
+                condition,
+                actions,
+                enabled: row.get::<_, i32>(5)? != 0,
+                protected: row.get::<_, i32>(6)? != 0,
+                source_note_id: row.get(7)?,
+                fire_count: row.get::<_, i64>(8)? as u64,
+                created_at,
+                updated_at,
+            })
+        }).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    async fn disable_procedural_rule(&self, rule_id: &str) -> Result<()> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE procedural_rules SET enabled = 0, updated_at = ?2 WHERE id = ?1",
+            rusqlite::params![rule_id, now],
+        ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn increment_rule_fire_count(&self, rule_id: &str) -> Result<()> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE procedural_rules SET fire_count = fire_count + 1, updated_at = ?2 WHERE id = ?1",
+            rusqlite::params![rule_id, now],
+        ).map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        Ok(())
     }
 }

--- a/crates/karta-core/src/store/sqlite.rs
+++ b/crates/karta-core/src/store/sqlite.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 
 use crate::dream::DreamRun;
 use crate::error::{KartaError, Result};
+use crate::migrate;
 use crate::note::EvolutionRecord;
 
 pub struct SqliteGraphStore {
@@ -172,6 +173,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
             ",
         )
         .map_err(|e| KartaError::GraphStore(e.to_string()))?;
+
+        // Initialize schema_meta table and apply pending migrations
+        migrate::init_and_migrate(&conn)?;
+
         Ok(())
     }
 
@@ -787,5 +792,10 @@ impl crate::store::GraphStore for SqliteGraphStore {
         let ids = stmt.query_map(rusqlite::params![entity], |row| row.get(0))
             .map_err(|e| KartaError::GraphStore(e.to_string()))?;
         Ok(ids.filter_map(|r| r.ok()).collect())
+    }
+
+    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta> {
+        let conn = self.conn.lock().map_err(|e| KartaError::GraphStore(e.to_string()))?;
+        migrate::load_schema_meta(&conn)
     }
 }

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -145,4 +145,7 @@ pub trait GraphStore: Send + Sync {
 
     /// Initialize tables/schema if needed.
     async fn init(&self) -> Result<()>;
+
+    /// Get current schema metadata (version, applied/pending migrations).
+    async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta>;
 }

--- a/crates/karta-core/src/store/traits.rs
+++ b/crates/karta-core/src/store/traits.rs
@@ -148,4 +148,11 @@ pub trait GraphStore: Send + Sync {
 
     /// Get current schema metadata (version, applied/pending migrations).
     async fn get_schema_meta(&self) -> Result<crate::migrate::SchemaMeta>;
+
+    // --- Procedural Rules (Issue #6) ---
+
+    async fn upsert_procedural_rule(&self, _rule: &crate::rules::ProceduralRule) -> Result<()> { Ok(()) }
+    async fn list_procedural_rules(&self) -> Result<Vec<crate::rules::ProceduralRule>> { Ok(Vec::new()) }
+    async fn disable_procedural_rule(&self, _rule_id: &str) -> Result<()> { Ok(()) }
+    async fn increment_rule_fire_count(&self, _rule_id: &str) -> Result<()> { Ok(()) }
 }


### PR DESCRIPTION
## Summary
- Add `RuleEngine` with `ProceduralRule`, `RuleCondition`, and `RuleAction` types
- `procedural_rules` SQLite table with condition/actions JSON, fire_count tracking
- `GraphStore` trait gains upsert/list/disable/increment methods for procedural rules
- `SqliteGraphStore` implements full CRUD
- `Karta` gains `evaluate_rules`, `add_rule`, `disable_rule`, `list_rules` convenience methods
- Rule actions constrained to safe prompt/retrieval modifications only
- Rules can be sourced from notes and marked protected from forgetting
- Fired rules returned in evaluation traces with fire count updates

## Acceptance criteria
- [x] Rules can be created, listed, disabled, and evaluated
- [x] Rule actions are constrained to safe prompt/retrieval modifications
- [x] Fired rules are returned in traces
- [x] Rule fire counts update after evaluation
- [x] Rules can be sourced from notes and protected from forgetting

Closes #6