### PR TITLE
Add scope metadata to memory notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # GitHub's hosted Linux runners can trip rust-lld bus errors while linking
+  # several large test binaries in parallel. Keep CI linking serial and force
+  # lld to a single worker so failures stay about code, not runner memory.
+  CARGO_BUILD_JOBS: 1
+  RUSTFLAGS: -C link-arg=-Wl,--threads=1
 
 jobs:
   check:

--- a/crates/karta-cli/src/main.rs
+++ b/crates/karta-cli/src/main.rs
@@ -1,7 +1,11 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
-use karta_core::{Karta, config::KartaConfig, note::MemoryNote};
+use karta_core::{
+    Karta,
+    config::KartaConfig,
+    note::{MemoryNote, normalize_scope_id, normalize_scope_type, normalize_source_ref},
+};
 use serde::Serialize;
 use serde_json::json;
 
@@ -214,9 +218,12 @@ async fn run(cli: Cli) -> Result<()> {
             scope_id,
             source_ref,
         } => {
-            let has_scope = scope_type.is_some() || scope_id.is_some() || source_ref.is_some();
-            let scope_type = scope_type.as_deref().unwrap_or("global");
-            let scope_id = scope_id.as_deref().unwrap_or("default");
+            let normalized_scope_type = normalize_scope_type(scope_type.as_deref());
+            let normalized_scope_id = normalize_scope_id(scope_id.as_deref());
+            let normalized_source_ref = normalize_source_ref(source_ref.as_deref());
+            let has_scope = scope_type.as_deref().is_some_and(|s| !s.trim().is_empty())
+                || scope_id.as_deref().is_some_and(|s| !s.trim().is_empty())
+                || normalized_source_ref.is_some();
             let note = match (
                 session_id.as_deref(),
                 turn_index,
@@ -232,9 +239,9 @@ async fn run(cli: Cli) -> Result<()> {
                             session_id,
                             turn_index,
                             source_timestamp,
-                            scope_type,
-                            scope_id,
-                            source_ref.as_deref(),
+                            &normalized_scope_type,
+                            &normalized_scope_id,
+                            normalized_source_ref.as_deref(),
                         )
                         .await?
                 }
@@ -250,9 +257,9 @@ async fn run(cli: Cli) -> Result<()> {
                         .add_note_with_session_scoped(
                             &content,
                             session_id,
-                            scope_type,
-                            scope_id,
-                            source_ref.as_deref(),
+                            &normalized_scope_type,
+                            &normalized_scope_id,
+                            normalized_source_ref.as_deref(),
                         )
                         .await?
                 }
@@ -261,7 +268,12 @@ async fn run(cli: Cli) -> Result<()> {
                 }
                 (None, None, None, true) => {
                     karta
-                        .add_note_scoped(&content, scope_type, scope_id, source_ref.as_deref())
+                        .add_note_scoped(
+                            &content,
+                            &normalized_scope_type,
+                            &normalized_scope_id,
+                            normalized_source_ref.as_deref(),
+                        )
                         .await?
                 }
                 (None, None, None, false) => karta.add_note(&content).await?,

--- a/crates/karta-cli/src/main.rs
+++ b/crates/karta-cli/src/main.rs
@@ -53,6 +53,18 @@ enum Commands {
         /// Optional source timestamp as RFC3339/ISO-8601.
         #[arg(long)]
         source_timestamp: Option<DateTime<Utc>>,
+
+        /// Optional memory scope type (for example: global, repo, workspace).
+        #[arg(long)]
+        scope_type: Option<String>,
+
+        /// Optional memory scope identifier (for repo scopes, prefer remote URL or canonical path).
+        #[arg(long)]
+        scope_id: Option<String>,
+
+        /// Optional source reference, such as a file path, issue URL, or conversation id.
+        #[arg(long)]
+        source_ref: Option<String>,
     },
 
     /// Search stored memories by semantic similarity.
@@ -198,20 +210,62 @@ async fn run(cli: Cli) -> Result<()> {
             session_id,
             turn_index,
             source_timestamp,
+            scope_type,
+            scope_id,
+            source_ref,
         } => {
-            let note = match (session_id.as_deref(), turn_index, source_timestamp) {
-                (Some(session_id), turn_index, source_timestamp)
+            let has_scope = scope_type.is_some() || scope_id.is_some() || source_ref.is_some();
+            let scope_type = scope_type.as_deref().unwrap_or("global");
+            let scope_id = scope_id.as_deref().unwrap_or("default");
+            let note = match (
+                session_id.as_deref(),
+                turn_index,
+                source_timestamp,
+                has_scope,
+            ) {
+                (Some(session_id), turn_index, source_timestamp, true)
+                    if turn_index.is_some() || source_timestamp.is_some() =>
+                {
+                    karta
+                        .add_note_with_metadata_scoped(
+                            &content,
+                            session_id,
+                            turn_index,
+                            source_timestamp,
+                            scope_type,
+                            scope_id,
+                            source_ref.as_deref(),
+                        )
+                        .await?
+                }
+                (Some(session_id), turn_index, source_timestamp, false)
                     if turn_index.is_some() || source_timestamp.is_some() =>
                 {
                     karta
                         .add_note_with_metadata(&content, session_id, turn_index, source_timestamp)
                         .await?
                 }
-                (Some(session_id), _, _) => {
+                (Some(session_id), _, _, true) => {
+                    karta
+                        .add_note_with_session_scoped(
+                            &content,
+                            session_id,
+                            scope_type,
+                            scope_id,
+                            source_ref.as_deref(),
+                        )
+                        .await?
+                }
+                (Some(session_id), _, _, false) => {
                     karta.add_note_with_session(&content, session_id).await?
                 }
-                (None, None, None) => karta.add_note(&content).await?,
-                (None, Some(_), _) | (None, _, Some(_)) => {
+                (None, None, None, true) => {
+                    karta
+                        .add_note_scoped(&content, scope_type, scope_id, source_ref.as_deref())
+                        .await?
+                }
+                (None, None, None, false) => karta.add_note(&content).await?,
+                (None, Some(_), _, _) | (None, _, Some(_), _) => {
                     anyhow::bail!("--turn-index and --source-timestamp require --session-id")
                 }
             };

--- a/crates/karta-core/src/dream/engine.rs
+++ b/crates/karta-core/src/dream/engine.rs
@@ -559,6 +559,9 @@ impl DreamEngine {
             access_count: 0,
             access_history: Vec::new(),
             session_id: None,
+            scope_type: crate::note::default_scope_type(),
+            scope_id: crate::note::default_scope_id(),
+            source_ref: None,
         };
 
         self.vector_store.upsert(&note).await?;
@@ -698,6 +701,9 @@ impl DreamEngine {
             access_count: 0,
             access_history: Vec::new(),
             session_id: None,
+            scope_type: crate::note::default_scope_type(),
+            scope_id: crate::note::default_scope_id(),
+            source_ref: None,
         };
 
         self.vector_store.upsert(&note).await?;
@@ -875,6 +881,9 @@ impl DreamEngine {
                 access_count: 0,
                 access_history: Vec::new(),
                 session_id: None,
+                scope_type: crate::note::default_scope_type(),
+                scope_id: crate::note::default_scope_id(),
+                source_ref: None,
             };
 
             digest_note_id = Some(note.id.clone());

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -182,15 +182,9 @@ impl Karta {
         scope_id: &str,
         source_ref: Option<&str>,
     ) -> Result<MemoryNote> {
-        let mut note = self
-            .write_engine
-            .add_note_with_session(content, session_id)
-            .await?;
-        note.scope_type = scope_type.to_string();
-        note.scope_id = scope_id.to_string();
-        note.source_ref = source_ref.map(str::to_string);
-        self.vector_store.upsert(&note).await?;
-        Ok(note)
+        self.write_engine
+            .add_note_with_session_scoped(content, session_id, scope_type, scope_id, source_ref)
+            .await
     }
 
     /// Add a note with explicit memory scope metadata.
@@ -201,12 +195,9 @@ impl Karta {
         scope_id: &str,
         source_ref: Option<&str>,
     ) -> Result<MemoryNote> {
-        let mut note = self.write_engine.add_note(content).await?;
-        note.scope_type = scope_type.to_string();
-        note.scope_id = scope_id.to_string();
-        note.source_ref = source_ref.map(str::to_string);
-        self.vector_store.upsert(&note).await?;
-        Ok(note)
+        self.write_engine
+            .add_note_scoped(content, scope_type, scope_id, source_ref)
+            .await
     }
 
     /// Add a note with session context and optional temporal metadata.
@@ -246,12 +237,16 @@ impl Karta {
         source_ref: Option<&str>,
     ) -> Result<MemoryNote> {
         let mut note = self
-            .add_note_with_metadata(content, session_id, turn_index, source_timestamp)
+            .write_engine
+            .add_note_with_session_scoped(content, session_id, scope_type, scope_id, source_ref)
             .await?;
-        note.scope_type = scope_type.to_string();
-        note.scope_id = scope_id.to_string();
-        note.source_ref = source_ref.map(str::to_string);
-        self.vector_store.upsert(&note).await?;
+
+        if turn_index.is_some() || source_timestamp.is_some() {
+            note.turn_index = turn_index;
+            note.source_timestamp = source_timestamp;
+            self.vector_store.upsert(&note).await?;
+        }
+
         Ok(note)
     }
 

--- a/crates/karta-core/src/karta.rs
+++ b/crates/karta-core/src/karta.rs
@@ -173,6 +173,42 @@ impl Karta {
             .await
     }
 
+    /// Add a session-linked note with explicit memory scope metadata.
+    pub async fn add_note_with_session_scoped(
+        &self,
+        content: &str,
+        session_id: &str,
+        scope_type: &str,
+        scope_id: &str,
+        source_ref: Option<&str>,
+    ) -> Result<MemoryNote> {
+        let mut note = self
+            .write_engine
+            .add_note_with_session(content, session_id)
+            .await?;
+        note.scope_type = scope_type.to_string();
+        note.scope_id = scope_id.to_string();
+        note.source_ref = source_ref.map(str::to_string);
+        self.vector_store.upsert(&note).await?;
+        Ok(note)
+    }
+
+    /// Add a note with explicit memory scope metadata.
+    pub async fn add_note_scoped(
+        &self,
+        content: &str,
+        scope_type: &str,
+        scope_id: &str,
+        source_ref: Option<&str>,
+    ) -> Result<MemoryNote> {
+        let mut note = self.write_engine.add_note(content).await?;
+        note.scope_type = scope_type.to_string();
+        note.scope_id = scope_id.to_string();
+        note.source_ref = source_ref.map(str::to_string);
+        self.vector_store.upsert(&note).await?;
+        Ok(note)
+    }
+
     /// Add a note with session context and optional temporal metadata.
     /// `turn_index`: position of this message within its conversation (0-indexed).
     /// `source_timestamp`: original timestamp from source data (distinct from ingestion time).
@@ -194,6 +230,28 @@ impl Karta {
             self.vector_store.upsert(&note).await?;
         }
 
+        Ok(note)
+    }
+
+    /// Add a note with session, temporal metadata, and explicit scope metadata.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn add_note_with_metadata_scoped(
+        &self,
+        content: &str,
+        session_id: &str,
+        turn_index: Option<u32>,
+        source_timestamp: Option<DateTime<Utc>>,
+        scope_type: &str,
+        scope_id: &str,
+        source_ref: Option<&str>,
+    ) -> Result<MemoryNote> {
+        let mut note = self
+            .add_note_with_metadata(content, session_id, turn_index, source_timestamp)
+            .await?;
+        note.scope_type = scope_type.to_string();
+        note.scope_id = scope_id.to_string();
+        note.source_ref = source_ref.map(str::to_string);
+        self.vector_store.upsert(&note).await?;
         Ok(note)
     }
 

--- a/crates/karta-core/src/note.rs
+++ b/crates/karta-core/src/note.rs
@@ -52,6 +52,23 @@ pub struct MemoryNote {
     /// Session this note was written in — required for PAS sequential linkage.
     #[serde(default)]
     pub session_id: Option<String>,
+    /// Scope namespace used to keep memories from different projects/repos separate.
+    #[serde(default = "default_scope_type")]
+    pub scope_type: String,
+    /// Scope identifier within `scope_type` (for repos, prefer remote URL or canonical path).
+    #[serde(default = "default_scope_id")]
+    pub scope_id: String,
+    /// Optional human-readable source reference such as a file path, issue, or conversation id.
+    #[serde(default)]
+    pub source_ref: Option<String>,
+}
+
+pub fn default_scope_type() -> String {
+    "global".to_string()
+}
+
+pub fn default_scope_id() -> String {
+    "default".to_string()
 }
 
 /// Maximum stamps retained in `MemoryNote::access_history`. Keeps per-note
@@ -82,6 +99,9 @@ impl MemoryNote {
             access_count: 0,
             access_history: Vec::new(),
             session_id: None,
+            scope_type: default_scope_type(),
+            scope_id: default_scope_id(),
+            source_ref: None,
         }
     }
 
@@ -472,4 +492,40 @@ pub enum NoteStatus {
         by: String,
     },
     Archived,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_note_deserializes_legacy_scope_defaults() {
+        let note: MemoryNote = serde_json::from_value(serde_json::json!({
+            "id": "note-1",
+            "content": "legacy",
+            "context": "",
+            "keywords": [],
+            "tags": [],
+            "links": [],
+            "created_at": "2026-04-28T00:00:00Z",
+            "updated_at": "2026-04-28T00:00:00Z",
+            "evolution_history": [],
+            "provenance": "Observed",
+            "confidence": 1.0
+        }))
+        .expect("legacy note should deserialize");
+
+        assert_eq!(note.scope_type, "global");
+        assert_eq!(note.scope_id, "default");
+        assert_eq!(note.source_ref, None);
+    }
+
+    #[test]
+    fn new_memory_note_uses_global_default_scope() {
+        let note = MemoryNote::new("remember this".to_string());
+
+        assert_eq!(note.scope_type, "global");
+        assert_eq!(note.scope_id, "default");
+        assert_eq!(note.source_ref, None);
+    }
 }

--- a/crates/karta-core/src/note.rs
+++ b/crates/karta-core/src/note.rs
@@ -63,12 +63,38 @@ pub struct MemoryNote {
     pub source_ref: Option<String>,
 }
 
+pub const DEFAULT_SCOPE_TYPE: &str = "global";
+pub const DEFAULT_SCOPE_ID: &str = "default";
+
 pub fn default_scope_type() -> String {
-    "global".to_string()
+    DEFAULT_SCOPE_TYPE.to_string()
 }
 
 pub fn default_scope_id() -> String {
-    "default".to_string()
+    DEFAULT_SCOPE_ID.to_string()
+}
+
+pub fn normalize_scope_type(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(default_scope_type)
+}
+
+pub fn normalize_scope_id(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(default_scope_id)
+}
+
+pub fn normalize_source_ref(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 /// Maximum stamps retained in `MemoryNote::access_history`. Keeps per-note
@@ -527,5 +553,18 @@ mod tests {
         assert_eq!(note.scope_type, "global");
         assert_eq!(note.scope_id, "default");
         assert_eq!(note.source_ref, None);
+    }
+
+    #[test]
+    fn scope_input_normalization_trims_and_defaults_empty_values() {
+        assert_eq!(normalize_scope_type(Some(" repo ")), "repo");
+        assert_eq!(normalize_scope_type(Some("   ")), "global");
+        assert_eq!(normalize_scope_id(Some(" project-1 ")), "project-1");
+        assert_eq!(normalize_scope_id(Some("")), "default");
+        assert_eq!(
+            normalize_source_ref(Some(" file.rs ")).as_deref(),
+            Some("file.rs")
+        );
+        assert_eq!(normalize_source_ref(Some("   ")), None);
     }
 }

--- a/crates/karta-core/src/store/lance.rs
+++ b/crates/karta-core/src/store/lance.rs
@@ -64,6 +64,9 @@ impl LanceVectorStore {
             Field::new("access_count", DataType::Utf8, true),
             Field::new("access_history_json", DataType::Utf8, true),
             Field::new("session_id", DataType::Utf8, true),
+            Field::new("scope_type", DataType::Utf8, true),
+            Field::new("scope_id", DataType::Utf8, true),
+            Field::new("source_ref", DataType::Utf8, true),
             Field::new(
                 "vector",
                 DataType::FixedSizeList(
@@ -105,6 +108,15 @@ impl LanceVectorStore {
         if !existing_names.contains("session_id") {
             to_add.push(("session_id".into(), "CAST(NULL AS STRING)".into()));
         }
+        if !existing_names.contains("scope_type") {
+            to_add.push(("scope_type".into(), "CAST(NULL AS STRING)".into()));
+        }
+        if !existing_names.contains("scope_id") {
+            to_add.push(("scope_id".into(), "CAST(NULL AS STRING)".into()));
+        }
+        if !existing_names.contains("source_ref") {
+            to_add.push(("source_ref".into(), "CAST(NULL AS STRING)".into()));
+        }
         if to_add.is_empty() {
             return Ok(());
         }
@@ -114,7 +126,7 @@ impl LanceVectorStore {
             .await
             .map_err(|e| {
                 KartaError::VectorStore(format!(
-                    "ACTIVATE: failed to migrate notes table schema (access_count / access_history_json / session_id); refusing to continue so writes don't diverge from reader schema: {}",
+                    "failed to migrate notes table schema (access_count / access_history_json / session_id / scope fields); refusing to continue so writes don't diverge from reader schema: {}",
                     e
                 ))
             })?;
@@ -376,6 +388,7 @@ impl LanceVectorStore {
                 .collect::<Vec<_>>(),
         )?;
         let session_id_str = note.session_id.clone().unwrap_or_default();
+        let source_ref_str = note.source_ref.clone().unwrap_or_default();
 
         let batch = RecordBatch::try_new(
             Self::schema(),
@@ -396,6 +409,9 @@ impl LanceVectorStore {
                 Arc::new(StringArray::from(vec![access_count_str.as_str()])),
                 Arc::new(StringArray::from(vec![access_history_json.as_str()])),
                 Arc::new(StringArray::from(vec![session_id_str.as_str()])),
+                Arc::new(StringArray::from(vec![note.scope_type.as_str()])),
+                Arc::new(StringArray::from(vec![note.scope_id.as_str()])),
+                Arc::new(StringArray::from(vec![source_ref_str.as_str()])),
                 Arc::new(vector_array),
             ],
         )
@@ -479,6 +495,9 @@ impl LanceVectorStore {
         let access_count_strs = Self::get_str_opt(batch, "access_count");
         let access_history_jsons = Self::get_str_opt(batch, "access_history_json");
         let session_id_strs = Self::get_str_opt(batch, "session_id");
+        let scope_type_strs = Self::get_str_opt(batch, "scope_type");
+        let scope_id_strs = Self::get_str_opt(batch, "scope_id");
+        let source_ref_strs = Self::get_str_opt(batch, "source_ref");
 
         let vector_col = batch
             .column_by_name("vector")
@@ -536,6 +555,26 @@ impl LanceVectorStore {
                 .flatten()
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_string());
+            let scope_type = scope_type_strs
+                .get(i)
+                .copied()
+                .flatten()
+                .filter(|s| !s.is_empty())
+                .unwrap_or("global")
+                .to_string();
+            let scope_id = scope_id_strs
+                .get(i)
+                .copied()
+                .flatten()
+                .filter(|s| !s.is_empty())
+                .unwrap_or("default")
+                .to_string();
+            let source_ref = source_ref_strs
+                .get(i)
+                .copied()
+                .flatten()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
 
             notes.push(MemoryNote {
                 id: ids.value(i).to_string(),
@@ -574,6 +613,9 @@ impl LanceVectorStore {
                 access_count,
                 access_history,
                 session_id,
+                scope_type,
+                scope_id,
+                source_ref,
             });
         }
 

--- a/crates/karta-core/src/store/lance.rs
+++ b/crates/karta-core/src/store/lance.rs
@@ -14,7 +14,10 @@ use lancedb::{
 use tokio::sync::RwLock;
 
 use crate::error::{KartaError, Result};
-use crate::note::{ACCESS_HISTORY_CAP, MemoryNote, NoteStatus, Provenance};
+use crate::note::{
+    ACCESS_HISTORY_CAP, DEFAULT_SCOPE_ID, DEFAULT_SCOPE_TYPE, MemoryNote, NoteStatus, Provenance,
+    default_scope_id, default_scope_type,
+};
 
 const TABLE_NAME: &str = "notes";
 const FACTS_TABLE_NAME: &str = "atomic_facts";
@@ -109,10 +112,16 @@ impl LanceVectorStore {
             to_add.push(("session_id".into(), "CAST(NULL AS STRING)".into()));
         }
         if !existing_names.contains("scope_type") {
-            to_add.push(("scope_type".into(), "CAST(NULL AS STRING)".into()));
+            to_add.push((
+                "scope_type".into(),
+                format!("CAST('{DEFAULT_SCOPE_TYPE}' AS STRING)"),
+            ));
         }
         if !existing_names.contains("scope_id") {
-            to_add.push(("scope_id".into(), "CAST(NULL AS STRING)".into()));
+            to_add.push((
+                "scope_id".into(),
+                format!("CAST('{DEFAULT_SCOPE_ID}' AS STRING)"),
+            ));
         }
         if !existing_names.contains("source_ref") {
             to_add.push(("source_ref".into(), "CAST(NULL AS STRING)".into()));
@@ -388,7 +397,6 @@ impl LanceVectorStore {
                 .collect::<Vec<_>>(),
         )?;
         let session_id_str = note.session_id.clone().unwrap_or_default();
-        let source_ref_str = note.source_ref.clone().unwrap_or_default();
 
         let batch = RecordBatch::try_new(
             Self::schema(),
@@ -411,7 +419,7 @@ impl LanceVectorStore {
                 Arc::new(StringArray::from(vec![session_id_str.as_str()])),
                 Arc::new(StringArray::from(vec![note.scope_type.as_str()])),
                 Arc::new(StringArray::from(vec![note.scope_id.as_str()])),
-                Arc::new(StringArray::from(vec![source_ref_str.as_str()])),
+                Arc::new(StringArray::from(vec![note.source_ref.as_deref()])),
                 Arc::new(vector_array),
             ],
         )
@@ -560,15 +568,15 @@ impl LanceVectorStore {
                 .copied()
                 .flatten()
                 .filter(|s| !s.is_empty())
-                .unwrap_or("global")
-                .to_string();
+                .map(str::to_string)
+                .unwrap_or_else(default_scope_type);
             let scope_id = scope_id_strs
                 .get(i)
                 .copied()
                 .flatten()
                 .filter(|s| !s.is_empty())
-                .unwrap_or("default")
-                .to_string();
+                .map(str::to_string)
+                .unwrap_or_else(default_scope_id);
             let source_ref = source_ref_strs
                 .get(i)
                 .copied()
@@ -837,5 +845,141 @@ impl crate::store::VectorStore for LanceVectorStore {
         }
         facts.sort_by_key(|f| f.ordinal);
         Ok(facts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::VectorStore;
+    use arrow_array::FixedSizeListArray;
+
+    fn temp_data_dir(name: &str) -> String {
+        let dir = std::env::temp_dir().join(format!("karta-{name}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("temp dir should be created");
+        dir.to_string_lossy().to_string()
+    }
+
+    #[tokio::test]
+    async fn lance_round_trips_scope_fields_and_null_source_ref() {
+        let dir = temp_data_dir("scope-roundtrip");
+        let store = LanceVectorStore::new(&dir).await.unwrap();
+
+        let mut scoped = MemoryNote::new("scoped note".to_string());
+        scoped.embedding = vec![0.0; EMBEDDING_DIM];
+        scoped.scope_type = "repo".to_string();
+        scoped.scope_id = "git@github.com:5queezer/karta.git".to_string();
+        scoped.source_ref = Some("crates/karta-core/src/store/lance.rs".to_string());
+        store.upsert(&scoped).await.unwrap();
+
+        let got = store.get(&scoped.id).await.unwrap().unwrap();
+        assert_eq!(got.scope_type, "repo");
+        assert_eq!(got.scope_id, "git@github.com:5queezer/karta.git");
+        assert_eq!(
+            got.source_ref.as_deref(),
+            Some("crates/karta-core/src/store/lance.rs")
+        );
+
+        let mut no_source = MemoryNote::new("no source".to_string());
+        no_source.embedding = vec![0.0; EMBEDDING_DIM];
+        no_source.source_ref = None;
+        store.upsert(&no_source).await.unwrap();
+
+        let got = store.get(&no_source.id).await.unwrap().unwrap();
+        assert_eq!(got.source_ref, None);
+    }
+
+    #[tokio::test]
+    async fn lance_migrates_legacy_scope_columns_to_queryable_defaults() {
+        let dir = temp_data_dir("scope-migration");
+        let uri = format!("{dir}/lance");
+        std::fs::create_dir_all(&uri).unwrap();
+        let conn = connect(&uri).execute().await.unwrap();
+
+        let legacy_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("content", DataType::Utf8, false),
+            Field::new("context", DataType::Utf8, false),
+            Field::new("keywords_json", DataType::Utf8, false),
+            Field::new("tags_json", DataType::Utf8, false),
+            Field::new("provenance_json", DataType::Utf8, false),
+            Field::new("confidence", DataType::Float32, false),
+            Field::new("created_at", DataType::Utf8, false),
+            Field::new("updated_at", DataType::Utf8, false),
+            Field::new("status_json", DataType::Utf8, true),
+            Field::new("last_accessed_at", DataType::Utf8, true),
+            Field::new("turn_index", DataType::Utf8, true),
+            Field::new("source_timestamp", DataType::Utf8, true),
+            Field::new("access_count", DataType::Utf8, true),
+            Field::new("access_history_json", DataType::Utf8, true),
+            Field::new("session_id", DataType::Utf8, true),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    EMBEDDING_DIM as i32,
+                ),
+                false,
+            ),
+        ]));
+        let now = Utc::now().to_rfc3339();
+        let vector_array = FixedSizeListArray::try_new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            EMBEDDING_DIM as i32,
+            Arc::new(Float32Array::from(vec![0.0; EMBEDDING_DIM])),
+            None,
+        )
+        .unwrap();
+        let batch = RecordBatch::try_new(
+            legacy_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["legacy-note"])),
+                Arc::new(StringArray::from(vec!["legacy content"])),
+                Arc::new(StringArray::from(vec![""])),
+                Arc::new(StringArray::from(vec!["[]"])),
+                Arc::new(StringArray::from(vec!["[]"])),
+                Arc::new(StringArray::from(vec!["\"Observed\""])),
+                Arc::new(Float32Array::from(vec![1.0])),
+                Arc::new(StringArray::from(vec![now.as_str()])),
+                Arc::new(StringArray::from(vec![now.as_str()])),
+                Arc::new(StringArray::from(vec!["\"Active\""])),
+                Arc::new(StringArray::from(vec![now.as_str()])),
+                Arc::new(StringArray::from(vec![""])),
+                Arc::new(StringArray::from(vec![""])),
+                Arc::new(StringArray::from(vec!["0"])),
+                Arc::new(StringArray::from(vec!["[]"])),
+                Arc::new(StringArray::from(vec![""])),
+                Arc::new(vector_array),
+            ],
+        )
+        .unwrap();
+        let reader = LanceVectorStore::make_reader(vec![batch], legacy_schema);
+        conn.create_table(TABLE_NAME, reader)
+            .execute()
+            .await
+            .unwrap();
+
+        let store = LanceVectorStore::new(&dir).await.unwrap();
+        let note = store.get("legacy-note").await.unwrap().unwrap();
+        assert_eq!(note.scope_type, DEFAULT_SCOPE_TYPE);
+        assert_eq!(note.scope_id, DEFAULT_SCOPE_ID);
+        assert_eq!(note.source_ref, None);
+
+        let table = store.get_table().await.unwrap();
+        let results = table
+            .query()
+            .only_if(format!(
+                "scope_type = '{DEFAULT_SCOPE_TYPE}' AND scope_id = '{DEFAULT_SCOPE_ID}'"
+            ))
+            .execute()
+            .await
+            .unwrap();
+        let rows: usize = LanceVectorStore::collect_batches(results)
+            .await
+            .unwrap()
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum();
+        assert_eq!(rows, 1);
     }
 }

--- a/crates/karta-core/src/write.rs
+++ b/crates/karta-core/src/write.rs
@@ -100,6 +100,25 @@ impl WriteEngine {
     }
 
     pub async fn add_note(&self, content: &str) -> Result<MemoryNote> {
+        self.add_note_scoped(
+            content,
+            crate::note::DEFAULT_SCOPE_TYPE,
+            crate::note::DEFAULT_SCOPE_ID,
+            None,
+        )
+        .await
+    }
+
+    pub async fn add_note_scoped(
+        &self,
+        content: &str,
+        scope_type: &str,
+        scope_id: &str,
+        source_ref: Option<&str>,
+    ) -> Result<MemoryNote> {
+        let scope_type = crate::note::normalize_scope_type(Some(scope_type));
+        let scope_id = crate::note::normalize_scope_id(Some(scope_id));
+        let source_ref = crate::note::normalize_source_ref(source_ref);
         let preview_end = {
             let max = 60;
             let mut end = content.len().min(max);
@@ -120,6 +139,9 @@ impl WriteEngine {
 
         // 2. Create the note
         let mut note = MemoryNote::new(content.to_string());
+        note.scope_type = scope_type;
+        note.scope_id = scope_id;
+        note.source_ref = source_ref;
         note.context = attrs.context;
         note.keywords = attrs.keywords;
         note.tags = attrs.tags;
@@ -285,11 +307,8 @@ impl WriteEngine {
         content: &str,
         session_id: &str,
     ) -> Result<MemoryNote> {
-        // First, add the note normally
         let mut note = self.add_note(content).await?;
 
-        // Stamp session_id + emit the "follows" edge from the previous
-        // session tail so PAS can walk the sequential chain later.
         self.emit_sequential_link(session_id, &mut note).await?;
         self.vector_store.upsert(&note).await?;
 
@@ -297,6 +316,42 @@ impl WriteEngine {
             return Ok(note);
         }
 
+        self.update_episode_for_note(content, session_id, &note)
+            .await?;
+        Ok(note)
+    }
+
+    /// Add a note within a session context with explicit scope metadata.
+    pub async fn add_note_with_session_scoped(
+        &self,
+        content: &str,
+        session_id: &str,
+        scope_type: &str,
+        scope_id: &str,
+        source_ref: Option<&str>,
+    ) -> Result<MemoryNote> {
+        let mut note = self
+            .add_note_scoped(content, scope_type, scope_id, source_ref)
+            .await?;
+
+        self.emit_sequential_link(session_id, &mut note).await?;
+        self.vector_store.upsert(&note).await?;
+
+        if !self.episode_config.enabled {
+            return Ok(note);
+        }
+
+        self.update_episode_for_note(content, session_id, &note)
+            .await?;
+        Ok(note)
+    }
+
+    async fn update_episode_for_note(
+        &self,
+        content: &str,
+        session_id: &str,
+        note: &MemoryNote,
+    ) -> Result<()> {
         // Get existing episodes for this session
         let episodes = self
             .graph_store
@@ -392,7 +447,7 @@ impl WriteEngine {
             debug!(episode_id = %ep.id, notes = all_note_ids.len(), "Extended episode");
         }
 
-        Ok(note)
+        Ok(())
     }
 
     async fn detect_episode_boundary(

--- a/crates/karta-core/src/write.rs
+++ b/crates/karta-core/src/write.rs
@@ -487,6 +487,9 @@ impl WriteEngine {
             access_count: 0,
             access_history: Vec::new(),
             session_id: None,
+            scope_type: crate::note::default_scope_type(),
+            scope_id: crate::note::default_scope_id(),
+            source_ref: None,
         };
 
         self.vector_store.upsert(&note).await?;

--- a/crates/karta-server/src/mcp.rs
+++ b/crates/karta-server/src/mcp.rs
@@ -6,7 +6,10 @@ use rmcp::{
 };
 use serde::Deserialize;
 
-use karta_core::Karta;
+use karta_core::{
+    Karta,
+    note::{normalize_scope_id, normalize_scope_type, normalize_source_ref},
+};
 
 // -- Tool parameter types --
 
@@ -108,19 +111,27 @@ impl KartaService {
         &self,
         Parameters(params): Parameters<AddNoteParams>,
     ) -> Result<CallToolResult, McpError> {
-        let has_scope =
-            params.scope_type.is_some() || params.scope_id.is_some() || params.source_ref.is_some();
-        let scope_type = params.scope_type.as_deref().unwrap_or("global");
-        let scope_id = params.scope_id.as_deref().unwrap_or("default");
+        let scope_type = normalize_scope_type(params.scope_type.as_deref());
+        let scope_id = normalize_scope_id(params.scope_id.as_deref());
+        let source_ref = normalize_source_ref(params.source_ref.as_deref());
+        let has_scope = params
+            .scope_type
+            .as_deref()
+            .is_some_and(|s| !s.trim().is_empty())
+            || params
+                .scope_id
+                .as_deref()
+                .is_some_and(|s| !s.trim().is_empty())
+            || source_ref.is_some();
         let result = match (params.session_id.as_deref(), has_scope) {
             (Some(session_id), true) => {
                 self.karta
                     .add_note_with_session_scoped(
                         &params.content,
                         session_id,
-                        scope_type,
-                        scope_id,
-                        params.source_ref.as_deref(),
+                        &scope_type,
+                        &scope_id,
+                        source_ref.as_deref(),
                     )
                     .await
             }
@@ -133,9 +144,9 @@ impl KartaService {
                 self.karta
                     .add_note_scoped(
                         &params.content,
-                        scope_type,
-                        scope_id,
-                        params.source_ref.as_deref(),
+                        &scope_type,
+                        &scope_id,
+                        source_ref.as_deref(),
                     )
                     .await
             }

--- a/crates/karta-server/src/mcp.rs
+++ b/crates/karta-server/src/mcp.rs
@@ -17,6 +17,15 @@ pub struct AddNoteParams {
     /// Optional session ID for grouping related notes
     #[serde(default)]
     pub session_id: Option<String>,
+    /// Optional memory scope type (for example: global, repo, workspace)
+    #[serde(default)]
+    pub scope_type: Option<String>,
+    /// Optional memory scope identifier
+    #[serde(default)]
+    pub scope_id: Option<String>,
+    /// Optional source reference, such as a file path, issue URL, or conversation id
+    #[serde(default)]
+    pub source_ref: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -99,12 +108,38 @@ impl KartaService {
         &self,
         Parameters(params): Parameters<AddNoteParams>,
     ) -> Result<CallToolResult, McpError> {
-        let result = if let Some(session_id) = &params.session_id {
-            self.karta
-                .add_note_with_session(&params.content, session_id)
-                .await
-        } else {
-            self.karta.add_note(&params.content).await
+        let has_scope =
+            params.scope_type.is_some() || params.scope_id.is_some() || params.source_ref.is_some();
+        let scope_type = params.scope_type.as_deref().unwrap_or("global");
+        let scope_id = params.scope_id.as_deref().unwrap_or("default");
+        let result = match (params.session_id.as_deref(), has_scope) {
+            (Some(session_id), true) => {
+                self.karta
+                    .add_note_with_session_scoped(
+                        &params.content,
+                        session_id,
+                        scope_type,
+                        scope_id,
+                        params.source_ref.as_deref(),
+                    )
+                    .await
+            }
+            (Some(session_id), false) => {
+                self.karta
+                    .add_note_with_session(&params.content, session_id)
+                    .await
+            }
+            (None, true) => {
+                self.karta
+                    .add_note_scoped(
+                        &params.content,
+                        scope_type,
+                        scope_id,
+                        params.source_ref.as_deref(),
+                    )
+                    .await
+            }
+            (None, false) => self.karta.add_note(&params.content).await,
         };
 
         match result {
@@ -117,6 +152,9 @@ impl KartaService {
                     "tags": note.tags,
                     "links": note.links,
                     "confidence": note.confidence,
+                    "scope_type": note.scope_type,
+                    "scope_id": note.scope_id,
+                    "source_ref": note.source_ref,
                     "created_at": note.created_at.to_rfc3339(),
                 });
                 Ok(CallToolResult::success(vec![Content::text(


### PR DESCRIPTION
## Summary

- add `scope_type`, `scope_id`, and `source_ref` metadata to `MemoryNote`
- persist scope fields in LanceDB with backwards-compatible defaults for legacy rows
- expose scoped add-note APIs through core, CLI, and MCP

## Test plan

- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## Notes

This is the first, storage/API-focused slice of scoped memory support. Retrieval policy/filtering can build on these persisted fields in a follow-up PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scope metadata and source reference parameters to note creation, enabling better organization and source tracking across CLI and server interfaces.

* **Chores**
  * Updated CI environment configuration for build optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->