### PR TITLE
Add Karta client installers

### DIFF
--- a/.pi/extensions/karta.ts
+++ b/.pi/extensions/karta.ts
@@ -31,18 +31,29 @@ const HARD_TOKEN_PATTERNS = [
 ];
 
 type JsonObject = Record<string, unknown>;
-type ExecFileFailure = Error & { stdout?: string; stderr?: string; code?: unknown; signal?: unknown };
+type ExecFileFailure = Error & {
+  stdout?: string;
+  stderr?: string;
+  code?: unknown;
+  signal?: unknown;
+};
 
-function timeoutMs(): number {
-  const raw = process.env.KARTA_TIMEOUT_MS;
-  if (!raw) return 120_000;
+function timeoutMs(
+  envName = "KARTA_TIMEOUT_MS",
+  defaultValue = 120_000,
+): number {
+  const raw = process.env[envName];
+  if (!raw) return defaultValue;
   const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120_000;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
 }
 
 function topK(value: unknown): string {
   const parsed = Number(value ?? 5);
-  const clamped = Math.max(1, Math.min(100, Number.isFinite(parsed) ? Math.trunc(parsed) : 5));
+  const clamped = Math.max(
+    1,
+    Math.min(100, Number.isFinite(parsed) ? Math.trunc(parsed) : 5),
+  );
   return String(clamped);
 }
 
@@ -52,7 +63,12 @@ function envFlag(name: string, defaultValue: boolean): boolean {
   return !["0", "false", "no", "off"].includes(raw.toLowerCase());
 }
 
-function envInt(name: string, defaultValue: number, min: number, max: number): number {
+function envInt(
+  name: string,
+  defaultValue: number,
+  min: number,
+  max: number,
+): number {
   const parsed = Number(process.env[name]);
   if (!Number.isFinite(parsed)) return defaultValue;
   return Math.max(min, Math.min(max, Math.trunc(parsed)));
@@ -77,7 +93,10 @@ function extractHardTokens(text: string): string[] {
   return [...tokens].slice(0, 24);
 }
 
-function buildAutoContextQuery(prompt: string, cwd: string | undefined): string {
+function buildAutoContextQuery(
+  prompt: string,
+  cwd: string | undefined,
+): string {
   const hardTokens = extractHardTokens(prompt);
   const suffixParts = [
     cwd ? `cwd:${cwd}` : undefined,
@@ -90,7 +109,10 @@ function buildAutoContextQuery(prompt: string, cwd: string | undefined): string 
   }
 
   const ellipsis = "\n…[query truncated]";
-  const promptBudget = Math.max(0, MAX_AUTO_CONTEXT_QUERY_CHARS - suffix.length - ellipsis.length);
+  const promptBudget = Math.max(
+    0,
+    MAX_AUTO_CONTEXT_QUERY_CHARS - suffix.length - ellipsis.length,
+  );
   if (promptBudget > 0) {
     return `${prompt.slice(0, promptBudget).trimEnd()}${ellipsis}${suffix}`;
   }
@@ -107,16 +129,23 @@ function getStringField(value: unknown, field: string): string | undefined {
 function getNumberField(value: unknown, field: string): number | undefined {
   if (!value || typeof value !== "object") return undefined;
   const fieldValue = (value as JsonObject)[field];
-  return typeof fieldValue === "number" && Number.isFinite(fieldValue) ? fieldValue : undefined;
+  return typeof fieldValue === "number" && Number.isFinite(fieldValue)
+    ? fieldValue
+    : undefined;
 }
 
-function formatAutoContext(result: JsonObject, maxChars: number): string | undefined {
-  const data = result.data && typeof result.data === "object" ? (result.data as JsonObject) : undefined;
+function formatAutoContext(
+  result: JsonObject,
+  maxChars: number,
+): string | undefined {
+  const data = result.data && typeof result.data === "object"
+    ? (result.data as JsonObject)
+    : undefined;
   const hits = Array.isArray(data?.results)
     ? data.results
     : Array.isArray(result.results)
-      ? result.results
-      : [];
+    ? result.results
+    : [];
   const blocks: string[] = [];
 
   for (const hit of hits) {
@@ -130,10 +159,13 @@ function formatAutoContext(result: JsonObject, maxChars: number): string | undef
     if (!content?.trim()) continue;
 
     const score = getNumberField(hitObject, "score");
-    const updatedAt = getStringField(note, "updated_at") ?? getStringField(note, "created_at");
+    const updatedAt = getStringField(note, "updated_at") ??
+      getStringField(note, "created_at");
     const provenance = getStringField(note, "provenance");
     const keywords = Array.isArray((note as JsonObject).keywords)
-      ? ((note as JsonObject).keywords as unknown[]).filter((item): item is string => typeof item === "string").slice(0, 6)
+      ? ((note as JsonObject).keywords as unknown[]).filter((
+        item,
+      ): item is string => typeof item === "string").slice(0, 6)
       : [];
 
     const metadata = [
@@ -146,7 +178,11 @@ function formatAutoContext(result: JsonObject, maxChars: number): string | undef
       .filter(Boolean)
       .join("; ");
 
-    blocks.push(`- ${metadata}\n  ${truncateText(content.replace(/\s+/g, " ").trim(), 700)}`);
+    blocks.push(
+      `- ${metadata}\n  ${
+        truncateText(content.replace(/\s+/g, " ").trim(), 700)
+      }`,
+    );
   }
 
   if (!blocks.length) return undefined;
@@ -163,38 +199,70 @@ function formatAutoContext(result: JsonObject, maxChars: number): string | undef
   );
 }
 
-async function runKarta(args: string[], signal?: AbortSignal): Promise<JsonObject> {
+async function runKarta(
+  args: string[],
+  signal?: AbortSignal,
+  commandTimeoutMs = timeoutMs(),
+): Promise<JsonObject> {
   const fullArgs = ["--json", ...args];
   const options = {
     env: process.env,
     maxBuffer: 10 * 1024 * 1024,
-    timeout: timeoutMs(),
+    timeout: commandTimeoutMs,
     signal,
   };
 
   try {
-    // If KARTA_BIN is set, use that binary. Otherwise, default to the workspace
-    // crate so the extension works immediately from a Karta checkout.
+    // If KARTA_BIN is set, use that binary. Otherwise, prefer an installed
+    // `karta` on PATH, falling back to the workspace crate for checkout-local use.
     const command = process.env.KARTA_BIN;
-    const result = command
-      ? await execFileAsync(command, fullArgs, options)
-      : await execFileAsync("cargo", ["run", "-q", "-p", "karta-cli", "--", ...fullArgs], options);
+    if (command) {
+      const result = await execFileAsync(command, fullArgs, options);
+      return parseKartaJson(result.stdout, "stdout");
+    }
 
+    try {
+      const result = await execFileAsync("karta", fullArgs, options);
+      return parseKartaJson(result.stdout, "stdout");
+    } catch (error) {
+      if (!isCommandNotFound(error)) throw error;
+    }
+
+    const result = await execFileAsync("cargo", [
+      "run",
+      "-q",
+      "-p",
+      "karta-cli",
+      "--",
+      ...fullArgs,
+    ], options);
     return parseKartaJson(result.stdout, "stdout");
   } catch (error) {
     throw normalizeKartaError(error);
   }
 }
 
-function parseKartaJson(output: string | undefined, streamName: string): JsonObject {
+function parseKartaJson(
+  output: string | undefined,
+  streamName: string,
+): JsonObject {
   const text = output?.trim();
   if (!text) throw new Error(`karta returned empty ${streamName}`);
 
   try {
     return JSON.parse(text) as JsonObject;
   } catch (error) {
-    throw new Error(`failed to parse karta JSON from ${streamName}: ${(error as Error).message}\n${streamName}:\n${text}`);
+    throw new Error(
+      `failed to parse karta JSON from ${streamName}: ${
+        (error as Error).message
+      }\n${streamName}:\n${text}`,
+    );
   }
+}
+
+function isCommandNotFound(error: unknown): boolean {
+  const failure = error as ExecFileFailure & { code?: unknown };
+  return failure.code === "ENOENT";
 }
 
 function normalizeKartaError(error: unknown): Error {
@@ -204,19 +272,27 @@ function normalizeKartaError(error: unknown): Error {
     return new Error("karta command cancelled");
   }
 
-  for (const [streamName, output] of [
-    ["stderr", failure.stderr],
-    ["stdout", failure.stdout],
-  ] as const) {
+  for (
+    const [streamName, output] of [
+      ["stderr", failure.stderr],
+      ["stdout", failure.stdout],
+    ] as const
+  ) {
     const text = output?.trim();
     if (!text) continue;
 
     try {
       const payload = JSON.parse(text) as JsonObject;
-      if (payload && payload.ok === false && typeof payload.error === "string") {
+      if (
+        payload && payload.ok === false && typeof payload.error === "string"
+      ) {
         return new Error(payload.error);
       }
-      return new Error(`karta failed with JSON payload on ${streamName}: ${JSON.stringify(payload)}`);
+      return new Error(
+        `karta failed with JSON payload on ${streamName}: ${
+          JSON.stringify(payload)
+        }`,
+      );
     } catch {
       // Not JSON; fall through to stderr/stdout text below.
     }
@@ -252,8 +328,12 @@ function toolResult(result: JsonObject) {
 }
 
 export default function (pi: ExtensionAPI) {
+  let autoContextPausedUntil = 0;
+
   pi.on("session_start", async (_event, ctx) => {
-    const mode = process.env.KARTA_BIN ? "Karta memory" : "Karta memory (cargo)";
+    const mode = process.env.KARTA_BIN
+      ? "Karta memory (KARTA_BIN)"
+      : "Karta memory";
     const auto = envFlag("KARTA_AUTO_CONTEXT", true) ? ", auto-context" : "";
     ctx.ui.setStatus("karta", `${mode}${auto}`);
   });
@@ -261,12 +341,39 @@ export default function (pi: ExtensionAPI) {
   pi.on("before_agent_start", async (event, ctx) => {
     if (!envFlag("KARTA_AUTO_CONTEXT", true)) return;
 
-    const topKValue = envInt("KARTA_AUTO_CONTEXT_TOP_K", AUTO_CONTEXT_DEFAULT_TOP_K, 1, 20);
-    const maxChars = envInt("KARTA_AUTO_CONTEXT_MAX_CHARS", AUTO_CONTEXT_DEFAULT_MAX_CHARS, 500, 20_000);
-    const query = buildAutoContextQuery(event.prompt, event.systemPromptOptions.cwd);
+    const now = Date.now();
+    if (now < autoContextPausedUntil) return;
+
+    const topKValue = envInt(
+      "KARTA_AUTO_CONTEXT_TOP_K",
+      AUTO_CONTEXT_DEFAULT_TOP_K,
+      1,
+      20,
+    );
+    const maxChars = envInt(
+      "KARTA_AUTO_CONTEXT_MAX_CHARS",
+      AUTO_CONTEXT_DEFAULT_MAX_CHARS,
+      500,
+      20_000,
+    );
+    const autoTimeout = timeoutMs("KARTA_AUTO_CONTEXT_TIMEOUT_MS", 10_000);
+    const cooldownMs = envInt(
+      "KARTA_AUTO_CONTEXT_COOLDOWN_MS",
+      60_000,
+      0,
+      3_600_000,
+    );
+    const query = buildAutoContextQuery(
+      event.prompt,
+      event.systemPromptOptions.cwd,
+    );
 
     try {
-      const result = await runKarta(["search", "--query", query, "--top-k", String(topKValue)], ctx.signal);
+      const result = await runKarta(
+        ["search", "--query", query, "--top-k", String(topKValue)],
+        ctx.signal,
+        autoTimeout,
+      );
       const content = formatAutoContext(result, maxChars);
       if (!content) return;
 
@@ -278,7 +385,13 @@ export default function (pi: ExtensionAPI) {
         },
       };
     } catch (error) {
-      ctx.ui.notify(`Karta auto-context failed: ${(error as Error).message}`, "warning");
+      autoContextPausedUntil = Date.now() + cooldownMs;
+      ctx.ui.notify(
+        `Karta auto-context unavailable; continuing without it${
+          cooldownMs ? ` (retrying in ${Math.round(cooldownMs / 1000)}s)` : ""
+        }: ${(error as Error).message}`,
+        "warning",
+      );
     }
   });
 
@@ -290,23 +403,51 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "Store durable project memory in Karta.",
     promptGuidelines: KARTA_USAGE_GUIDELINES,
     parameters: Type.Object({
-      content: Type.String({ description: "The durable memory content to store." }),
-      session_id: Type.Optional(Type.String({ description: "Optional session/workspace grouping ID." })),
-      turn_index: Type.Optional(Type.Integer({ minimum: 0, description: "Optional source conversation turn index. Requires session_id." })),
-      source_timestamp: Type.Optional(Type.String({ description: "Optional RFC3339 source timestamp. Requires session_id." })),
+      content: Type.String({
+        description: "The durable memory content to store.",
+      }),
+      session_id: Type.Optional(
+        Type.String({ description: "Optional session/workspace grouping ID." }),
+      ),
+      turn_index: Type.Optional(
+        Type.Integer({
+          minimum: 0,
+          description:
+            "Optional source conversation turn index. Requires session_id.",
+        }),
+      ),
+      source_timestamp: Type.Optional(
+        Type.String({
+          description:
+            "Optional RFC3339 source timestamp. Requires session_id.",
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal) {
-      if ((params.turn_index !== undefined || params.source_timestamp) && !params.session_id) {
-        throw new Error("session_id is required when turn_index or source_timestamp is provided");
+      if (
+        (params.turn_index !== undefined || params.source_timestamp) &&
+        !params.session_id
+      ) {
+        throw new Error(
+          "session_id is required when turn_index or source_timestamp is provided",
+        );
       }
-      if (params.turn_index !== undefined && (!Number.isFinite(params.turn_index) || !Number.isInteger(params.turn_index) || params.turn_index < 0)) {
+      if (
+        params.turn_index !== undefined &&
+        (!Number.isFinite(params.turn_index) ||
+          !Number.isInteger(params.turn_index) || params.turn_index < 0)
+      ) {
         throw new Error("turn_index must be a non-negative integer");
       }
 
       const args = ["add-note", "--content", params.content];
       if (params.session_id) args.push("--session-id", params.session_id);
-      if (params.turn_index !== undefined) args.push("--turn-index", String(params.turn_index));
-      if (params.source_timestamp) args.push("--source-timestamp", params.source_timestamp);
+      if (params.turn_index !== undefined) {
+        args.push("--turn-index", String(params.turn_index));
+      }
+      if (params.source_timestamp) {
+        args.push("--source-timestamp", params.source_timestamp);
+      }
       return toolResult(await runKarta(args, signal));
     },
   });
@@ -320,25 +461,51 @@ export default function (pi: ExtensionAPI) {
     promptGuidelines: KARTA_USAGE_GUIDELINES,
     parameters: Type.Object({
       query: Type.String({ description: "Search query." }),
-      top_k: Type.Optional(Type.Number({ description: "Number of memories to return, 1-100. Defaults to 5." })),
+      top_k: Type.Optional(
+        Type.Number({
+          description: "Number of memories to return, 1-100. Defaults to 5.",
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal) {
-      return toolResult(await runKarta(["search", "--query", params.query, "--top-k", topK(params.top_k)], signal));
+      return toolResult(
+        await runKarta([
+          "search",
+          "--query",
+          params.query,
+          "--top-k",
+          topK(params.top_k),
+        ], signal),
+      );
     },
   });
 
   pi.registerTool({
     name: "karta_ask",
     label: "Karta: Ask",
-    description: "Ask Karta a question against stored memories and get a synthesized answer with retrieval metadata.",
+    description:
+      "Ask Karta a question against stored memories and get a synthesized answer with retrieval metadata.",
     promptSnippet: "Ask Karta for a synthesized answer from durable memory.",
     promptGuidelines: KARTA_USAGE_GUIDELINES,
     parameters: Type.Object({
       query: Type.String({ description: "Question to ask Karta." }),
-      top_k: Type.Optional(Type.Number({ description: "Number of context notes to consider, 1-100. Defaults to 5." })),
+      top_k: Type.Optional(
+        Type.Number({
+          description:
+            "Number of context notes to consider, 1-100. Defaults to 5.",
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal) {
-      return toolResult(await runKarta(["ask", "--query", params.query, "--top-k", topK(params.top_k)], signal));
+      return toolResult(
+        await runKarta([
+          "ask",
+          "--query",
+          params.query,
+          "--top-k",
+          topK(params.top_k),
+        ], signal),
+      );
     },
   });
 
@@ -351,7 +518,9 @@ export default function (pi: ExtensionAPI) {
       id: Type.String({ description: "Note ID." }),
     }),
     async execute(_toolCallId, params, signal) {
-      return toolResult(await runKarta(["get-note", "--id", params.id], signal));
+      return toolResult(
+        await runKarta(["get-note", "--id", params.id], signal),
+      );
     },
   });
 
@@ -385,13 +554,27 @@ export default function (pi: ExtensionAPI) {
     promptSnippet: "Run Karta background reasoning over the memory graph.",
     promptGuidelines: KARTA_USAGE_GUIDELINES,
     parameters: Type.Object({
-      scope_type: Type.Optional(Type.String({ description: "Dream scope type. Defaults to workspace." })),
-      scope_id: Type.Optional(Type.String({ description: "Dream scope identifier. Defaults to default." })),
+      scope_type: Type.Optional(
+        Type.String({
+          description: "Dream scope type. Defaults to workspace.",
+        }),
+      ),
+      scope_id: Type.Optional(
+        Type.String({
+          description: "Dream scope identifier. Defaults to default.",
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal) {
       return toolResult(
         await runKarta(
-          ["dream", "--scope-type", params.scope_type ?? "workspace", "--scope-id", params.scope_id ?? "default"],
+          [
+            "dream",
+            "--scope-type",
+            params.scope_type ?? "workspace",
+            "--scope-id",
+            params.scope_id ?? "default",
+          ],
           signal,
         ),
       );
@@ -405,7 +588,10 @@ export default function (pi: ExtensionAPI) {
         const result = await runKarta(["health"]);
         ctx.ui.notify(`Karta health: ${JSON.stringify(result)}`, "success");
       } catch (error) {
-        ctx.ui.notify(`Karta health failed: ${(error as Error).message}`, "error");
+        ctx.ui.notify(
+          `Karta health failed: ${(error as Error).message}`,
+          "error",
+        );
       }
     },
   });

--- a/README.md
+++ b/README.md
@@ -158,10 +158,23 @@ karta/
 ## Development
 
 ```bash
+# Install the CLI
+./install.sh
+
 # Use the CLI (requires LLM credentials for commands that write/search/ask)
+karta --help
 cargo run -p karta-cli -- --help
 cargo run -p karta-cli -- --json add-note --content "Sarah prefers Slack notifications"
 cargo run -p karta-cli -- --json search --query "Sarah notification preferences" --top-k 5
+
+# Install Karta into AI clients
+# claude: skill + global CLAUDE.md + project UserPromptSubmit hook
+# codex: skill + AGENTS.md + project hooks.json/config.toml
+# gemini: skill + GEMINI.md + project BeforeAgent hook
+# pi: skill + global pi extension
+# hermes: skill (Hermes exposes skills as the integration surface)
+karta install --platform claude   # also: codex, gemini, hermes, pi
+karta uninstall --platform claude
 
 # Run tests (mock LLM, no API keys needed)
 cargo test
@@ -180,9 +193,9 @@ CI gates on every PR: `cargo fmt --all -- --check`, `cargo clippy --workspace --
 
 ## Pi Integration
 
-This repository includes a project-local pi extension at `.pi/extensions/karta.ts`.
-When you run pi from the repository root, the extension registers Karta memory tools
-backed by the local CLI:
+This repository includes a pi extension at `.pi/extensions/karta.ts`.
+`./install.sh` installs or updates it globally at `~/.pi/agent/extensions/karta.ts`.
+When loaded, the extension registers Karta memory tools backed by the CLI:
 
 - `karta_add_note` — store durable memories
 - `karta_search` — semantic memory search
@@ -192,12 +205,12 @@ backed by the local CLI:
 - `karta_health` — check embedded store health
 - `karta_dream` — run background reasoning
 
-By default the extension shells out to `cargo run -q -p karta-cli -- --json ...`,
-so it works directly from a checkout. To use an installed binary instead:
+By default the extension uses `KARTA_BIN` when set, otherwise an installed `karta`
+on `PATH`, otherwise it falls back to `cargo run -q -p karta-cli -- --json ...`
+so it still works directly from a checkout.
 
 ```bash
-cargo install --path crates/karta-cli
-export KARTA_BIN=karta
+./install.sh
 pi
 ```
 

--- a/crates/karta-cli/Cargo.toml
+++ b/crates/karta-cli/Cargo.toml
@@ -19,3 +19,6 @@ anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/karta-cli/src/installer.rs
+++ b/crates/karta-cli/src/installer.rs
@@ -1,0 +1,572 @@
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+const START_MARKER: &str = "<!-- karta:start -->";
+const END_MARKER: &str = "<!-- karta:end -->";
+const PI_EXTENSION_TS: &str = include_str!("../../../.pi/extensions/karta.ts");
+const CLAUDE_USER_PROMPT_HOOK_COMMAND: &str = r#"KARTA_HOOK_PAYLOAD="$(cat)" python3 - <<'PY'
+import json, os, subprocess
+try:
+    payload = json.loads(os.environ.get('KARTA_HOOK_PAYLOAD') or '{}')
+except Exception:
+    payload = {}
+prompt = payload.get('prompt') or payload.get('user_prompt') or ''
+if not prompt.strip():
+    raise SystemExit(0)
+top_k = os.environ.get('KARTA_AUTO_CONTEXT_TOP_K', '5')
+karta_bin = os.environ.get('KARTA_BIN', 'karta')
+cmd = [karta_bin, '--json', 'search', '--query', prompt, '--top-k', top_k]
+try:
+    result = subprocess.run(cmd, text=True, capture_output=True, timeout=10, check=False)
+    if result.returncode != 0:
+        raise SystemExit(0)
+    data = json.loads(result.stdout)
+except Exception:
+    raise SystemExit(0)
+hits = data.get('results') or data.get('data', {}).get('results') or []
+lines = []
+for hit in hits[:5]:
+    note = hit.get('note') or {}
+    content = ' '.join((note.get('content') or '').split())
+    if content:
+        lines.append(f"- {note.get('id', 'unknown')}: {content[:700]}")
+if not lines:
+    raise SystemExit(0)
+context = "Relevant durable Karta memories for this prompt:\n" + "\n".join(lines)
+event_name = payload.get('hook_event_name') or payload.get('hookEventName') or 'UserPromptSubmit'
+print(json.dumps({"hookSpecificOutput":{"hookEventName": event_name,"additionalContext": context}}))
+PY"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Client {
+    Claude,
+    Codex,
+    Gemini,
+    Hermes,
+    Pi,
+}
+
+impl std::str::FromStr for Client {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "claude" | "claude-code" => Ok(Self::Claude),
+            "codex" => Ok(Self::Codex),
+            "gemini" | "gemini-cli" => Ok(Self::Gemini),
+            "hermes" => Ok(Self::Hermes),
+            "pi" | "pi-coding-agent" => Ok(Self::Pi),
+            other => {
+                bail!("unknown client '{other}'. Choose from: claude, codex, gemini, hermes, pi")
+            }
+        }
+    }
+}
+
+pub fn parse_client(value: &str) -> std::result::Result<Client, String> {
+    value.parse::<Client>().map_err(|error| error.to_string())
+}
+
+impl Client {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Gemini => "gemini",
+            Self::Hermes => "hermes",
+            Self::Pi => "pi",
+        }
+    }
+
+    fn skill_path(self, home: &Path) -> PathBuf {
+        match self {
+            Self::Claude => home.join(".claude/skills/karta/SKILL.md"),
+            Self::Codex => home.join(".agents/skills/karta/SKILL.md"),
+            Self::Gemini => home.join(".gemini/skills/karta/SKILL.md"),
+            Self::Hermes => home.join(".hermes/skills/karta/SKILL.md"),
+            Self::Pi => home.join(".pi/agent/skills/karta/SKILL.md"),
+        }
+    }
+}
+
+pub fn install_client(client: Client, home: &Path, project: &Path) -> Result<Vec<PathBuf>> {
+    let mut changed = Vec::new();
+    let skill_path = client.skill_path(home);
+    write_file(&skill_path, skill_content(client))?;
+    changed.push(skill_path.clone());
+
+    match client {
+        Client::Claude => {
+            let path = home.join(".claude/CLAUDE.md");
+            upsert_section(&path, &global_section("CLAUDE.md"))?;
+            changed.push(path);
+
+            let hook_path = project.join(".claude/settings.json");
+            install_claude_hook(&hook_path)?;
+            changed.push(hook_path);
+        }
+        Client::Codex => {
+            let path = project.join("AGENTS.md");
+            upsert_section(&path, &project_section("AGENTS.md"))?;
+            changed.push(path);
+
+            let config_path = project.join(".codex/config.toml");
+            install_codex_config(&config_path)?;
+            changed.push(config_path);
+
+            let hook_path = project.join(".codex/hooks.json");
+            install_json_hook(&hook_path, "UserPromptSubmit")?;
+            changed.push(hook_path);
+        }
+        Client::Gemini => {
+            let path = project.join("GEMINI.md");
+            upsert_section(&path, &project_section("GEMINI.md"))?;
+            changed.push(path);
+
+            let settings_path = project.join(".gemini/settings.json");
+            install_json_hook(&settings_path, "BeforeAgent")?;
+            changed.push(settings_path);
+        }
+        Client::Hermes => {}
+        Client::Pi => {
+            let extension_path = home.join(".pi/agent/extensions/karta.ts");
+            write_file(&extension_path, PI_EXTENSION_TS.to_string())?;
+            changed.push(extension_path);
+        }
+    }
+
+    Ok(changed)
+}
+
+pub fn uninstall_client(client: Client, home: &Path, project: &Path) -> Result<Vec<PathBuf>> {
+    let mut changed = Vec::new();
+    let skill_path = client.skill_path(home);
+    if skill_path.exists() {
+        fs::remove_file(&skill_path)
+            .with_context(|| format!("failed to remove {}", skill_path.display()))?;
+        changed.push(skill_path.clone());
+        prune_empty_dirs(skill_path.parent());
+    }
+
+    match client {
+        Client::Claude => {
+            let path = home.join(".claude/CLAUDE.md");
+            if remove_section(&path)? {
+                changed.push(path);
+            }
+
+            let hook_path = project.join(".claude/settings.json");
+            if uninstall_claude_hook(&hook_path)? {
+                changed.push(hook_path);
+            }
+        }
+        Client::Codex => {
+            let path = project.join("AGENTS.md");
+            if remove_section(&path)? {
+                changed.push(path);
+            }
+
+            let hook_path = project.join(".codex/hooks.json");
+            if uninstall_json_hook(&hook_path, "UserPromptSubmit")? {
+                changed.push(hook_path);
+            }
+        }
+        Client::Gemini => {
+            let path = project.join("GEMINI.md");
+            if remove_section(&path)? {
+                changed.push(path);
+            }
+
+            let settings_path = project.join(".gemini/settings.json");
+            if uninstall_json_hook(&settings_path, "BeforeAgent")? {
+                changed.push(settings_path);
+            }
+        }
+        Client::Hermes => {}
+        Client::Pi => {
+            let extension_path = home.join(".pi/agent/extensions/karta.ts");
+            if extension_path.exists() {
+                fs::remove_file(&extension_path)
+                    .with_context(|| format!("failed to remove {}", extension_path.display()))?;
+                changed.push(extension_path.clone());
+                prune_empty_dirs(extension_path.parent());
+            }
+        }
+    }
+
+    Ok(changed)
+}
+
+pub fn default_home_dir() -> Result<PathBuf> {
+    if let Some(home) = std::env::var_os("HOME") {
+        return Ok(PathBuf::from(home));
+    }
+    if let Some(home) = std::env::var_os("USERPROFILE") {
+        return Ok(PathBuf::from(home));
+    }
+    bail!("could not determine home directory; set HOME")
+}
+
+fn write_file(path: &Path, content: String) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn upsert_section(path: &Path, section: &str) -> Result<()> {
+    let existing = fs::read_to_string(path).unwrap_or_default();
+    let without_old = strip_section(&existing);
+    let mut next = without_old.trim_end().to_string();
+    if !next.is_empty() {
+        next.push_str("\n\n");
+    }
+    next.push_str(section.trim_end());
+    next.push('\n');
+    write_file(path, next)
+}
+
+fn remove_section(path: &Path) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let existing =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let stripped = strip_section(&existing);
+    if stripped == existing {
+        return Ok(false);
+    }
+    let next = stripped.trim().to_string();
+    if next.is_empty() {
+        fs::remove_file(path).with_context(|| format!("failed to remove {}", path.display()))?;
+    } else {
+        write_file(path, format!("{}\n", next))?;
+    }
+    Ok(true)
+}
+
+fn install_claude_hook(path: &Path) -> Result<()> {
+    install_json_hook(path, "UserPromptSubmit")
+}
+
+fn uninstall_claude_hook(path: &Path) -> Result<bool> {
+    uninstall_json_hook(path, "UserPromptSubmit")
+}
+
+fn install_json_hook(path: &Path, event: &str) -> Result<()> {
+    let mut settings = read_json_object(path)?;
+    let hooks = settings
+        .as_object_mut()
+        .expect("read_json_object always returns an object")
+        .entry("hooks")
+        .or_insert_with(|| json!({}));
+    if !hooks.is_object() {
+        *hooks = json!({});
+    }
+    let event_hooks = hooks
+        .as_object_mut()
+        .expect("hooks was normalized to an object")
+        .entry(event)
+        .or_insert_with(|| json!([]));
+    if !event_hooks.is_array() {
+        *event_hooks = json!([]);
+    }
+
+    let entries = event_hooks
+        .as_array_mut()
+        .expect("event hook list was normalized to an array");
+    entries.retain(|entry| !entry.to_string().contains("karta-memory"));
+    entries.push(json!({
+        "name": "karta-memory",
+        "hooks": [
+            {
+                "type": "command",
+                "command": CLAUDE_USER_PROMPT_HOOK_COMMAND,
+            }
+        ]
+    }));
+
+    write_json(path, &settings)
+}
+
+fn uninstall_json_hook(path: &Path, event: &str) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let mut settings = read_json_object(path)?;
+    let Some(event_hooks) = settings
+        .get_mut("hooks")
+        .and_then(|hooks| hooks.get_mut(event))
+        .and_then(Value::as_array_mut)
+    else {
+        return Ok(false);
+    };
+
+    let original_len = event_hooks.len();
+    event_hooks.retain(|entry| !entry.to_string().contains("karta-memory"));
+    if event_hooks.len() == original_len {
+        return Ok(false);
+    }
+    write_json(path, &settings)?;
+    Ok(true)
+}
+
+fn install_codex_config(path: &Path) -> Result<()> {
+    let existing = fs::read_to_string(path).unwrap_or_default();
+    let mut lines: Vec<String> = existing.lines().map(ToString::to_string).collect();
+    let mut features_index = None;
+    let mut codex_hooks_index = None;
+
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed == "[features]" {
+            features_index = Some(index);
+        } else if trimmed.starts_with("codex_hooks") {
+            codex_hooks_index = Some(index);
+        }
+    }
+
+    if let Some(index) = codex_hooks_index {
+        lines[index] = "codex_hooks = true".to_string();
+    } else if let Some(index) = features_index {
+        lines.insert(index + 1, "codex_hooks = true".to_string());
+    } else {
+        if !lines.is_empty() && !lines.last().is_some_and(|line| line.trim().is_empty()) {
+            lines.push(String::new());
+        }
+        lines.push("[features]".to_string());
+        lines.push("codex_hooks = true".to_string());
+    }
+
+    write_file(path, format!("{}\n", lines.join("\n")))
+}
+
+fn read_json_object(path: &Path) -> Result<Value> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+    let text =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let value = serde_json::from_str::<Value>(&text).unwrap_or_else(|_| json!({}));
+    if value.is_object() {
+        Ok(value)
+    } else {
+        Ok(json!({}))
+    }
+}
+
+fn write_json(path: &Path, value: &Value) -> Result<()> {
+    write_file(path, format!("{}\n", serde_json::to_string_pretty(value)?))
+}
+
+fn strip_section(content: &str) -> String {
+    let Some(start) = content.find(START_MARKER) else {
+        return content.to_string();
+    };
+    let Some(end_relative) = content[start..].find(END_MARKER) else {
+        return content.to_string();
+    };
+    let end = start + end_relative + END_MARKER.len();
+    format!("{}{}", &content[..start], &content[end..])
+}
+
+fn prune_empty_dirs(mut dir: Option<&Path>) {
+    while let Some(path) = dir {
+        if fs::remove_dir(path).is_err() {
+            break;
+        }
+        dir = path.parent();
+    }
+}
+
+fn skill_content(client: Client) -> String {
+    format!(
+        r#"---
+name: karta
+description: Persistent agentic memory for durable project facts, decisions, preferences, bug root causes, and architectural context. Use before answering questions that may depend on prior project history; add concise notes for stable facts worth remembering.
+---
+
+# Karta Memory ({client})
+
+Karta is an agentic memory system available through the `karta` CLI.
+
+## When to use
+- Search Karta before answering questions that may depend on previous project decisions, maintainer preferences, recurring bugs, or architectural context.
+- Add a note only for stable, reusable information: architecture decisions, constraints, preferences, root causes, and important follow-ups.
+- Do not store secrets, raw logs, transient scratch work, speculative guesses, or large code blocks.
+
+## Commands
+- `karta search --query "..." --top-k 5`
+- `karta ask --query "..." --top-k 5`
+- `karta add-note --content "..."`
+- `karta health`
+
+Prefer `--json` when the client needs machine-readable output.
+"#,
+        client = client.as_str()
+    )
+}
+
+fn global_section(_file_name: &str) -> String {
+    section("The Karta skill is installed globally for this client.")
+}
+
+fn project_section(_file_name: &str) -> String {
+    section("This project is configured to use Karta memory.")
+}
+
+fn section(intro: &str) -> String {
+    format!(
+        r#"{START_MARKER}
+## karta
+
+{intro}
+
+Rules:
+- Before answering questions that may depend on previous project context, run `karta search --query "<question>" --top-k 5` or `karta ask --query "<question>" --top-k 5`.
+- Store only stable, reusable memory with `karta add-note --content "<concise fact>"`.
+- Do not store secrets, raw logs, transient scratch work, speculative guesses, or large code blocks.
+- Prefer `karta --json ...` for automation.
+
+Installed by `karta install`; remove with `karta uninstall`.
+{END_MARKER}
+"#,
+        START_MARKER = START_MARKER,
+        END_MARKER = END_MARKER,
+        intro = intro,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn read(path: &std::path::Path) -> String {
+        fs::read_to_string(path).unwrap()
+    }
+
+    #[test]
+    fn install_claude_writes_skill_registers_claude_md_and_user_prompt_hook() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+
+        install_client(Client::Claude, &home, &project).unwrap();
+
+        let skill = home.join(".claude/skills/karta/SKILL.md");
+        assert!(skill.exists());
+        assert!(read(&skill).contains("karta"));
+        let claude_md = home.join(".claude/CLAUDE.md");
+        assert!(read(&claude_md).contains("## karta"));
+        let settings = read(&project.join(".claude/settings.json"));
+        assert!(settings.contains("UserPromptSubmit"));
+        assert!(settings.contains("karta"));
+    }
+
+    #[test]
+    fn install_codex_writes_skill_project_agents_md_and_hooks_idempotently() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("AGENTS.md"), "# Existing\n\nKeep me.\n").unwrap();
+
+        install_client(Client::Codex, &home, &project).unwrap();
+        install_client(Client::Codex, &home, &project).unwrap();
+
+        assert!(home.join(".agents/skills/karta/SKILL.md").exists());
+        let agents = read(&project.join("AGENTS.md"));
+        assert!(agents.contains("Keep me."));
+        assert_eq!(agents.matches("## karta").count(), 1);
+        assert!(read(&project.join(".codex/config.toml")).contains("codex_hooks = true"));
+        let hooks = read(&project.join(".codex/hooks.json"));
+        assert!(hooks.contains("UserPromptSubmit"));
+        assert_eq!(hooks.matches("karta-memory").count(), 1);
+    }
+
+    #[test]
+    fn install_gemini_writes_skill_project_gemini_md_and_before_agent_hook() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+
+        install_client(Client::Gemini, &home, &project).unwrap();
+
+        assert!(home.join(".gemini/skills/karta/SKILL.md").exists());
+        assert!(read(&project.join("GEMINI.md")).contains("## karta"));
+        let settings = read(&project.join(".gemini/settings.json"));
+        assert!(settings.contains("BeforeAgent"));
+        assert!(settings.contains("karta"));
+    }
+
+    #[test]
+    fn install_hermes_writes_skill_and_pi_writes_extension_plus_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+
+        install_client(Client::Hermes, &home, &project).unwrap();
+        install_client(Client::Pi, &home, &project).unwrap();
+
+        assert!(home.join(".hermes/skills/karta/SKILL.md").exists());
+        assert!(home.join(".pi/agent/skills/karta/SKILL.md").exists());
+        let extension = home.join(".pi/agent/extensions/karta.ts");
+        assert!(extension.exists());
+        assert!(read(&extension).contains("karta_add_note"));
+    }
+
+    #[test]
+    fn parse_client_names_and_reject_unknown() {
+        assert_eq!("claude".parse::<Client>().unwrap(), Client::Claude);
+        assert_eq!("codex".parse::<Client>().unwrap(), Client::Codex);
+        assert_eq!("gemini".parse::<Client>().unwrap(), Client::Gemini);
+        assert_eq!("hermes".parse::<Client>().unwrap(), Client::Hermes);
+        assert_eq!("pi".parse::<Client>().unwrap(), Client::Pi);
+        assert!("cursor".parse::<Client>().is_err());
+    }
+
+    #[test]
+    fn uninstall_removes_karta_section_but_preserves_existing_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(project.join("AGENTS.md"), "# Existing\n\nKeep me.\n").unwrap();
+        install_client(Client::Codex, &home, &project).unwrap();
+
+        uninstall_client(Client::Codex, &home, &project).unwrap();
+
+        assert!(!home.join(".agents/skills/karta/SKILL.md").exists());
+        let agents = read(&project.join("AGENTS.md"));
+        assert!(agents.contains("Keep me."));
+        assert!(!agents.contains("## karta"));
+    }
+
+    #[test]
+    fn uninstall_claude_and_pi_remove_tightly_coupled_artifacts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        install_client(Client::Claude, &home, &project).unwrap();
+        install_client(Client::Pi, &home, &project).unwrap();
+
+        uninstall_client(Client::Claude, &home, &project).unwrap();
+        uninstall_client(Client::Pi, &home, &project).unwrap();
+
+        assert!(!home.join(".claude/skills/karta/SKILL.md").exists());
+        assert!(!home.join(".pi/agent/skills/karta/SKILL.md").exists());
+        assert!(!home.join(".pi/agent/extensions/karta.ts").exists());
+        let settings = read(&project.join(".claude/settings.json"));
+        assert!(!settings.contains("karta"));
+    }
+}

--- a/crates/karta-cli/src/main.rs
+++ b/crates/karta-cli/src/main.rs
@@ -1,6 +1,9 @@
+mod installer;
+
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
+use installer::{Client, default_home_dir, install_client, parse_client, uninstall_client};
 use karta_core::{
     Karta,
     config::KartaConfig,
@@ -132,6 +135,20 @@ enum Commands {
 
     /// Preview what the forgetting engine would do without mutating data.
     PreviewForgetting,
+
+    /// Install Karta memory instructions for an AI client.
+    Install {
+        /// Target client: claude, codex, gemini, hermes, or pi.
+        #[arg(long = "platform", alias = "client", default_value = "claude", value_parser = parse_client)]
+        client: Client,
+    },
+
+    /// Remove Karta memory instructions for an AI client.
+    Uninstall {
+        /// Target client: claude, codex, gemini, hermes, or pi.
+        #[arg(long = "platform", alias = "client", default_value = "claude", value_parser = parse_client)]
+        client: Client,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -176,6 +193,12 @@ struct CountResponse {
     count: usize,
 }
 
+#[derive(Debug, Serialize)]
+struct InstallResponse {
+    client: String,
+    paths: Vec<String>,
+}
+
 #[tokio::main]
 async fn main() {
     dotenvy::dotenv().ok();
@@ -206,6 +229,66 @@ async fn main() {
 }
 
 async fn run(cli: Cli) -> Result<()> {
+    match &cli.command {
+        Commands::Install { client } => {
+            let home = default_home_dir()?;
+            let project = std::env::current_dir().context("failed to get current directory")?;
+            let paths = install_client(*client, &home, &project)?;
+            output(
+                cli.json,
+                OkResponse {
+                    ok: true,
+                    data: InstallResponse {
+                        client: client.as_str().to_string(),
+                        paths: paths
+                            .iter()
+                            .map(|path| path.display().to_string())
+                            .collect(),
+                    },
+                },
+                |response| {
+                    format!(
+                        "installed Karta for {}\n{}",
+                        response.data.client,
+                        response.data.paths.join("\n")
+                    )
+                },
+            )?;
+            return Ok(());
+        }
+        Commands::Uninstall { client } => {
+            let home = default_home_dir()?;
+            let project = std::env::current_dir().context("failed to get current directory")?;
+            let paths = uninstall_client(*client, &home, &project)?;
+            output(
+                cli.json,
+                OkResponse {
+                    ok: true,
+                    data: InstallResponse {
+                        client: client.as_str().to_string(),
+                        paths: paths
+                            .iter()
+                            .map(|path| path.display().to_string())
+                            .collect(),
+                    },
+                },
+                |response| {
+                    if response.data.paths.is_empty() {
+                        format!("Karta was not installed for {}", response.data.client)
+                    } else {
+                        format!(
+                            "uninstalled Karta for {}\n{}",
+                            response.data.client,
+                            response.data.paths.join("\n")
+                        )
+                    }
+                },
+            )?;
+            return Ok(());
+        }
+        _ => {}
+    }
+
     let karta = create_karta(&cli).await?;
 
     match cli.command {
@@ -477,6 +560,9 @@ async fn run(cli: Cli) -> Result<()> {
                     )
                 },
             )?;
+        }
+        Commands::Install { .. } | Commands::Uninstall { .. } => {
+            unreachable!("handled before Karta initialization")
         }
     }
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$repo_root"
+
+usage() {
+  cat <<'EOF'
+Install the Karta CLI and update the global pi extension from this checkout.
+
+Usage:
+  ./install.sh [cargo-install-options]
+
+Examples:
+  ./install.sh
+  ./install.sh --root ~/.local
+
+Environment:
+  PI_EXTENSION_DIR   Override pi extension install dir
+                     (default: ~/.pi/agent/extensions)
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "error: cargo is required to install Karta." >&2
+  echo "Install Rust from https://rustup.rs/ and run this script again." >&2
+  exit 1
+fi
+
+install_root="${CARGO_INSTALL_ROOT:-$HOME/.cargo}"
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    --root)
+      if ((i + 1 < ${#args[@]})); then
+        install_root="${args[$((i + 1))]}"
+      fi
+      ;;
+    --root=*)
+      install_root="${args[$i]#--root=}"
+      ;;
+  esac
+done
+
+printf 'Installing Karta CLI to %s/bin...\n' "$install_root"
+cargo install --path crates/karta-cli --bin karta --locked --force "$@"
+
+bin_path="$install_root/bin/karta"
+pi_extension_src="$repo_root/.pi/extensions/karta.ts"
+pi_extension_dir="${PI_EXTENSION_DIR:-$HOME/.pi/agent/extensions}"
+pi_extension_dest="$pi_extension_dir/karta.ts"
+
+if [[ -f "$pi_extension_src" ]]; then
+  printf 'Installing/updating pi extension at %s...\n' "$pi_extension_dest"
+  mkdir -p "$pi_extension_dir"
+  install -m 0644 "$pi_extension_src" "$pi_extension_dest"
+else
+  echo "warning: pi extension source not found at $pi_extension_src; skipping pi extension install." >&2
+fi
+
+cat <<EOF
+
+Karta CLI installed.
+Pi extension installed/updated at:
+  $pi_extension_dest
+
+Run:
+  karta --help
+
+If 'karta' is not found, add this to your shell profile:
+  export PATH=\"$install_root/bin:\$PATH\"
+
+If pi cannot find 'karta', launch pi with:
+  export KARTA_BIN=\"$bin_path\"
+EOF
+
+if [[ -x "$bin_path" ]]; then
+  printf '\nInstalled binary: %s\n' "$bin_path"
+fi


### PR DESCRIPTION
## Summary
- Add `karta install/uninstall --platform` for claude, codex, gemini, hermes, and pi
- Install tighter agent integrations: Claude/Codex/Gemini hooks and Pi extension, plus skills
- Add installer tests and document client install behavior

## Test Plan
- [x] cargo fmt --check
- [x] cargo test -p karta-cli installer
- [x] cargo check -p karta-cli
- [x] git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scoped Karta dream runs with optional scope parameters
  * Introduced install/uninstall commands to manage Karta integration across multiple AI clients

* **Bug Fixes**
  * Improved auto-context error handling with retry mechanisms and clearer error messages
  * Enhanced timeout configuration and error normalization

* **Documentation**
  * Updated README with installation workflow and multi-client setup guidance

* **Chores**
  * Added test dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->