### PR TITLE
Tune BEAM retrieval defaults

### DIFF
--- a/crates/karta-core/src/read.rs
+++ b/crates/karta-core/src/read.rs
@@ -269,14 +269,6 @@ fn classify_query_keywords(query: &str) -> QueryMode {
     QueryMode::Standard
 }
 
-fn sort_search_results_by_score(results: &mut [SearchResult]) {
-    results.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-}
-
 /// Handles the read path: search, graph traversal, reranking, synthesis.
 pub struct ReadEngine {
     vector_store: Arc<dyn VectorStore>,
@@ -885,7 +877,6 @@ impl ReadEngine {
         results.extend(episode_results);
         results.extend(fact_expanded);
         results.extend(flat_results);
-        sort_search_results_by_score(&mut results);
 
         info!(
             results = results.len(),
@@ -960,10 +951,12 @@ impl ReadEngine {
                 );
             }
 
-            // Reorder results by cross-encoder relevance, EXCEPT for Computation mode.
+            // Reorder results by cross-encoder relevance, EXCEPT for modes where
+            // sequence/completeness matters more than topical precision.
             // Computation needs factual completeness (both date notes), not topical precision.
-            // Reranker pushes date-bearing notes down because they score low on topical relevance.
-            if mode != QueryMode::Computation {
+            // Temporal/event-ordering needs chronological coverage; reranking can drop
+            // low-topical bridge events that are required to reconstruct the sequence.
+            if !matches!(mode, QueryMode::Computation | QueryMode::Temporal) {
                 let reranked_ids: HashSet<String> =
                     reranked.iter().map(|r| r.note.id.clone()).collect();
                 let mut reordered: Vec<SearchResult> = Vec::new();
@@ -993,7 +986,7 @@ impl ReadEngine {
                     "Reranker: reordered results by relevance"
                 );
             } else {
-                debug!("Reranker: skipping reorder for Computation mode (preserving ANN order)");
+                debug!(mode = ?mode, "Reranker: skipping reorder to preserve completeness/order");
             }
         }
 
@@ -1527,33 +1520,5 @@ mod tests {
             classify_query_keywords("What tools am I using?"),
             QueryMode::Existence,
         );
-    }
-
-    #[test]
-    fn search_results_are_sorted_by_score_descending() {
-        let mut results = vec![
-            SearchResult {
-                note: MemoryNote::new("low".to_string()),
-                score: 0.2,
-                linked_notes: Vec::new(),
-            },
-            SearchResult {
-                note: MemoryNote::new("high".to_string()),
-                score: 0.9,
-                linked_notes: Vec::new(),
-            },
-            SearchResult {
-                note: MemoryNote::new("mid".to_string()),
-                score: 0.5,
-                linked_notes: Vec::new(),
-            },
-        ];
-
-        sort_search_results_by_score(&mut results);
-
-        let scores: Vec<f32> = results.iter().map(|r| r.score).collect();
-        assert_eq!(scores, vec![0.9, 0.5, 0.2]);
-        let contents: Vec<&str> = results.iter().map(|r| r.note.content.as_str()).collect();
-        assert_eq!(contents, vec!["high", "mid", "low"]);
     }
 }

--- a/crates/karta-core/tests/beam_100k.rs
+++ b/crates/karta-core/tests/beam_100k.rs
@@ -294,17 +294,19 @@ fn apply_config_env(config: &mut KartaConfig) {
     config.write.extract_atomic_facts = env_bool("K_EXTRACT_FACTS", true);
     config.read.fact_retrieval_enabled = env_bool("K_FACT_RETRIEVAL", true);
     config.read.fact_match_boost = env_f32("K_FACT_BOOST", 0.1);
+    config.read.activate.enabled = env_bool("KARTA_ACTIVATE_ENABLED", true);
 
     let exp = std::env::var("K_EXPERIMENT").unwrap_or_else(|_| "default".to_string());
     println!(
-        "  Config [{}]: episode={}, ep_retrieval={}, graph={}, foresight={}, reranker={}, abstention_thresh={}",
+        "  Config [{}]: episode={}, ep_retrieval={}, graph={}, foresight={}, reranker={}, abstention_thresh={}, activate={}",
         exp,
         config.episode.enabled,
         config.read.episode_retrieval_enabled,
         config.read.graph_weight,
         config.read.foresight_boost,
         config.reranker.enabled,
-        config.reranker.abstention_threshold
+        config.reranker.abstention_threshold,
+        config.read.activate.enabled
     );
 }
 
@@ -519,7 +521,7 @@ async fn eval_conversation(
     let query_concurrency: usize = std::env::var("BEAM_QUERY_CONCURRENCY")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(3);
+        .unwrap_or(1);
     let semaphore = Arc::new(tokio::sync::Semaphore::new(query_concurrency));
     let mut ask_handles = Vec::new();
 


### PR DESCRIPTION
## Summary
- Preserve chronological coverage by skipping reranker reordering for Temporal queries, matching the kept BEAM autoresearch result.
- Remove the regressing merged-result score sort from the read path.
- Default the BEAM eval harness to ACTIVATE with serialized query concurrency to avoid Jina concurrency-limit skipped questions.

## Validation
- BEAM autoresearch validation slice previously reached 60.90% on conv indexes 0 and 3 with ACTIVATE enabled and BEAM_QUERY_CONCURRENCY=1.
- `cargo fmt --check`
- `cargo test -p karta-core --lib`
- `cargo test -p karta-core --features eval-harnesses --test beam_100k -- --list`

## Notes
- This PR targets the fork (`5queezer/karta`) only.
- Does not edit BEAM data, rubrics, judge logic, or reference answers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Search results now follow merge sequence ordering instead of score-based sorting
  * Reranker reordering disabled for Computation and Temporal modes to preserve search ordering

* **Bug Fixes**
  * Updated test configuration to track activate feature
  * Adjusted query concurrency defaults in test harness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->