### PR TITLE
Add automatic Karta context injection for pi

### DIFF
--- a/.pi/extensions/karta.ts
+++ b/.pi/extensions/karta.ts
@@ -18,9 +18,11 @@ const KARTA_USAGE_GUIDELINES = [
 
 const AUTO_CONTEXT_DEFAULT_TOP_K = 5;
 const AUTO_CONTEXT_DEFAULT_MAX_CHARS = 4_000;
+const MAX_AUTO_CONTEXT_QUERY_CHARS = 16_000;
 
 const HARD_TOKEN_PATTERNS = [
   /`([^`]+)`/g,
+  /@[A-Za-z0-9_.-]+\/[A-Za-z0-9_.\/-]+/g,
   /[A-Za-z0-9_.-]+\/[A-Za-z0-9_./-]+/g,
   /\b[A-Z_][A-Z0-9_]{2,}\b/g,
   /\b[A-Z][A-Za-z0-9_]{2,}\b/g,
@@ -77,13 +79,23 @@ function extractHardTokens(text: string): string[] {
 
 function buildAutoContextQuery(prompt: string, cwd: string | undefined): string {
   const hardTokens = extractHardTokens(prompt);
-  return [
-    prompt,
+  const suffixParts = [
     cwd ? `cwd:${cwd}` : undefined,
     hardTokens.length ? `exact tokens: ${hardTokens.join(" ")}` : undefined,
-  ]
-    .filter(Boolean)
-    .join("\n");
+  ].filter(Boolean);
+  const suffix = suffixParts.length ? `\n${suffixParts.join("\n")}` : "";
+
+  if (prompt.length + suffix.length <= MAX_AUTO_CONTEXT_QUERY_CHARS) {
+    return `${prompt}${suffix}`;
+  }
+
+  const ellipsis = "\n…[query truncated]";
+  const promptBudget = Math.max(0, MAX_AUTO_CONTEXT_QUERY_CHARS - suffix.length - ellipsis.length);
+  if (promptBudget > 0) {
+    return `${prompt.slice(0, promptBudget).trimEnd()}${ellipsis}${suffix}`;
+  }
+
+  return truncateText(suffix.trimStart(), MAX_AUTO_CONTEXT_QUERY_CHARS);
 }
 
 function getStringField(value: unknown, field: string): string | undefined {
@@ -99,7 +111,12 @@ function getNumberField(value: unknown, field: string): number | undefined {
 }
 
 function formatAutoContext(result: JsonObject, maxChars: number): string | undefined {
-  const hits = Array.isArray(result.results) ? result.results : [];
+  const data = result.data && typeof result.data === "object" ? (result.data as JsonObject) : undefined;
+  const hits = Array.isArray(data?.results)
+    ? data.results
+    : Array.isArray(result.results)
+      ? result.results
+      : [];
   const blocks: string[] = [];
 
   for (const hit of hits) {

--- a/.pi/extensions/karta.ts
+++ b/.pi/extensions/karta.ts
@@ -16,6 +16,18 @@ const KARTA_USAGE_GUIDELINES = [
   "Search Karta before answering questions that may depend on prior project context or decisions.",
 ];
 
+const AUTO_CONTEXT_DEFAULT_TOP_K = 5;
+const AUTO_CONTEXT_DEFAULT_MAX_CHARS = 4_000;
+
+const HARD_TOKEN_PATTERNS = [
+  /`([^`]+)`/g,
+  /[A-Za-z0-9_.-]+\/[A-Za-z0-9_./-]+/g,
+  /\b[A-Z_][A-Z0-9_]{2,}\b/g,
+  /\b[A-Z][A-Za-z0-9_]{2,}\b/g,
+  /#[0-9]+\b/g,
+  /\b[A-Za-z0-9_.-]+@[0-9][A-Za-z0-9_.-]*\b/g,
+];
+
 type JsonObject = Record<string, unknown>;
 type ExecFileFailure = Error & { stdout?: string; stderr?: string; code?: unknown; signal?: unknown };
 
@@ -30,6 +42,108 @@ function topK(value: unknown): string {
   const parsed = Number(value ?? 5);
   const clamped = Math.max(1, Math.min(100, Number.isFinite(parsed) ? Math.trunc(parsed) : 5));
   return String(clamped);
+}
+
+function envFlag(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return defaultValue;
+  return !["0", "false", "no", "off"].includes(raw.toLowerCase());
+}
+
+function envInt(name: string, defaultValue: number, min: number, max: number): number {
+  const parsed = Number(process.env[name]);
+  if (!Number.isFinite(parsed)) return defaultValue;
+  return Math.max(min, Math.min(max, Math.trunc(parsed)));
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 24)).trimEnd()}\n…[truncated]`;
+}
+
+function extractHardTokens(text: string): string[] {
+  const tokens = new Set<string>();
+
+  for (const pattern of HARD_TOKEN_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const token = (match[1] ?? match[0]).trim();
+      if (token.length >= 2 && token.length <= 160) tokens.add(token);
+    }
+  }
+
+  return [...tokens].slice(0, 24);
+}
+
+function buildAutoContextQuery(prompt: string, cwd: string | undefined): string {
+  const hardTokens = extractHardTokens(prompt);
+  return [
+    prompt,
+    cwd ? `cwd:${cwd}` : undefined,
+    hardTokens.length ? `exact tokens: ${hardTokens.join(" ")}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function getStringField(value: unknown, field: string): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const fieldValue = (value as JsonObject)[field];
+  return typeof fieldValue === "string" ? fieldValue : undefined;
+}
+
+function getNumberField(value: unknown, field: string): number | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const fieldValue = (value as JsonObject)[field];
+  return typeof fieldValue === "number" && Number.isFinite(fieldValue) ? fieldValue : undefined;
+}
+
+function formatAutoContext(result: JsonObject, maxChars: number): string | undefined {
+  const hits = Array.isArray(result.results) ? result.results : [];
+  const blocks: string[] = [];
+
+  for (const hit of hits) {
+    if (!hit || typeof hit !== "object") continue;
+    const hitObject = hit as JsonObject;
+    const note = hitObject.note;
+    if (!note || typeof note !== "object") continue;
+
+    const id = getStringField(note, "id") ?? "unknown";
+    const content = getStringField(note, "content");
+    if (!content?.trim()) continue;
+
+    const score = getNumberField(hitObject, "score");
+    const updatedAt = getStringField(note, "updated_at") ?? getStringField(note, "created_at");
+    const provenance = getStringField(note, "provenance");
+    const keywords = Array.isArray((note as JsonObject).keywords)
+      ? ((note as JsonObject).keywords as unknown[]).filter((item): item is string => typeof item === "string").slice(0, 6)
+      : [];
+
+    const metadata = [
+      `id=${id}`,
+      score === undefined ? undefined : `score=${score.toFixed(3)}`,
+      updatedAt ? `updated=${updatedAt}` : undefined,
+      provenance ? `provenance=${provenance}` : undefined,
+      keywords.length ? `keywords=${keywords.join(", ")}` : undefined,
+    ]
+      .filter(Boolean)
+      .join("; ");
+
+    blocks.push(`- ${metadata}\n  ${truncateText(content.replace(/\s+/g, " ").trim(), 700)}`);
+  }
+
+  if (!blocks.length) return undefined;
+
+  return truncateText(
+    [
+      "Relevant durable Karta memories were retrieved automatically for this turn.",
+      "Use them as background context only when relevant; prefer current user instructions and repository state if they conflict.",
+      "Do not expose private memory details unless the user asks about memory.",
+      "",
+      ...blocks,
+    ].join("\n"),
+    maxChars,
+  );
 }
 
 async function runKarta(args: string[], signal?: AbortSignal): Promise<JsonObject> {
@@ -122,7 +236,33 @@ function toolResult(result: JsonObject) {
 
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
-    ctx.ui.setStatus("karta", process.env.KARTA_BIN ? "Karta memory" : "Karta memory (cargo)");
+    const mode = process.env.KARTA_BIN ? "Karta memory" : "Karta memory (cargo)";
+    const auto = envFlag("KARTA_AUTO_CONTEXT", true) ? ", auto-context" : "";
+    ctx.ui.setStatus("karta", `${mode}${auto}`);
+  });
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    if (!envFlag("KARTA_AUTO_CONTEXT", true)) return;
+
+    const topKValue = envInt("KARTA_AUTO_CONTEXT_TOP_K", AUTO_CONTEXT_DEFAULT_TOP_K, 1, 20);
+    const maxChars = envInt("KARTA_AUTO_CONTEXT_MAX_CHARS", AUTO_CONTEXT_DEFAULT_MAX_CHARS, 500, 20_000);
+    const query = buildAutoContextQuery(event.prompt, event.systemPromptOptions.cwd);
+
+    try {
+      const result = await runKarta(["search", "--query", query, "--top-k", String(topKValue)], ctx.signal);
+      const content = formatAutoContext(result, maxChars);
+      if (!content) return;
+
+      return {
+        message: {
+          customType: "karta-memory",
+          content,
+          display: envFlag("KARTA_AUTO_CONTEXT_DISPLAY", false),
+        },
+      };
+    } catch (error) {
+      ctx.ui.notify(`Karta auto-context failed: ${(error as Error).message}`, "warning");
+    }
   });
 
   pi.registerTool({

--- a/README.md
+++ b/README.md
@@ -209,9 +209,21 @@ export KARTA_LANCE_URI=.karta/lance   # optional LanceDB URI override
 export KARTA_TIMEOUT_MS=120000        # extension command timeout
 ```
 
-Memory policy instructions for pi live in `.pi/APPEND_SYSTEM.md`. The extension
-intentionally starts with explicit tools only; automatic recall/write should be
-added only after memory quality is validated.
+The pi extension also performs automatic memory recall before each agent turn.
+It builds a search query from the user prompt, cwd, and exact-match tokens such
+as paths, symbols, constants, issue IDs, and code spans, then injects a compact,
+provenance-rich memory message. Configure it with:
+
+```bash
+export KARTA_AUTO_CONTEXT=0             # disable automatic recall
+export KARTA_AUTO_CONTEXT_TOP_K=5       # retrieved memories, 1-20
+export KARTA_AUTO_CONTEXT_MAX_CHARS=4000 # injected context budget
+export KARTA_AUTO_CONTEXT_DISPLAY=1     # show injected memory messages in the TUI
+```
+
+Memory policy instructions for pi live in `.pi/APPEND_SYSTEM.md`. Automatic
+recall is intentionally read-only; writes still happen through explicit memory
+tools so durable memory promotion remains conservative.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- add a pi `before_agent_start` hook that automatically retrieves relevant Karta memories
- enrich recall queries with cwd and exact-match tokens like paths, symbols, constants, issues, packages, and code spans
- inject compact, provenance-rich memory context with env controls for top-k, budget, display, and disabling
- document the automatic recall configuration

## Test
- `cargo check -q -p karta-cli`

Note: this PR is opened against the fork only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Karta extension now automatically retrieves and injects relevant memory notes as context before each agent turn, extracting keywords from user prompts and current environment.
  * Configurable via environment variables for auto-recall enablement, retrieval result count, and maximum context size.

* **Documentation**
  * Updated integration guide with automatic memory recall behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->